### PR TITLE
Establish multi-OS Molecule validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,12 +146,45 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$validation_status"
 
+  molecule:
+    name: molecule (${{ matrix.platform }})
+    needs: classify
+    if: needs.classify.outputs.run_molecule == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        platform:
+          - debian13
+          - rockylinux9
+          - archlinux
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Install locked tools
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          install: true
+          cache: true
+      - name: Bootstrap controller dependencies
+        run: mise run bootstrap
+      - name: Run Molecule platform validation
+        env:
+          HOMELAB_MOLECULE_PLATFORM: ${{ matrix.platform }}
+        run: mise run test:molecule -- system_maintenance/default
+
   merge-gate:
     name: merge-gate
     needs:
       - classify
       - fast
       - ansible
+      - molecule
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -172,12 +205,14 @@ jobs:
           CLASSIFY_RESULT: ${{ needs.classify.result }}
           FAST_RESULT: ${{ needs.fast.result }}
           ANSIBLE_RESULT: ${{ needs.ansible.result }}
+          MOLECULE_RESULT: ${{ needs.molecule.result }}
         run: |
           mise exec -- python scripts/ci/merge_gate.py \
             --depth "$SELECTED_DEPTH" \
             --classify-result "$CLASSIFY_RESULT" \
             --fast-result "$FAST_RESULT" \
-            --ansible-result "$ANSIBLE_RESULT"
+            --ansible-result "$ANSIBLE_RESULT" \
+            --molecule-result "$MOLECULE_RESULT"
       - name: Write validation summary
         if: always()
         env:
@@ -186,11 +221,13 @@ jobs:
           CLASSIFY_RESULT: ${{ needs.classify.result }}
           FAST_RESULT: ${{ needs.fast.result }}
           ANSIBLE_RESULT: ${{ needs.ansible.result }}
+          MOLECULE_RESULT: ${{ needs.molecule.result }}
         run: |
           {
             printf '%s\n\n' '### CI summary'
             printf -- '- Selected depth: %s\n' "${SELECTED_DEPTH:-missing}"
             printf -- '- Reasons: %s\n' "${REASONS:-missing}"
-            printf -- '- Results: classify=%s, fast=%s, ansible=%s\n' \
-              "$CLASSIFY_RESULT" "$FAST_RESULT" "$ANSIBLE_RESULT"
+            printf -- '- Results: classify=%s, fast=%s, ansible=%s, molecule=%s\n' \
+              "$CLASSIFY_RESULT" "$FAST_RESULT" "$ANSIBLE_RESULT" \
+              "$MOLECULE_RESULT"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.mise.toml
+++ b/.mise.toml
@@ -37,7 +37,7 @@ description = "Test system_maintenance in rootless Podman containers"
 run = "uv run --frozen --no-sync python scripts/molecule.py"
 
 [tasks."ci:changed"]
-description = "Classify local changes and run required offline validation"
+description = "Classify local changes and run required validation"
 run = "uv run --frozen --no-sync python scripts/ci/run_changed.py"
 
 [tasks."github-protection:check"]
@@ -53,8 +53,9 @@ description = "Apply explicitly authorized GitHub main protection reconciliation
 run = "uv run --frozen --no-sync python scripts/repository/github_protection.py apply"
 
 [tasks.ci]
-description = "Run complete offline validation"
+description = "Run complete validation"
 run = '''
 FULL_SECRET_SCAN=1 mise run validate:fast
 mise run validate:ansible
+mise run test:molecule -- system_maintenance/default
 '''

--- a/.mise.toml
+++ b/.mise.toml
@@ -32,6 +32,10 @@ run = "./scripts/ci/validate-fast.sh"
 description = "Run offline Ansible, inventory, and Vault validation"
 run = "./scripts/ci/validate-ansible.sh"
 
+[tasks."test:molecule"]
+description = "Test system_maintenance in rootless Podman containers"
+run = "uv run --frozen --no-sync python scripts/molecule.py"
+
 [tasks."ci:changed"]
 description = "Classify local changes and run required offline validation"
 run = "uv run --frozen --no-sync python scripts/ci/run_changed.py"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ configuration fields, or quoted text solely to satisfy these style rules.
   explicit operator authorization for that exact target and action.
 - Treat `check` and `verify` commands as observational toward their targets.
   Use a registered `test` workflow when evidence requires a bounded temporary
-  mutation.
+  mutation. Classify new or renamed commands with the
+  [repository command lifecycle](docs/reference/repository-command-lifecycle.md).
 - Never execute a playbook against production or staging without explicit
   operator direction for that target and action. Reconfirm the playbook,
   action, inventory, and extra arguments immediately before execution.
@@ -136,7 +137,7 @@ configuration fields, or quoted text solely to satisfy these style rules.
 - Durable design specifications belong in `docs/specs/`; implementation plans,
   generated execution ledgers, review packages, and other transient tool state
   belong uncommitted under `.tmp/` to support execution, resumption, and
-  handoff.
+  handoff. Supporting references belong in `docs/reference/`.
 - A validation assertion must use an independent oracle or encode a current
   invariant. Remove obsolete executable checks instead of adding permanent
   forbidden-reference checks.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ mise run ci:changed
 required depth. Use `mise run ci` to force all currently implemented offline
 validation. Pull-request validation is offline and secret-free.
 
+### Molecule tests
+
+`mise run test:molecule -- system_maintenance/default` runs the repository's
+rootless Podman scenario. ARM64 hosts run Debian and Rocky Linux locally;
+GitHub's native AMD64 matrix also runs Arch Linux.
+
 ## GitHub main protection
 
 Changes reach `main` through a feature branch, a current pull request, the
@@ -102,10 +108,6 @@ outside CI. Applying a plan is a separately authorized, repository-bound action;
 the plan and its confirmation value do not grant that authority. See the
 [GitHub main protection guide](docs/guides/github-main-protection.md) for the
 exact Ruleset, guarded apply procedure, UI inspection, and recovery steps.
-
-`mise run test:molecule -- system_maintenance/default` runs the repository's
-rootless Podman scenario. ARM64 hosts run Debian and Rocky Linux locally;
-GitHub's native AMD64 matrix also runs Arch Linux.
 
 ## Frozen K3s
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ the plan and its confirmation value do not grant that authority. See the
 [GitHub main protection guide](docs/guides/github-main-protection.md) for the
 exact Ruleset, guarded apply procedure, UI inspection, and recovery steps.
 
-Molecule is reserved as a future `test:molecule` command for scenarios under
-`roles/<role>/molecule/<scenario>/`. This repository currently has no Molecule
-task, dependency, scenario, or CI job.
+`mise run test:molecule -- system_maintenance/default` runs the repository's
+rootless Podman scenario. ARM64 hosts run Debian and Rocky Linux locally;
+GitHub's native AMD64 matrix also runs Arch Linux.
 
 ## Frozen K3s
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ the plan and its confirmation value do not grant that authority. See the
 [GitHub main protection guide](docs/guides/github-main-protection.md) for the
 exact Ruleset, guarded apply procedure, UI inspection, and recovery steps.
 
-Molecule is reserved as a future convention for scenarios under
+Molecule is reserved as a future `test:molecule` command for scenarios under
 `roles/<role>/molecule/<scenario>/`. This repository currently has no Molecule
 task, dependency, scenario, or CI job.
 

--- a/docs/reference/repository-command-lifecycle.md
+++ b/docs/reference/repository-command-lifecycle.md
@@ -89,8 +89,6 @@ shape when an established convention already describes the operation.
 ```text
 mise run validate:fast
 mise run validate:ansible
-mise run ci:changed
-mise run ci
 ```
 
 These commands inspect repository-controlled inputs and produce local assurance.
@@ -112,6 +110,10 @@ The default platform set follows the Podman host architecture. ARM64 runs
 Debian and Rocky concurrently and reports Arch as skipped. AMD64 runs Debian,
 Rocky, and Arch concurrently. GitHub uses exact matrix selection on native
 AMD64 so every pull request still validates all three platforms.
+
+`mise run ci:changed` and `mise run ci` orchestrate validation and this
+controlled test when their selected depth includes Molecule. Their effects are
+the combined effects of the commands they run.
 
 ### GitHub protection administration
 

--- a/docs/reference/repository-command-lifecycle.md
+++ b/docs/reference/repository-command-lifecycle.md
@@ -1,0 +1,184 @@
+# Repository command lifecycle
+
+This guide classifies repository commands by their effects and describes the
+lifecycle conventions for adding or changing commands in this repository.
+
+`AGENTS.md` remains the sole agent-policy surface. Current repository policy and
+executable source take precedence over this procedural guide.
+
+## Primary terms
+
+| Term | Meaning |
+| --- | --- |
+| `validate` | Prove local source, configuration, schema, policy, or evidence correctness. |
+| `verify` | Observe live or external state and prove an invariant without intentionally changing that target. |
+| `apply` | Reconcile existing state when a generic reconciliation term is clearer than a purpose-specific action. |
+| `bootstrap` | Perform exceptional initialization or establish required local or target capability. |
+| `test` | Conduct a controlled experiment that can create, alter, or remove bounded temporary state. |
+
+These terms distinguish local assurance, live observation, reconciliation,
+initialization, and experimental evidence. Other established terms fit around
+them:
+
+- `check` is a specialized verification form, usually for drift or compliance.
+- `plan`, `preflight`, and `dry-run` are stages or safeguards, not peer
+  operations.
+- `cleanup` is a deletion effect and transaction stage. It is also a valid
+  standalone command when targeted removal is the requested result.
+- precise terms such as `status`, `diagnostics`, `render`, `generate`, `sync`,
+  `restart`, and `reset` remain valid when they state the requested result more
+  clearly.
+
+An approved semantic rename updates all repository-owned consumers together.
+Do not retain a deprecated alias or parallel terminology.
+
+## Workflow profiles
+
+| Profile | Canonical term | Expected shape |
+| --- | --- | --- |
+| Local validation | `validate` | Read local inputs, prove correctness, and return an actionable result without live credentials or confirmation. Explicit local outputs are allowed. |
+| Live or external observation | `verify`; specialized `check`, `status`, or `diagnostics` | Use bounded read access, do not intentionally mutate the target, and never fall back to broader credentials. |
+| Existing-state reconciliation | `apply` or a precise action | Validate or preflight, obtain authority, confirm when proportionate, mutate, and read back the result. |
+| Initialization or capability setup | `bootstrap` | Check initial state, establish the required capability, and verify it. |
+| Controlled experiment | `test` | Bind temporary state to an exact run or target, collect evidence, clean up, and preserve cleanup failure separately. |
+| Targeted removal | `cleanup` | Resolve an exact owned target, delete only that target, and verify absence. |
+
+A command can have several effects. Name it for the result requested by the
+caller, then choose safeguards from its actual behavior. A local command is not
+automatically `validate`: if it creates and removes containers to obtain
+evidence, it follows the controlled-test profile.
+
+## Stages and safeguards
+
+| Stage or safeguard | Meaning |
+| --- | --- |
+| validation | Prove source, input, schema, policy, or evidence correctness before relying on it. |
+| preflight | Prove current prerequisites before an operation. Expose it separately only when it has independent value. |
+| plan | Describe intended later work from current inputs. It is optional and never grants authority. |
+| dry-run | Exercise the real operation or target validation path without persisting the intended mutation. |
+| confirmation | Bind deliberate execution intent to useful operation, target, revision, or run context. |
+| operator authorization | Supply policy authority to perform an operation. Naming and confirmation do not supply it. |
+| post-verification | Read back and prove the requested result. |
+| rollback or containment | Restore prior state or stop reconciliation when a failed operation can be contained safely. |
+| cleanup | Remove only bounded temporary or run-owned state and keep cleanup failure visible. |
+
+Not every operation needs every stage. Prefer embedded preflight when a separate
+command would add ceremony or allow the checked state to become stale. Add a
+standalone plan only when it provides real review or reuse value.
+
+## Classify a command
+
+Answer these questions in order:
+
+1. What can the command affect: local files, temporary local state, a live host,
+   repository settings, credentials, or another external target?
+2. Which workflow profile matches the requested result?
+3. Which primary or purpose-specific term describes that result?
+4. Which safeguards match the actual consequence: validation, preflight, plan,
+   dry-run, confirmation, post-verification, containment, or cleanup?
+5. Who owns execution under `AGENTS.md`, and which credentials are allowed?
+6. Which existing repository command family is comparable?
+
+Do not add a stage for visual symmetry. Do not introduce a new term or workflow
+shape when an established convention already describes the operation.
+
+## Repository examples
+
+### Local validation
+
+```text
+mise run validate:fast
+mise run validate:ansible
+mise run ci:changed
+mise run ci
+```
+
+These commands inspect repository-controlled inputs and produce local assurance.
+They do not contact an inventory host or intentionally change live state.
+
+### Controlled Molecule test
+
+```text
+mise run test:molecule -- system_maintenance/default
+```
+
+Molecule creates and removes rootless local containers to obtain executable role
+evidence. It therefore uses `test`, with embedded Podman preflight, exact
+container ownership, bounded cleanup, and no ordinary confirmation. The
+containers are local, unprivileged, disposable test state; a confirmation token
+would add friction without a proportionate safety benefit.
+
+### GitHub protection administration
+
+```text
+mise run github-protection:check
+mise run github-protection:plan
+mise run github-protection:apply
+```
+
+`check` observes external settings. `plan` previews reconciliation but does not
+authorize it. `apply` requires current operator authorization and its documented
+repository-bound confirmation, then reads back the result.
+
+### Playbook execution
+
+```text
+mise run playbook -- <playbook> <action> <inventory> [ansible-args...]
+```
+
+`playbook` is an operator gateway rather than a lifecycle term. Its requested
+action determines the effect. Production or staging execution requires explicit
+operator direction for the exact playbook, action, inventory, and extra
+arguments. Observational actions remain read-only; mutating actions follow the
+authority and precondition rules in `AGENTS.md`.
+
+### Dependency bootstrap
+
+```text
+mise run bootstrap
+```
+
+Bootstrap establishes the locked local controller and Galaxy capability. It
+does not authorize playbook execution or install dependencies implicitly during
+a later live operation.
+
+## Command and failure contracts
+
+- Validate public arguments and registered targets before starting an operation.
+- Use status `2` for invalid usage, an unknown target, or an unsupported internal
+  dispatch value.
+- Use status `1` for an unmet runtime precondition or a failed operation. Preserve
+  signal statuses when practical.
+- Print concise, actionable failures to standard error without a traceback for
+  expected operator or environment errors.
+- Keep external-dependency, primary assertion, cleanup, and recovery outcomes
+  distinct when a workflow has those phases.
+- A cleanup failure makes a controlled test fail but does not replace or hide
+  the primary assertion outcome.
+- Never broaden a target selector, credential, or deletion scope after a scoped
+  check fails.
+
+## Repository invariants
+
+1. `validate`, `verify`, `check`, `plan`, `preflight`, and `dry-run` do not
+   persist the intended target-state mutation.
+2. `verify` and `check` are observational toward their targets. Use `test` when
+   positive evidence requires deliberate temporary mutation.
+3. Local validation does not require inventory credentials or contact managed
+   hosts.
+4. Experiments and cleanup operate only on run-owned or exactly identified state.
+5. Cleanup and recovery failure remain visible separately from the primary
+   assertion.
+6. A standalone preflight or plan exists only when it has independent value.
+7. A confirmation value records execution intent; it does not grant operator
+   authorization.
+8. Consequential live operations repeat safety-critical preconditions
+   immediately before mutation.
+9. A failed scoped permission or capability check never triggers a fallback to
+   broader credentials or privileges.
+10. New terminology or workflow shape requires a behavioral or safety
+    distinction, not visual symmetry.
+
+Executable Mise tasks, their implementation scripts, and subsystem guides remain
+the authority for individual command behavior. This guide defines shared
+classification and lifecycle conventions; it is not a second command inventory.

--- a/docs/reference/repository-command-lifecycle.md
+++ b/docs/reference/repository-command-lifecycle.md
@@ -108,6 +108,11 @@ container ownership, bounded cleanup, and no ordinary confirmation. The
 containers are local, unprivileged, disposable test state; a confirmation token
 would add friction without a proportionate safety benefit.
 
+The default platform set follows the Podman host architecture. ARM64 runs
+Debian and Rocky concurrently and reports Arch as skipped. AMD64 runs Debian,
+Rocky, and Arch concurrently. GitHub uses exact matrix selection on native
+AMD64 so every pull request still validates all three platforms.
+
 ### GitHub protection administration
 
 ```text

--- a/docs/specs/002-multi-os-molecule-validation.md
+++ b/docs/specs/002-multi-os-molecule-validation.md
@@ -20,8 +20,9 @@ repository secret, or claiming VM or physical-hardware coverage.
    committed image digests.
 4. Each platform explicitly pulls its base once per invocation, then builds and
    tests without another registry check.
-5. Debian and Rocky run natively on ARM64 and AMD64. Arch runs as AMD64, with
-   emulation only when the local host is ARM64.
+5. Debian and Rocky run natively on ARM64 and AMD64. The default platform set
+   skips Arch on ARM64 hosts and includes native Arch on AMD64 hosts. GitHub's
+   AMD64 matrix always includes Arch.
 6. Local platform workers and GitHub matrix jobs use the same worker lifecycle.
 7. Local and GitHub platform validation runs concurrently.
 8. Base and built images remain cached. Test containers are recreated for every
@@ -129,7 +130,7 @@ would add friction without a proportionate safeguard.
 | --- | --- | --- | --- |
 | Debian 13 | `docker.io/library/debian:13` | native ARM64 | native AMD64 |
 | Rocky Linux 9 | `docker.io/rockylinux/rockylinux:9` | native ARM64 | native AMD64 |
-| Arch Linux | `docker.io/archlinux/archlinux:base` | emulated AMD64 | native AMD64 |
+| Arch Linux | `docker.io/archlinux/archlinux:base` | skipped | native AMD64 |
 
 The Debian and Rocky tags follow their selected major release lines. The Arch
 tag follows Arch Linux's rolling distribution model. They intentionally move as
@@ -149,8 +150,8 @@ Before local workers or a GitHub platform worker starts, the repository runner:
 3. confirms that `podman` exists in `PATH`;
 4. runs bounded `podman info` inspection as the current user;
 5. confirms rootless operation and cgroup v2;
-6. computes and validates the native/emulated platform plan without pulling a
-   probe image; and
+6. selects the default platform set for the Podman host architecture without
+   pulling a probe image; and
 7. acquires one non-blocking host-local invocation lock shared by linked
    worktrees of this repository.
 
@@ -217,11 +218,12 @@ The preflight must prove:
 - Podman is reachable without `sudo`;
 - Podman reports rootless operation;
 - the Podman host supplies cgroup v2; and
-- the requested platform matches the native/emulated architecture plan.
+- the default platform set matches the Podman host architecture.
 
-The preflight does not pull or start a separate probe image. The Arch build and
-container start prove that AMD64 emulation works on an ARM64 host. Their failure
-is reported as a platform build or start failure.
+The preflight does not pull or start a separate probe image. An ARM64 default
+run omits Arch and reports that GitHub CI covers it on native AMD64. The
+workflow-only platform selector still selects one exact matrix worker; GitHub
+runs that selector on its AMD64 host.
 
 After container creation, a bounded readiness check confirms that systemd is PID
 1 and responds inside the container. This is the authoritative proof that the
@@ -322,15 +324,16 @@ The public command is:
 mise run test:molecule -- system_maintenance/default
 ```
 
-It validates the exact role/scenario selector, runs all three platforms, and
-returns failure if any worker fails. Unknown roles, scenarios, or extra public
+It validates the exact role/scenario selector and returns failure if any worker
+fails. On ARM64 it runs Debian and Rocky and reports that Arch is skipped. On
+AMD64 it runs all three platforms. Unknown roles, scenarios, or extra public
 arguments fail with a concise usage message and status `2` before Podman is
 inspected.
 
-The local runner starts the three isolated platform workers concurrently. It
-waits for all workers so one failure does not discard useful results from the
-other platforms. Output identifies the originating platform, and the final
-summary reports every result.
+The local runner starts the selected isolated platform workers concurrently.
+It waits for all workers so one failure does not discard useful results from
+the other platforms. Output identifies the originating platform, and the final
+summary reports every result and any architecture-based skip.
 
 Molecule's experimental collection-only worker interface is not part of this
 design. Repository orchestration supplies bounded parallelism for this
@@ -462,7 +465,7 @@ GitHub workflow totals:
 - the proportion of overall platform time spent building the test image.
 
 The initial data establishes whether a later prebuilt-image design is warranted.
-No performance conclusion is made from local emulated Arch timing alone.
+Arch timing comes from the native AMD64 GitHub worker.
 
 ## Acceptance criteria
 
@@ -470,10 +473,11 @@ Issue #11 is complete when:
 
 1. Molecule and `containers.podman` are exactly pinned through uv and Galaxy
    dependency management;
-2. `mise run test:molecule -- system_maintenance/default` runs Debian 13,
-   Rocky Linux 9, and Arch Linux concurrently with Podman only;
-3. local ARM64 uses native Debian and Rocky images and AMD64 emulation only for
-   Arch, while GitHub uses native AMD64 for all platforms;
+2. `mise run test:molecule -- system_maintenance/default` runs the
+   architecture-selected platforms concurrently with Podman only;
+3. local ARM64 runs native Debian and Rocky and reports Arch as skipped, local
+   AMD64 runs all three platforms natively, and GitHub's AMD64 matrix runs all
+   three platforms natively;
 4. Podman is rootless and all scenario hosts use `container_privileged: false`,
    `container_systemd: always`, and no added capabilities;
 5. one embedded global preflight rejects invalid selectors, unavailable or
@@ -484,8 +488,8 @@ Issue #11 is complete when:
    local image identity;
 7. base and built images remain after local testing, while exact label-owned
    scenario containers are destroyed after both success and failure;
-8. converge, idempotence, and independent verification pass for all three
-   operating systems;
+8. converge, idempotence, and independent verification pass for each selected
+   operating system, including Arch in GitHub's AMD64 matrix;
 9. the role exposes an explicit reboot control whose production default remains
    enabled and whose scenario value prevents actual container reboot;
 10. verification covers representative current role invariants, including Rocky

--- a/docs/specs/002-multi-os-molecule-validation.md
+++ b/docs/specs/002-multi-os-molecule-validation.md
@@ -1,0 +1,505 @@
+# Specification 002: Multi-OS Molecule validation
+
+Issue: [#11 Establish multi-OS Molecule validation](https://github.com/supermorphic/homelab-playbook/issues/11)
+
+## Purpose
+
+Add change-directed executable validation for the repository-owned
+`system_maintenance` role. The validation uses Molecule and rootless Podman to
+exercise Debian 13, Rocky Linux 9, and Arch Linux in systemd-capable containers.
+
+This initiative adds and activates the change-directed `molecule` validation
+depth. It adds container evidence without contacting an inventory host, using a
+repository secret, or claiming VM or physical-hardware coverage.
+
+## Governing decisions
+
+1. Podman is the only supported container runtime locally and in GitHub Actions.
+2. Podman runs rootless and every test container runs unprivileged.
+3. Tests use maintained, moving operating-system release tags rather than
+   committed image digests.
+4. Each platform explicitly pulls its base once per invocation, then builds and
+   tests without another registry check.
+5. Debian and Rocky run natively on ARM64 and AMD64. Arch runs as AMD64, with
+   emulation only when the local host is ARM64.
+6. Local platform workers and GitHub matrix jobs use the same worker lifecycle.
+7. Local and GitHub platform validation runs concurrently.
+8. Base and built images remain cached. Test containers are recreated for every
+   invocation and removed afterward, including after a failed test.
+9. Pull, image-build, Molecule, per-platform total, and invocation total times
+   are reported separately.
+
+These decisions replace issue #11's initial privileged-container and immutable
+image-pin assumptions. They preserve its operating-system, systemd, executable
+behavior, change-directed validation, and container-only boundaries.
+
+## Scope
+
+### Included
+
+- one `default` Molecule scenario for `roles/system_maintenance`;
+- Debian 13, Rocky Linux 9, and Arch Linux container platforms;
+- rootless Podman preflight, image acquisition, image building, container
+  lifecycle, and cleanup;
+- converge, idempotence, and independent verification phases;
+- explicit suppression of real reboot attempts during container tests while
+  retaining the production default;
+- a public scenario test command and shared per-platform worker;
+- parallel local execution and a three-job GitHub Actions matrix;
+- activation of classifier, `full`, and merge-gate support for the `molecule`
+  depth;
+- separate timing and image-provenance reporting; and
+- adoption of the repository command lifecycle reference for current and future
+  command classification.
+
+### Excluded
+
+- Docker CLI, Docker daemon, Docker socket, Docker-compatible wrappers, or a
+  Docker fallback;
+- the legacy Molecule Podman plugin;
+- privileged containers, rootful Podman, `sudo`, added Linux capabilities, or
+  host cgroup mounts;
+- committed OCI image digests;
+- prebuilt repository test images or a container-registry publishing workflow;
+- a registry mirror, fallback registry, stale-cache fallback, or offline test
+  mode;
+- GitHub Actions caching of Podman image storage;
+- VMs, libvirt, Vagrant, self-hosted runners, live staging, production hosts, or
+  physical hardware;
+- testing third-party Galaxy roles or every repository playbook;
+- validation of real reboot, boot persistence, firmware, kernel parameters,
+  networking, routing, DNS failover, mounts, or hardware behavior.
+
+## Toolchain and dependency model
+
+Mise remains the task and tool entry point. uv remains the Python resolver and
+lock owner.
+
+The Molecule dependency group pins:
+
+```text
+molecule==26.6.0
+```
+
+The repository Galaxy requirements pin:
+
+```text
+containers.podman==1.20.2
+```
+
+The scenario uses Molecule's default, Ansible-native driver with explicit
+Ansible create and destroy playbooks. It does not install or use
+`molecule-plugins[podman]`. The create and destroy playbooks use modules from
+`containers.podman`. Molecule's dependency phase is disabled because repository
+bootstrap owns exact controller and Galaxy installation. This prevents parallel
+workers from attempting concurrent dependency installation into shared paths.
+
+Podman is a host runtime, not a Python project dependency. The repository does
+not install it through bootstrap or invoke it with elevated privileges. The
+embedded test preflight checks required capabilities and reports the detected
+version. It does not require the local and GitHub hosts to use an identical
+Podman release.
+
+On macOS, the operator must install Podman and start a rootless Podman machine
+before validation. On Linux, the operator must provide a working rootless
+Podman installation. GitHub uses the Podman installation supplied by the fixed
+`ubuntu-24.04` hosted-runner image; the workflow does not install or configure a
+rootful service.
+
+## Command lifecycle classification
+
+The [repository command lifecycle](../reference/repository-command-lifecycle.md)
+classifies a command by its effects. Molecule deliberately creates and removes
+bounded local containers to obtain executable evidence, so it is a controlled
+`test`, not a read-only `validate` command.
+
+The public command is therefore `test:molecule`. There is no
+`validate:molecule` alias. The `molecule` classifier depth and GitHub job retain
+their names because they identify validation selection and CI execution, not a
+public lifecycle operation.
+
+The test embeds its Podman preflight because that check has no independent
+operator value. It requires no confirmation: rootless, unprivileged, exactly
+owned local test containers are a bounded consequence for which a static token
+would add friction without a proportionate safeguard.
+
+## Platform matrix
+
+| Platform | Maintained base tag | Local ARM64 | GitHub AMD64 |
+| --- | --- | --- | --- |
+| Debian 13 | `docker.io/library/debian:13` | native ARM64 | native AMD64 |
+| Rocky Linux 9 | `docker.io/rockylinux/rockylinux:9` | native ARM64 | native AMD64 |
+| Arch Linux | `docker.io/archlinux/archlinux:base` | emulated AMD64 | native AMD64 |
+
+The Debian and Rocky tags follow their selected major release lines. The Arch
+tag follows Arch Linux's rolling distribution model. They intentionally move as
+upstream publishers release maintenance and security updates.
+
+Every reference is fully qualified to avoid short-name registry resolution.
+The repository records the locally resolved image identifier after each pull,
+but does not commit it or use it as a later pin.
+
+## Image acquisition and build lifecycle
+
+Before local workers or a GitHub platform worker starts, the repository runner:
+
+1. validates the exact registered role/scenario selector;
+2. confirms the locked controller and Galaxy dependencies are present, otherwise
+   directing the operator to `mise run bootstrap`;
+3. confirms that `podman` exists in `PATH`;
+4. runs bounded `podman info` inspection as the current user;
+5. confirms rootless operation and cgroup v2;
+6. computes and validates the native/emulated platform plan without pulling a
+   probe image; and
+7. acquires one non-blocking host-local invocation lock shared by linked
+   worktrees of this repository.
+
+Invalid usage or an unknown selector exits with status `2`. An unavailable
+dependency, Podman executable, Podman service or machine, rootless mode, cgroup
+v2 host, or invocation lock exits with status `1` and one actionable message.
+Expected setup failures print no traceback. The runner does not pull an image,
+inspect or delete a container, or start workers until this preflight succeeds.
+
+On macOS, an unreachable Podman service reports that the operator should run
+`podman machine start`. On Linux, it reports that rootless Podman must be made
+available to the current user. Neither path installs software, starts a machine,
+uses `sudo`, or selects a different runtime automatically.
+
+After global preflight, each platform worker owns this sequence:
+
+1. inspect the worker's exact stable container name;
+2. if that container exists, verify its repository, scenario, and platform
+   ownership labels before removing it;
+3. run one `podman pull --policy=always --retry=3` for the maintained base tag;
+4. read the pulled image's local identifier and, when Podman supplies it, its
+   repository digest for the log;
+5. build the repository-owned systemd test image with `--pull=never`;
+6. run the Molecule test sequence using that local built image with container
+   pull policy `never`;
+7. remove the scenario container in an unconditional cleanup path; and
+8. retain the base image, built image, and reusable build layers.
+
+A container with the expected name but missing or different ownership labels is
+not deleted; that worker fails with a collision message. The invocation lock
+prevents overlapping local runs from treating another active run as stale while
+still allowing the three workers within one invocation to run concurrently.
+The lock identity derives from Git's common directory so linked worktrees on the
+same host coordinate with each other. The lock is released on success, failure,
+or interruption. GitHub matrix jobs run on separate ephemeral hosts and
+therefore do not share this lock.
+
+The explicit pull is inside the worker. There is no separate local pre-pull
+stage and no GitHub digest-resolution job. This keeps local and GitHub behavior
+the same and avoids a registry check that cannot transfer image layers to
+ephemeral matrix runners.
+
+`--policy=always` makes inability to confirm the maintained tag an acquisition
+failure even when a local image exists. The workflow never silently substitutes
+a stale cached image. Podman's bounded retry handles short transient failures.
+A continuing registry outage fails the affected platform with a clear image
+acquisition result. A fresh GitHub runner cannot continue without the base
+image, so rerunning after registry recovery is the initial recovery procedure.
+
+The repository owns one minimal Containerfile per platform. Each derives from
+the selected base and installs only the prerequisites needed to start systemd
+and let Ansible manage the container. Test images are built during validation;
+they are not published in this initiative.
+
+The first implementation measures the cost of these builds. Prebuilt images or
+a repository-controlled registry mirror require a later measured design. They
+are justified only if build duration or public-registry reliability materially
+limits the validation workflow.
+
+## Least-privilege container model
+
+The preflight must prove:
+
+- Podman is reachable without `sudo`;
+- Podman reports rootless operation;
+- the Podman host supplies cgroup v2; and
+- the requested platform matches the native/emulated architecture plan.
+
+The preflight does not pull or start a separate probe image. The Arch build and
+container start prove that AMD64 emulation works on an ARM64 host. Their failure
+is reported as a platform build or start failure.
+
+After container creation, a bounded readiness check confirms that systemd is PID
+1 and responds inside the container. This is the authoritative proof that the
+host's rootless cgroup delegation is sufficient. A failure reports systemd or
+cgroup delegation as the container-start cause instead of misclassifying it as
+a role assertion failure.
+
+Scenario inventory uses:
+
+```yaml
+container_privileged: false
+container_systemd: always
+```
+
+It adds no capabilities and does not mount the host cgroup filesystem. The
+Podman collection supplies the systemd-specific writable tmpfs and cgroup setup
+required by `container_systemd: always`.
+
+Ansible operates as root inside the container because package management,
+system configuration, and systemd require it. With rootless Podman, this user is
+mapped into the invoking user's namespace and is not host root. No host
+administrative credential or rootful service is an accepted fallback.
+
+## Scenario structure and lifecycle
+
+The scenario lives at:
+
+```text
+roles/system_maintenance/molecule/default/
+```
+
+It contains repository-owned configuration, create, converge, verify, cleanup,
+destroy, and platform Containerfile inputs. The normal test sequence is:
+
+```text
+destroy -> syntax -> create -> prepare -> converge -> idempotence -> verify ->
+cleanup -> destroy
+```
+
+The outer worker also requests destroy on failure so an interrupted Molecule
+sequence does not intentionally retain a test container. Cleanup targets only
+the exact names owned by this scenario. It does not prune Podman storage or
+remove unrelated containers, images, networks, or volumes.
+
+Workers use distinct container names, built-image tags, logs, and Molecule
+ephemeral state. This isolation permits three local workers to execute at the
+same time without sharing mutable scenario state.
+
+## Role contract and reboot control
+
+The role gains one explicit default shaped as:
+
+```yaml
+system_maintenance_reboot_enabled: true
+```
+
+Both existing reboot tasks require this value in addition to their current
+operating-system reboot signal. The default preserves production behavior.
+Molecule convergence sets it to `false`; tests therefore exercise the update
+and reboot-decision logic without attempting to reboot a container.
+
+The new variable controls only reboot execution. It does not suppress package
+updates, cleanup, package installation, reboot-signal inspection, or any other
+role behavior.
+
+## Verification contract
+
+Molecule's idempotence phase runs the role a second time and requires no changed
+tasks. Verification then uses Ansible modules and commands that observe the
+result rather than calling the role again.
+
+The initial assertions cover current role-owned invariants:
+
+- all platforms complete converge with the expected operating-system family;
+- representative packages that are not part of the Containerfile baseline are
+  installed;
+- Debian package maintenance and representative common-package installation
+  complete successfully;
+- Rocky Linux has `installonly_limit=2`, the EPEL package is installed, and the
+  EPEL repository is disabled by default;
+- Arch Linux has the requested `en_US.UTF-8` locale and `/etc/locale.conf`
+  content and permissions;
+- a functioning systemd process exists in each test container.
+
+Assertions use package facts, file metadata and content, service-manager facts,
+or a direct read-only command as appropriate. They do not reproduce the role's
+task implementation as the oracle.
+
+The scenario does not assert service enablement that the role does not own.
+Package-provided defaults are not promoted to a role contract merely because
+they occur in a base image or package release.
+
+## Public command and parallel execution
+
+The public command is:
+
+```text
+mise run test:molecule -- system_maintenance/default
+```
+
+It validates the exact role/scenario selector, runs all three platforms, and
+returns failure if any worker fails. Unknown roles, scenarios, or extra public
+arguments fail with a concise usage message and status `2` before Podman is
+inspected.
+
+The local runner starts the three isolated platform workers concurrently. It
+waits for all workers so one failure does not discard useful results from the
+other platforms. Output identifies the originating platform, and the final
+summary reports every result.
+
+Molecule's experimental collection-only worker interface is not part of this
+design. Repository orchestration supplies bounded parallelism for this
+role-based scenario.
+
+## Timing and diagnostic output
+
+For each platform, the runner reports:
+
+- Podman version, host architecture, requested architecture, and native or
+  emulated execution;
+- maintained source tag and resolved local image identifier;
+- pull/check duration;
+- test-image build duration;
+- Molecule lifecycle duration;
+- per-platform total duration; and
+- pass, test failure, acquisition failure, build failure, or cleanup failure.
+
+The local summary also reports wall-clock invocation duration. It does not use
+the sum of concurrent worker durations as the overall time.
+
+GitHub writes the same platform data to each job summary. The workflow and
+merge-gate summaries make infrastructure acquisition failures distinguishable
+from role assertion failures. The implementation report records GitHub's
+workflow elapsed time from the completed run rather than adding API access only
+to calculate it inside the workflow. Logs and summaries contain no environment
+dump, credentials, inventory content, or Vault material.
+
+## GitHub Actions topology
+
+The workflow retains the existing `classify`, `fast`, `ansible`, and stable
+`merge-gate` jobs and adds a conditional `molecule` matrix:
+
+```text
+classify
+   |-- fast (always) -----------------------------|
+   |-- ansible (ansible, molecule, or full) ------|
+   `-- molecule (molecule or full)                 |-- merge-gate
+         |-- Debian 13                             |
+         |-- Rocky Linux 9                         |
+         `-- Arch Linux ---------------------------|
+```
+
+The matrix uses `ubuntu-24.04`, `fail-fast: false`, and at most three concurrent
+jobs. Every platform is native AMD64 in GitHub Actions. Each matrix job invokes
+the same platform worker used by the local command and has a bounded timeout.
+The initial timeout allows for a cold image build and full package upgrade; it
+must be tightened later if measured results support a smaller reliable bound.
+
+The workflow has read-only repository permissions, uses no container-registry
+credentials, and does not use `sudo`. GitHub runners are ephemeral, so their
+images and containers disappear with the job. The workflow does not add a
+redundant cleanup or image-pruning stage beyond scenario cleanup.
+
+## Change-directed validation
+
+The classifier begins emitting all four ordered depths:
+
+```text
+fast < ansible < molecule < full
+```
+
+The intended mappings are:
+
+| Change | Selected depth |
+| --- | --- |
+| `system_maintenance` role source or defaults | `molecule` |
+| its Molecule scenario, Containerfiles, runner, or focused tests | `molecule` |
+| other Ansible roles, playbooks, or inventories | `ansible` |
+| toolchain locks, Galaxy requirements, classifier, CI, or merge gate | `full` |
+| documentation and ordinary policy files | `fast` |
+| unknown or ambiguous path | `full` |
+
+Specific `system_maintenance` mappings take precedence over the existing generic
+`roles/ -> ansible` mapping. Classifier fixtures cover both the positive
+Molecule paths and unchanged shallower paths.
+
+`run_molecule` is true for `molecule` and `full`. `full` now means all
+implemented validation and therefore includes Molecule. The public `ci` task and
+`ci:changed -- --force-depth molecule` follow the same rule.
+
+The merge gate accepts `molecule` as an implemented depth, requires successful
+Ansible and Molecule results when selected, permits a skipped Molecule job only
+for `fast` or `ansible`, and continues to fail closed for missing or unknown
+results.
+
+## Failure and cleanup behavior
+
+- A missing or unusable Podman runtime fails before container creation.
+- Rootful Podman, cgroup v1, an unavailable invocation lock, an unavailable
+  required architecture, or a request for privilege fails without attempting an
+  elevated fallback.
+- A Podman preflight failure leaves existing images and containers untouched.
+- A same-name container without the complete expected ownership labels is not
+  deleted and fails as a collision.
+- Registry failure after Podman's bounded retries fails image acquisition; a
+  cached image is not silently substituted.
+- Build, converge, idempotence, and verify failures retain their distinct stage
+  in the summary.
+- Cleanup runs after success and failure and removes only scenario-owned
+  containers.
+- Cleanup failure makes the worker fail even if the test assertions passed.
+- Images and layers are never pruned by the validation workflow.
+- Parallel workers continue to completion so the final report contains all
+  available platform evidence.
+
+## Validation and measurement
+
+Implementation follows repository test and validation policy:
+
+1. add focused unit and contract tests for selector parsing, platform planning,
+   timing aggregation, classifier selection, and merge-gate reconciliation;
+2. run `mise run bootstrap` after dependency changes;
+3. use `mise run validate:fast` and `mise run validate:ansible` while iterating;
+4. run the scenario locally through its public command on the supported local
+   Podman environment;
+5. run `mise run ci:changed` before claiming completion or publishing the pull
+   request; and
+6. collect successful GitHub matrix timing from the pull request.
+
+The implementation report records, for every platform and for the local and
+GitHub workflow totals:
+
+- pull duration;
+- build duration;
+- Molecule duration;
+- overall duration;
+- whether execution was native or emulated; and
+- the proportion of overall platform time spent building the test image.
+
+The initial data establishes whether a later prebuilt-image design is warranted.
+No performance conclusion is made from local emulated Arch timing alone.
+
+## Acceptance criteria
+
+Issue #11 is complete when:
+
+1. Molecule and `containers.podman` are exactly pinned through uv and Galaxy
+   dependency management;
+2. `mise run test:molecule -- system_maintenance/default` runs Debian 13,
+   Rocky Linux 9, and Arch Linux concurrently with Podman only;
+3. local ARM64 uses native Debian and Rocky images and AMD64 emulation only for
+   Arch, while GitHub uses native AMD64 for all platforms;
+4. Podman is rootless and all scenario hosts use `container_privileged: false`,
+   `container_systemd: always`, and no added capabilities;
+5. one embedded global preflight rejects invalid selectors, unavailable or
+   rootful Podman, cgroup v1, and overlapping local invocations before touching
+   container state, without a privilege or runtime fallback;
+6. every worker pulls its fully qualified maintained tag exactly once with an
+   always-refresh policy, builds with no second pull, and logs the resolved
+   local image identity;
+7. base and built images remain after local testing, while exact label-owned
+   scenario containers are destroyed after both success and failure;
+8. converge, idempotence, and independent verification pass for all three
+   operating systems;
+9. the role exposes an explicit reboot control whose production default remains
+   enabled and whose scenario value prevents actual container reboot;
+10. verification covers representative current role invariants, including Rocky
+   kernel retention and EPEL settings and Arch locale configuration;
+11. the classifier selects `molecule` only for explicitly mapped role/scenario
+    changes, retains shallower depths for unaffected changes, and selects all
+    implemented validation for `full`;
+12. GitHub executes a bounded three-platform matrix in parallel and the stable
+    merge gate requires its success when selected;
+13. local and GitHub workers report pull, build, Molecule, and platform-total
+    timing; the local summary and implementation report add their respective
+    overall elapsed times to evaluate future prebuilt images;
+14. acquisition, build, assertion, and cleanup failures are distinguishable;
+15. no test contacts inventory hosts, reads Vault material, uses infrastructure
+    credentials, or claims VM or hardware evidence; and
+16. all repository-required change-directed validation passes from the issue
+    branch before completion is claimed.

--- a/docs/specs/002-multi-os-molecule-validation.md
+++ b/docs/specs/002-multi-os-molecule-validation.md
@@ -222,8 +222,9 @@ The preflight must prove:
 
 The preflight does not pull or start a separate probe image. An ARM64 default
 run omits Arch and reports that GitHub CI covers it on native AMD64. The
-workflow-only platform selector still selects one exact matrix worker; GitHub
-runs that selector on its AMD64 host.
+internal platform selector overrides the default with one exact worker. GitHub
+sets it for each matrix job and runs Arch on its AMD64 host; it is not a public
+command argument.
 
 After container creation, a bounded readiness check confirms that systemd is PID
 1 and responds inside the container. This is the authoritative proof that the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,13 @@ ansible = [
   "ansible-lint==26.8.0",
   "PyYAML==6.0.3",
 ]
+molecule = [
+  "molecule==26.6.0",
+]
 dev = [
   { include-group = "fast" },
   { include-group = "ansible" },
+  { include-group = "molecule" },
 ]
 
 [tool.uv]

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,3 +17,5 @@ collections:
     version: 13.3.0
   - name: community.library_inventory_filtering_v1
     version: 1.1.5
+  - name: containers.podman
+    version: 1.20.2

--- a/roles/system_maintenance/defaults/main.yml
+++ b/roles/system_maintenance/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+system_maintenance_reboot_enabled: true

--- a/roles/system_maintenance/molecule/default/Containerfile.archlinux
+++ b/roles/system_maintenance/molecule/default/Containerfile.archlinux
@@ -1,0 +1,12 @@
+FROM docker.io/archlinux/archlinux:base
+
+ENV container=podman
+
+RUN pacman --sync --refresh --noconfirm \
+        dbus \
+        python \
+        systemd \
+    && pacman --sync --clean --clean --noconfirm
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/roles/system_maintenance/molecule/default/Containerfile.archlinux
+++ b/roles/system_maintenance/molecule/default/Containerfile.archlinux
@@ -2,11 +2,11 @@ FROM docker.io/archlinux/archlinux:base
 
 ENV container=podman
 
-RUN pacman --sync --refresh --noconfirm \
+RUN pacman --sync --refresh --noconfirm --disable-sandbox-syscalls \
         dbus \
         python \
         systemd \
     && pacman --sync --clean --clean --noconfirm
 
 STOPSIGNAL SIGRTMIN+3
-CMD ["/sbin/init"]
+CMD ["/usr/lib/systemd/systemd"]

--- a/roles/system_maintenance/molecule/default/Containerfile.debian13
+++ b/roles/system_maintenance/molecule/default/Containerfile.debian13
@@ -11,4 +11,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 STOPSIGNAL SIGRTMIN+3
-CMD ["/sbin/init"]
+CMD ["/usr/lib/systemd/systemd"]

--- a/roles/system_maintenance/molecule/default/Containerfile.debian13
+++ b/roles/system_maintenance/molecule/default/Containerfile.debian13
@@ -1,0 +1,14 @@
+FROM docker.io/library/debian:13
+
+ENV container=podman
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        dbus \
+        python3 \
+        systemd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/roles/system_maintenance/molecule/default/Containerfile.rockylinux9
+++ b/roles/system_maintenance/molecule/default/Containerfile.rockylinux9
@@ -10,4 +10,4 @@ RUN dnf install --assumeyes \
     && rm -rf /var/cache/dnf
 
 STOPSIGNAL SIGRTMIN+3
-CMD ["/sbin/init"]
+CMD ["/usr/lib/systemd/systemd"]

--- a/roles/system_maintenance/molecule/default/Containerfile.rockylinux9
+++ b/roles/system_maintenance/molecule/default/Containerfile.rockylinux9
@@ -1,0 +1,13 @@
+FROM docker.io/rockylinux/rockylinux:9
+
+ENV container=podman
+
+RUN dnf install --assumeyes \
+        dbus-daemon \
+        python3 \
+        systemd \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/roles/system_maintenance/molecule/default/cleanup.yml
+++ b/roles/system_maintenance/molecule/default/cleanup.yml
@@ -4,8 +4,21 @@
   connection: local
   gather_facts: false
   vars:
-    system_maintenance_molecule_platform: "{{ molecule_yml.platforms | first }}"
+    system_maintenance_molecule_platform_name: >-
+      {{ lookup('ansible.builtin.env', 'HOMELAB_MOLECULE_PLATFORM') }}
+    system_maintenance_molecule_platforms: >-
+      {{ molecule_yml.platforms
+         | selectattr('name', 'equalto', system_maintenance_molecule_platform_name)
+         | list }}
+    system_maintenance_molecule_platform: >-
+      {{ system_maintenance_molecule_platforms | first }}
   tasks:
+    - name: Assert Molecule selected exactly one platform
+      ansible.builtin.assert:
+        that:
+          - system_maintenance_molecule_platforms | length == 1
+        fail_msg: Molecule must select exactly one platform per worker
+
     - name: Inspect the exact cleanup target
       containers.podman.podman_container_info:
         name:

--- a/roles/system_maintenance/molecule/default/cleanup.yml
+++ b/roles/system_maintenance/molecule/default/cleanup.yml
@@ -1,0 +1,35 @@
+---
+- name: Confirm cleanup target ownership
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    system_maintenance_molecule_platform: "{{ molecule_yml.platforms | first }}"
+  tasks:
+    - name: Inspect the exact cleanup target
+      containers.podman.podman_container_info:
+        name:
+          - "{{ system_maintenance_molecule_platform.container_name }}"
+      register: system_maintenance_molecule_cleanup_container
+
+    - name: Assert any cleanup target remains scenario-owned
+      ansible.builtin.assert:
+        that:
+          - >-
+            system_maintenance_molecule_cleanup_container.containers | length == 0 or
+            system_maintenance_molecule_cleanup_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.repository'
+            ] | default('') == 'homelab-playbook'
+          - >-
+            system_maintenance_molecule_cleanup_container.containers | length == 0 or
+            system_maintenance_molecule_cleanup_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.scenario'
+            ] | default('') == 'system_maintenance/default'
+          - >-
+            system_maintenance_molecule_cleanup_container.containers | length == 0 or
+            system_maintenance_molecule_cleanup_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.platform'
+            ] | default('') == system_maintenance_molecule_platform.name
+        fail_msg: >-
+          Refusing cleanup target collision for
+          {{ system_maintenance_molecule_platform.container_name }}

--- a/roles/system_maintenance/molecule/default/converge.yml
+++ b/roles/system_maintenance/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge system maintenance role
+  hosts: molecule
+  gather_facts: true
+  roles:
+    - role: system_maintenance
+      system_maintenance_reboot_enabled: false

--- a/roles/system_maintenance/molecule/default/create.yml
+++ b/roles/system_maintenance/molecule/default/create.yml
@@ -4,12 +4,19 @@
   connection: local
   gather_facts: false
   vars:
-    system_maintenance_molecule_platform: "{{ molecule_yml.platforms | first }}"
+    system_maintenance_molecule_platform_name: >-
+      {{ lookup('ansible.builtin.env', 'HOMELAB_MOLECULE_PLATFORM') }}
+    system_maintenance_molecule_platforms: >-
+      {{ molecule_yml.platforms
+         | selectattr('name', 'equalto', system_maintenance_molecule_platform_name)
+         | list }}
+    system_maintenance_molecule_platform: >-
+      {{ system_maintenance_molecule_platforms | first }}
   tasks:
     - name: Assert Molecule selected exactly one platform
       ansible.builtin.assert:
         that:
-          - molecule_yml.platforms | length == 1
+          - system_maintenance_molecule_platforms | length == 1
         fail_msg: Molecule must select exactly one platform per worker
 
     - name: Inspect the exact test container name before creation
@@ -99,6 +106,7 @@
       ansible.builtin.set_fact:
         system_maintenance_molecule_instance_configuration:
           - instance: "{{ system_maintenance_molecule_platform.name }}"
+            address: "{{ system_maintenance_molecule_platform.container_name }}"
             connection: containers.podman.podman
 
     - name: Write Molecule instance configuration

--- a/roles/system_maintenance/molecule/default/create.yml
+++ b/roles/system_maintenance/molecule/default/create.yml
@@ -1,0 +1,110 @@
+---
+- name: Create Molecule test container
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    system_maintenance_molecule_platform: "{{ molecule_yml.platforms | first }}"
+  tasks:
+    - name: Assert Molecule selected exactly one platform
+      ansible.builtin.assert:
+        that:
+          - molecule_yml.platforms | length == 1
+        fail_msg: Molecule must select exactly one platform per worker
+
+    - name: Inspect the exact test container name before creation
+      containers.podman.podman_container_info:
+        name:
+          - "{{ system_maintenance_molecule_platform.container_name }}"
+      register: system_maintenance_existing_container
+
+    - name: Refuse a container name owned by another process
+      ansible.builtin.assert:
+        that:
+          - >-
+            system_maintenance_existing_container.containers | length == 0 or
+            system_maintenance_existing_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.repository'
+            ] | default('') == 'homelab-playbook'
+          - >-
+            system_maintenance_existing_container.containers | length == 0 or
+            system_maintenance_existing_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.scenario'
+            ] | default('') == 'system_maintenance/default'
+          - >-
+            system_maintenance_existing_container.containers | length == 0 or
+            system_maintenance_existing_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.platform'
+            ] | default('') == system_maintenance_molecule_platform.name
+        fail_msg: >-
+          Refusing container-name collision for
+          {{ system_maintenance_molecule_platform.container_name }}
+
+    - name: Start the unprivileged systemd test container
+      containers.podman.podman_container:
+        name: "{{ system_maintenance_molecule_platform.container_name }}"
+        image: "{{ system_maintenance_molecule_platform.image }}"
+        command: "{{ system_maintenance_molecule_platform.container_command }}"
+        state: started
+        detach: true
+        privileged: "{{ system_maintenance_molecule_platform.container_privileged }}"
+        systemd: "{{ system_maintenance_molecule_platform.container_systemd }}"
+        pull: "{{ system_maintenance_molecule_platform.pull }}"
+        label: "{{ system_maintenance_molecule_platform.labels }}"
+
+    - name: Wait for systemd to become PID 1
+      containers.podman.podman_container_exec:
+        name: "{{ system_maintenance_molecule_platform.container_name }}"
+        argv:
+          - cat
+          - /proc/1/comm
+      register: system_maintenance_molecule_systemd_pid
+      changed_when: false
+      failed_when: false
+      retries: 30
+      delay: 2
+      until:
+        - system_maintenance_molecule_systemd_pid.rc == 0
+        - system_maintenance_molecule_systemd_pid.stdout | trim == 'systemd'
+
+    - name: Wait for systemd manager readiness
+      containers.podman.podman_container_exec:
+        name: "{{ system_maintenance_molecule_platform.container_name }}"
+        argv:
+          - systemctl
+          - is-system-running
+      register: system_maintenance_molecule_systemd_state
+      changed_when: false
+      failed_when: false
+      retries: 30
+      delay: 2
+      until:
+        - >-
+          system_maintenance_molecule_systemd_state.stdout | trim in
+          ['running', 'degraded']
+
+    - name: Assert rootless systemd and cgroup delegation are usable
+      ansible.builtin.assert:
+        that:
+          - system_maintenance_molecule_systemd_pid.rc == 0
+          - system_maintenance_molecule_systemd_pid.stdout | trim == 'systemd'
+          - >-
+            system_maintenance_molecule_systemd_state.stdout | trim in
+            ['running', 'degraded']
+        fail_msg: >-
+          The rootless container could not start systemd with usable cgroup
+          delegation
+
+    - name: Define Molecule connection data
+      ansible.builtin.set_fact:
+        system_maintenance_molecule_instance_configuration:
+          - instance: "{{ system_maintenance_molecule_platform.name }}"
+            connection: containers.podman.podman
+
+    - name: Write Molecule instance configuration
+      ansible.builtin.copy:
+        content: |-
+          # Molecule managed
+          {{ system_maintenance_molecule_instance_configuration | to_nice_yaml }}
+        dest: "{{ molecule_instance_config }}"
+        mode: '0600'

--- a/roles/system_maintenance/molecule/default/destroy.yml
+++ b/roles/system_maintenance/molecule/default/destroy.yml
@@ -4,12 +4,19 @@
   connection: local
   gather_facts: false
   vars:
-    system_maintenance_molecule_platform: "{{ molecule_yml.platforms | first }}"
+    system_maintenance_molecule_platform_name: >-
+      {{ lookup('ansible.builtin.env', 'HOMELAB_MOLECULE_PLATFORM') }}
+    system_maintenance_molecule_platforms: >-
+      {{ molecule_yml.platforms
+         | selectattr('name', 'equalto', system_maintenance_molecule_platform_name)
+         | list }}
+    system_maintenance_molecule_platform: >-
+      {{ system_maintenance_molecule_platforms | first }}
   tasks:
     - name: Assert Molecule selected exactly one platform
       ansible.builtin.assert:
         that:
-          - molecule_yml.platforms | length == 1
+          - system_maintenance_molecule_platforms | length == 1
         fail_msg: Molecule must select exactly one platform per worker
 
     - name: Inspect the exact test container name before destruction

--- a/roles/system_maintenance/molecule/default/destroy.yml
+++ b/roles/system_maintenance/molecule/default/destroy.yml
@@ -1,0 +1,55 @@
+---
+- name: Destroy Molecule test container
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    system_maintenance_molecule_platform: "{{ molecule_yml.platforms | first }}"
+  tasks:
+    - name: Assert Molecule selected exactly one platform
+      ansible.builtin.assert:
+        that:
+          - molecule_yml.platforms | length == 1
+        fail_msg: Molecule must select exactly one platform per worker
+
+    - name: Inspect the exact test container name before destruction
+      containers.podman.podman_container_info:
+        name:
+          - "{{ system_maintenance_molecule_platform.container_name }}"
+      register: system_maintenance_existing_container
+
+    - name: Refuse to destroy a container owned by another process
+      ansible.builtin.assert:
+        that:
+          - >-
+            system_maintenance_existing_container.containers | length == 0 or
+            system_maintenance_existing_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.repository'
+            ] | default('') == 'homelab-playbook'
+          - >-
+            system_maintenance_existing_container.containers | length == 0 or
+            system_maintenance_existing_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.scenario'
+            ] | default('') == 'system_maintenance/default'
+          - >-
+            system_maintenance_existing_container.containers | length == 0 or
+            system_maintenance_existing_container.containers[0].Config.Labels[
+              'io.supermorphic.homelab-playbook.platform'
+            ] | default('') == system_maintenance_molecule_platform.name
+        fail_msg: >-
+          Refusing container-name collision for
+          {{ system_maintenance_molecule_platform.container_name }}
+
+    - name: Remove the owned test container
+      containers.podman.podman_container:
+        name: "{{ system_maintenance_molecule_platform.container_name }}"
+        state: absent
+      when: system_maintenance_existing_container.containers | length > 0
+
+    - name: Clear Molecule instance configuration
+      ansible.builtin.copy:
+        content: |-
+          # Molecule managed
+          []
+        dest: "{{ molecule_instance_config }}"
+        mode: '0600'

--- a/roles/system_maintenance/molecule/default/molecule.yml
+++ b/roles/system_maintenance/molecule/default/molecule.yml
@@ -1,0 +1,69 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+
+driver:
+  name: default
+  options:
+    managed: true
+
+platforms:
+  - name: debian13
+    groups:
+      - molecule
+    image: localhost/homelab-playbook-system-maintenance-debian13:local
+    container_name: homelab-playbook-system-maintenance-debian13
+    container_command: /sbin/init
+    container_privileged: false
+    container_systemd: always
+    pull: never
+    labels:
+      io.supermorphic.homelab-playbook.repository: homelab-playbook
+      io.supermorphic.homelab-playbook.scenario: system_maintenance/default
+      io.supermorphic.homelab-playbook.platform: debian13
+  - name: rockylinux9
+    groups:
+      - molecule
+    image: localhost/homelab-playbook-system-maintenance-rockylinux9:local
+    container_name: homelab-playbook-system-maintenance-rockylinux9
+    container_command: /sbin/init
+    container_privileged: false
+    container_systemd: always
+    pull: never
+    labels:
+      io.supermorphic.homelab-playbook.repository: homelab-playbook
+      io.supermorphic.homelab-playbook.scenario: system_maintenance/default
+      io.supermorphic.homelab-playbook.platform: rockylinux9
+  - name: archlinux
+    groups:
+      - molecule
+    image: localhost/homelab-playbook-system-maintenance-archlinux:local
+    container_name: homelab-playbook-system-maintenance-archlinux
+    container_command: /sbin/init
+    container_privileged: false
+    container_systemd: always
+    pull: never
+    labels:
+      io.supermorphic.homelab-playbook.repository: homelab-playbook
+      io.supermorphic.homelab-playbook.scenario: system_maintenance/default
+      io.supermorphic.homelab-playbook.platform: archlinux
+
+provisioner:
+  name: ansible
+  log: true
+
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/roles/system_maintenance/molecule/default/molecule.yml
+++ b/roles/system_maintenance/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ platforms:
       - molecule
     image: localhost/homelab-playbook-system-maintenance-debian13:local
     container_name: homelab-playbook-system-maintenance-debian13
-    container_command: /sbin/init
+    container_command: /usr/lib/systemd/systemd
     container_privileged: false
     container_systemd: always
     pull: never
@@ -27,7 +27,7 @@ platforms:
       - molecule
     image: localhost/homelab-playbook-system-maintenance-rockylinux9:local
     container_name: homelab-playbook-system-maintenance-rockylinux9
-    container_command: /sbin/init
+    container_command: /usr/lib/systemd/systemd
     container_privileged: false
     container_systemd: always
     pull: never
@@ -40,7 +40,7 @@ platforms:
       - molecule
     image: localhost/homelab-playbook-system-maintenance-archlinux:local
     container_name: homelab-playbook-system-maintenance-archlinux
-    container_command: /sbin/init
+    container_command: /usr/lib/systemd/systemd
     container_privileged: false
     container_systemd: always
     pull: never

--- a/roles/system_maintenance/molecule/default/prepare.yml
+++ b/roles/system_maintenance/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Confirm Molecule container readiness
+  hosts: molecule
+  gather_facts: true
+  tasks:
+    - name: Read PID 1 process name
+      ansible.builtin.command:
+        argv:
+          - cat
+          - /proc/1/comm
+      register: system_maintenance_molecule_prepare_pid
+      changed_when: false
+
+    - name: Read systemd manager state
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - is-system-running
+      register: system_maintenance_molecule_prepare_systemd
+      changed_when: false
+      failed_when: >-
+        system_maintenance_molecule_prepare_systemd.stdout | trim not in
+        ['running', 'degraded']
+
+    - name: Assert systemd is PID 1
+      ansible.builtin.assert:
+        that:
+          - system_maintenance_molecule_prepare_pid.stdout | trim == 'systemd'

--- a/roles/system_maintenance/molecule/default/verify.yml
+++ b/roles/system_maintenance/molecule/default/verify.yml
@@ -1,0 +1,108 @@
+---
+- name: Verify system maintenance results
+  hosts: molecule
+  gather_facts: true
+  tasks:
+    - name: Gather installed package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Read PID 1 process name
+      ansible.builtin.command:
+        argv:
+          - cat
+          - /proc/1/comm
+      register: system_maintenance_molecule_verify_pid
+      changed_when: false
+
+    - name: Read systemd manager state
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - is-system-running
+      register: system_maintenance_molecule_verify_systemd
+      changed_when: false
+      failed_when: >-
+        system_maintenance_molecule_verify_systemd.stdout | trim not in
+        ['running', 'degraded']
+
+    - name: Assert common maintenance results
+      ansible.builtin.assert:
+        that:
+          - system_maintenance_molecule_verify_pid.stdout | trim == 'systemd'
+          - >-
+            system_maintenance_molecule_verify_systemd.stdout | trim in
+            ['running', 'degraded']
+          - "'tree' in ansible_facts.packages"
+
+    - name: Assert Debian maintenance results
+      ansible.builtin.assert:
+        that:
+          - ansible_os_family == 'Debian'
+          - "'apache2-utils' in ansible_facts.packages"
+          - "'openssh-server' in ansible_facts.packages"
+      when: inventory_hostname == 'debian13'
+
+    - name: Read Rocky Linux DNF configuration
+      ansible.builtin.slurp:
+        src: /etc/dnf/dnf.conf
+      register: system_maintenance_molecule_rocky_dnf_configuration
+      when: inventory_hostname == 'rockylinux9'
+
+    - name: Read Rocky Linux EPEL configuration
+      ansible.builtin.slurp:
+        src: /etc/yum.repos.d/epel.repo
+      register: system_maintenance_molecule_rocky_epel_configuration
+      when: inventory_hostname == 'rockylinux9'
+
+    - name: Assert Rocky Linux maintenance results
+      ansible.builtin.assert:
+        that:
+          - ansible_os_family == 'RedHat'
+          - "'epel-release' in ansible_facts.packages"
+          - "'httpd-tools' in ansible_facts.packages"
+          - >-
+            system_maintenance_molecule_rocky_dnf_configuration.content |
+            b64decode is
+            regex('(?m)^installonly_limit=2$')
+          - >-
+            system_maintenance_molecule_rocky_epel_configuration.content |
+            b64decode is
+            regex('(?ms)^\[epel\].*?^enabled=0$')
+      when: inventory_hostname == 'rockylinux9'
+
+    - name: Read generated Arch Linux locales
+      ansible.builtin.command:
+        argv:
+          - locale
+          - -a
+      register: system_maintenance_molecule_arch_locales
+      changed_when: false
+      when: inventory_hostname == 'archlinux'
+
+    - name: Inspect Arch Linux locale configuration
+      ansible.builtin.stat:
+        path: /etc/locale.conf
+      register: system_maintenance_molecule_arch_locale_stat
+      when: inventory_hostname == 'archlinux'
+
+    - name: Read Arch Linux locale configuration
+      ansible.builtin.slurp:
+        src: /etc/locale.conf
+      register: system_maintenance_molecule_arch_locale_configuration
+      when: inventory_hostname == 'archlinux'
+
+    - name: Assert Arch Linux maintenance results
+      ansible.builtin.assert:
+        that:
+          - ansible_os_family == 'Archlinux'
+          - "'apache' in ansible_facts.packages"
+          - >-
+            'en_US.utf8' in
+            system_maintenance_molecule_arch_locales.stdout_lines
+          - system_maintenance_molecule_arch_locale_stat.stat.mode == '0644'
+          - >-
+            system_maintenance_molecule_arch_locale_configuration.content |
+            b64decode | trim ==
+            'LANG=en_US.UTF-8'
+      when: inventory_hostname == 'archlinux'

--- a/roles/system_maintenance/tasks/setup-Archlinux.yml
+++ b/roles/system_maintenance/tasks/setup-Archlinux.yml
@@ -22,10 +22,30 @@
     state: present
     update_cache: false
 
-- name: Ensure the English locale exists
-  community.general.locale_gen:
-    name: en_US.UTF-8
-    state: present
+- name: Inspect generated locales
+  ansible.builtin.command:
+    argv:
+      - locale
+      - -a
+  register: system_maintenance_arch_available_locales
+  changed_when: false
+
+- name: Enable the English locale definition
+  ansible.builtin.lineinfile:
+    path: /etc/locale.gen
+    regexp: '^#?\s*en_US\.UTF-8\s+UTF-8$'
+    line: en_US.UTF-8 UTF-8
+    mode: '0644'
+  register: system_maintenance_arch_locale_definition
+
+- name: Generate the English locale
+  ansible.builtin.command:
+    argv:
+      - locale-gen
+  when: >-
+    system_maintenance_arch_locale_definition.changed or
+    'en_US.utf8' not in system_maintenance_arch_available_locales.stdout_lines
+  changed_when: true
 
 - name: Set the English locale as default
   ansible.builtin.lineinfile:

--- a/roles/system_maintenance/tasks/setup-Debian.yml
+++ b/roles/system_maintenance/tasks/setup-Debian.yml
@@ -48,4 +48,6 @@
     connect_timeout: 5
     reboot_timeout: 600
     test_command: whoami
-  when: system_maintenance_reboot_required_file.stat.exists
+  when:
+    - system_maintenance_reboot_required_file.stat.exists
+    - system_maintenance_reboot_enabled | bool

--- a/roles/system_maintenance/tasks/setup-RedHat.yml
+++ b/roles/system_maintenance/tasks/setup-RedHat.yml
@@ -68,4 +68,6 @@
     connect_timeout: 5
     reboot_timeout: 600
     test_command: whoami
-  when: system_maintenance_needs_restart.rc == 1
+  when:
+    - system_maintenance_needs_restart.rc == 1
+    - system_maintenance_reboot_enabled | bool

--- a/scripts/ci/classify.py
+++ b/scripts/ci/classify.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 
 
 DEPTH_ORDER = {"fast": 0, "ansible": 1, "molecule": 2, "full": 3}
-EMITTED_DEPTHS = ("fast", "ansible", "full")
+EMITTED_DEPTHS = ("fast", "ansible", "molecule", "full")
 DIFF_DISCOVERY_OPTIONS = [
     "diff",
     "--name-status",
@@ -92,6 +92,11 @@ def classify_path(path: str) -> tuple[str, str]:
     ):
         return "full", "validation implementation changes require full validation"
 
+    if _has_prefix(path, ("roles/system_maintenance/",)):
+        return (
+            "molecule",
+            "system_maintenance changes require container validation",
+        )
     if _has_prefix(path, ("inventory/", "playbooks/", "roles/", "overrides/")):
         return "ansible", "Ansible source changes require Ansible validation"
     if path in ANSIBLE_CONFIG_PATHS:
@@ -119,7 +124,7 @@ def _result(
         "depth": depth,
         "run_fast": True,
         "run_ansible": DEPTH_ORDER[depth] >= DEPTH_ORDER["ansible"],
-        "run_molecule": False,
+        "run_molecule": DEPTH_ORDER[depth] >= DEPTH_ORDER["molecule"],
         "paths": paths,
         "reasons": reasons,
     }

--- a/scripts/ci/merge_gate.py
+++ b/scripts/ci/merge_gate.py
@@ -5,7 +5,7 @@ import sys
 from collections.abc import Sequence
 
 
-IMPLEMENTED_DEPTHS = ("fast", "ansible", "full")
+IMPLEMENTED_DEPTHS = ("fast", "ansible", "molecule", "full")
 
 
 def _result_error(job: str, result: str, expected: str) -> str:
@@ -17,6 +17,7 @@ def reconcile(
     classify_result: str,
     fast_result: str,
     ansible_result: str,
+    molecule_result: str,
 ) -> list[str]:
     errors: list[str] = []
     if classify_result != "success":
@@ -26,9 +27,6 @@ def reconcile(
 
     if not depth:
         errors.append("validation depth is missing")
-        return errors
-    if depth == "molecule":
-        errors.append("validation depth 'molecule' is not implemented")
         return errors
     if depth not in IMPLEMENTED_DEPTHS:
         errors.append(f"validation depth '{depth}' is unknown")
@@ -42,6 +40,16 @@ def reconcile(
     elif ansible_result != "success":
         errors.append(_result_error("ansible", ansible_result, "'success'"))
 
+    if depth in {"fast", "ansible"}:
+        if molecule_result not in {"success", "skipped"}:
+            errors.append(
+                _result_error(
+                    "molecule", molecule_result, "'success' or 'skipped'"
+                )
+            )
+    elif molecule_result != "success":
+        errors.append(_result_error("molecule", molecule_result, "'success'"))
+
     return errors
 
 
@@ -53,6 +61,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--classify-result", required=True)
     parser.add_argument("--fast-result", required=True)
     parser.add_argument("--ansible-result", required=True)
+    parser.add_argument("--molecule-result", required=True)
     return parser
 
 
@@ -63,6 +72,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         arguments.classify_result,
         arguments.fast_result,
         arguments.ansible_result,
+        arguments.molecule_result,
     )
     for error in errors:
         print(error, file=sys.stderr)

--- a/scripts/ci/run_changed.py
+++ b/scripts/ci/run_changed.py
@@ -16,9 +16,27 @@ COMMANDS = {
         ["mise", "run", "validate:fast"],
         ["mise", "run", "validate:ansible"],
     ],
+    "molecule": [
+        ["mise", "run", "validate:fast"],
+        ["mise", "run", "validate:ansible"],
+        [
+            "mise",
+            "run",
+            "test:molecule",
+            "--",
+            "system_maintenance/default",
+        ],
+    ],
     "full": [
         ["mise", "run", "validate:fast"],
         ["mise", "run", "validate:ansible"],
+        [
+            "mise",
+            "run",
+            "test:molecule",
+            "--",
+            "system_maintenance/default",
+        ],
     ],
 }
 

--- a/scripts/ci/validate-ansible.sh
+++ b/scripts/ci/validate-ansible.sh
@@ -26,6 +26,7 @@ bash tests/ansible/inventory-test.sh
 bash tests/ansible/vault-test.sh
 uv run --frozen --no-sync python -m unittest -v \
   tests/ansible/test_ansible_sources.py \
+  tests/ansible/test_molecule_contract.py \
   tests/ansible/test_source_contracts.py
 
 ansible_source_manifest="$ansible_validation_root/ansible-sources.bin"

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -547,6 +547,10 @@ def run_platform(
             / invocation_id
             / platform_definition.name
         )
+        molecule_environment["ANSIBLE_ROLES_PATH"] = str(repo_root / "roles")
+        molecule_environment["ANSIBLE_COLLECTIONS_PATH"] = str(
+            repo_root / ".ansible" / "collections"
+        )
         molecule_result = runner.stream(
             [
                 "molecule",

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -605,9 +605,18 @@ def run_platform(
     )
 
 
-def select_platforms(environment: Mapping[str, str]) -> tuple[Platform, ...]:
+def select_platforms(
+    environment: Mapping[str, str],
+    host_architecture: str,
+) -> tuple[Platform, ...]:
     selected_name = environment.get("HOMELAB_MOLECULE_PLATFORM")
     if not selected_name:
+        if host_architecture == "arm64":
+            return tuple(
+                platform_definition
+                for platform_definition in PLATFORMS
+                if platform_definition.name != "archlinux"
+            )
         return PLATFORMS
     selected = tuple(
         platform_definition
@@ -643,6 +652,7 @@ def _terminal_summary(
     host_plan: HostPlan,
     results: Sequence[PlatformResult],
     invocation_seconds: float,
+    environment: Mapping[str, str],
 ) -> str:
     lines = [f"Podman: {host_plan.podman_version}"]
     for result in results:
@@ -663,6 +673,14 @@ def _terminal_summary(
             f"cleanup={result.cleanup_seconds:.2f}s "
             f"total={result.platform_seconds:.2f}s "
             f"result={result.status} message={result.message}"
+        )
+    if (
+        not environment.get("HOMELAB_MOLECULE_PLATFORM")
+        and host_plan.host_architecture == "arm64"
+        and not any(result.platform == "archlinux" for result in results)
+    ):
+        lines.append(
+            "archlinux: skipped on arm64; GitHub CI runs it on native amd64"
         )
     lines.append(f"Invocation total: {invocation_seconds:.2f}s")
     return "\n".join(lines)
@@ -718,7 +736,7 @@ def emit_summary(
     invocation_seconds: float,
     environment: Mapping[str, str],
 ) -> None:
-    print(_terminal_summary(host_plan, results, invocation_seconds))
+    print(_terminal_summary(host_plan, results, invocation_seconds, environment))
 
     summary_value = environment.get("GITHUB_STEP_SUMMARY")
     if not summary_value:
@@ -747,8 +765,17 @@ def run(arguments: Sequence[str] | None, runner: CommandRunner) -> int:
     repo_root = Path(__file__).resolve().parents[1]
     invocation_started = time.monotonic()
     try:
-        platform_definitions = select_platforms(os.environ)
+        selected_name = os.environ.get("HOMELAB_MOLECULE_PLATFORM")
+        if selected_name and not any(
+            platform_definition.name == selected_name
+            for platform_definition in PLATFORMS
+        ):
+            raise PreflightError(f"unknown Molecule platform: {selected_name}")
         host_plan = preflight(repo_root, runner)
+        platform_definitions = select_platforms(
+            os.environ,
+            host_plan.host_architecture,
+        )
         with invocation_lock(repo_root, runner):
             invocation_id = uuid.uuid4().hex
             results = run_platforms(

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse
@@ -12,12 +11,16 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
+import time
+import uuid
 
 from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, Protocol
+from typing import Callable, Iterator, Protocol
 
 
 SELECTOR = "system_maintenance/default"
@@ -30,6 +33,31 @@ class Platform:
     image: str
     container: str
     containerfile: Path
+
+
+PLATFORMS = (
+    Platform(
+        name="debian13",
+        base_image="docker.io/library/debian:13",
+        image="localhost/homelab-playbook-system-maintenance-debian13:local",
+        container="homelab-playbook-system-maintenance-debian13",
+        containerfile=Path("Containerfile.debian13"),
+    ),
+    Platform(
+        name="rockylinux9",
+        base_image="docker.io/rockylinux/rockylinux:9",
+        image="localhost/homelab-playbook-system-maintenance-rockylinux9:local",
+        container="homelab-playbook-system-maintenance-rockylinux9",
+        containerfile=Path("Containerfile.rockylinux9"),
+    ),
+    Platform(
+        name="archlinux",
+        base_image="docker.io/archlinux/archlinux:base",
+        image="localhost/homelab-playbook-system-maintenance-archlinux:local",
+        container="homelab-playbook-system-maintenance-archlinux",
+        containerfile=Path("Containerfile.archlinux"),
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -57,6 +85,20 @@ class CommandRunner(Protocol):
     ) -> CommandResult:
         raise NotImplementedError
 
+    def stream(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        line_prefix: str,
+    ) -> CommandResult:
+        raise NotImplementedError
+
+
+OUTPUT_LOCK = threading.Lock()
+
 
 class SubprocessCommandRunner:
     def capture(
@@ -82,9 +124,75 @@ class SubprocessCommandRunner:
             stderr=completed.stderr,
         )
 
+    def stream(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        line_prefix: str,
+    ) -> CommandResult:
+        if timeout is not None:
+            result = self.capture(command, cwd=cwd, env=env, timeout=timeout)
+            for line in (result.stdout + result.stderr).splitlines():
+                with OUTPUT_LOCK:
+                    print(f"{line_prefix} {line}", flush=True)
+            return result
+
+        output: list[str] = []
+        with subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=None if env is None else dict(env),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        ) as process:
+            if process.stdout is None:
+                process.kill()
+                raise WorkerError("could not capture worker output")
+            for line in process.stdout:
+                output.append(line)
+                with OUTPUT_LOCK:
+                    print(f"{line_prefix} {line.rstrip()}", flush=True)
+            returncode = process.wait()
+        return CommandResult(
+            returncode=returncode,
+            stdout="".join(output),
+            stderr="",
+        )
 
 class PreflightError(RuntimeError):
     """A setup problem the operator can correct without a traceback."""
+
+
+class WorkerError(RuntimeError):
+    """A platform lifecycle failure that should appear in the summary."""
+
+
+class StageError(WorkerError):
+    def __init__(self, status: str, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+@dataclass(frozen=True)
+class PlatformResult:
+    platform: str
+    status: str
+    message: str
+    image_id: str | None
+    repository_digest: str | None
+    pull_seconds: float
+    build_seconds: float
+    molecule_seconds: float
+    cleanup_seconds: float
+    platform_seconds: float
+
+    @property
+    def success(self) -> bool:
+        return self.status == "pass"
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -238,17 +346,424 @@ def invocation_lock(repo_root: Path, runner: CommandRunner) -> Iterator[None]:
         lock_file.close()
 
 
+def ownership_labels(platform_definition: Platform) -> dict[str, str]:
+    return {
+        "io.supermorphic.homelab-playbook.repository": "homelab-playbook",
+        "io.supermorphic.homelab-playbook.scenario": SELECTOR,
+        "io.supermorphic.homelab-playbook.platform": platform_definition.name,
+    }
+
+
+def remove_owned_container(
+    repo_root: Path,
+    runner: CommandRunner,
+    platform_definition: Platform,
+) -> bool:
+    exists_result = runner.capture(
+        ["podman", "container", "exists", platform_definition.container],
+        cwd=repo_root,
+    )
+    if exists_result.returncode == 1:
+        return False
+    if exists_result.returncode != 0:
+        raise WorkerError(
+            f"could not inspect container name {platform_definition.container}"
+        )
+
+    inspect_result = runner.capture(
+        [
+            "podman",
+            "container",
+            "inspect",
+            platform_definition.container,
+            "--format",
+            "json",
+        ],
+        cwd=repo_root,
+    )
+    if inspect_result.returncode != 0:
+        raise WorkerError(
+            f"could not inspect container labels for {platform_definition.container}"
+        )
+    try:
+        inspected = json.loads(inspect_result.stdout)
+        labels = inspected[0]["Config"]["Labels"]
+    except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
+        raise WorkerError(
+            f"could not inspect container labels for {platform_definition.container}"
+        ) from error
+
+    expected_labels = ownership_labels(platform_definition)
+    if not isinstance(labels, dict) or any(
+        labels.get(key) != value for key, value in expected_labels.items()
+    ):
+        raise WorkerError(
+            f"container name collision: {platform_definition.container} is not "
+            f"owned by {SELECTOR}/{platform_definition.name}"
+        )
+
+    remove_result = runner.capture(
+        ["podman", "rm", "--force", platform_definition.container],
+        cwd=repo_root,
+    )
+    if remove_result.returncode != 0:
+        raise WorkerError(
+            f"could not remove owned container {platform_definition.container}"
+        )
+    return True
+
+
+def _image_provenance(output: str, base_image: str) -> tuple[str, str | None]:
+    try:
+        inspected = json.loads(output)
+        image = inspected[0]
+        image_id = image["Id"]
+        repository_digests = image.get("RepoDigests") or []
+    except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
+        raise StageError(
+            "acquisition failure",
+            f"could not read the pulled image identity for {base_image}",
+        ) from error
+    if not isinstance(image_id, str) or not image_id:
+        raise StageError(
+            "acquisition failure",
+            f"could not read the pulled image identity for {base_image}",
+        )
+
+    repository = base_image.rsplit(":", maxsplit=1)[0]
+    matching_digest = next(
+        (
+            digest
+            for digest in repository_digests
+            if isinstance(digest, str) and digest.startswith(f"{repository}@")
+        ),
+        None,
+    )
+    return image_id, matching_digest
+
+
+def run_platform(
+    platform_definition: Platform,
+    host_plan: HostPlan,
+    repo_root: Path,
+    runner: CommandRunner,
+    invocation_id: str,
+    clock=time.monotonic,
+) -> PlatformResult:
+    platform_started = clock()
+    pull_seconds = 0.0
+    build_seconds = 0.0
+    molecule_seconds = 0.0
+    cleanup_seconds = 0.0
+    image_id: str | None = None
+    repository_digest: str | None = None
+    status = "pass"
+    message = "all Molecule phases passed"
+    requested_architecture = host_plan.requested_architectures[
+        platform_definition.name
+    ]
+    scenario_directory = (
+        repo_root / "roles" / "system_maintenance" / "molecule" / "default"
+    )
+    role_directory = repo_root / "roles" / "system_maintenance"
+    line_prefix = f"[{platform_definition.name}]"
+
+    try:
+        remove_owned_container(repo_root, runner, platform_definition)
+
+        pull_started = clock()
+        pull_result = runner.stream(
+            [
+                "podman",
+                "pull",
+                "--policy=always",
+                "--retry=3",
+                "--platform",
+                f"linux/{requested_architecture}",
+                platform_definition.base_image,
+            ],
+            cwd=repo_root,
+            line_prefix=line_prefix,
+        )
+        if pull_result.returncode != 0:
+            pull_seconds = clock() - pull_started
+            raise StageError(
+                "acquisition failure",
+                f"image pull failed for {platform_definition.base_image}",
+            )
+        inspect_result = runner.capture(
+            [
+                "podman",
+                "image",
+                "inspect",
+                platform_definition.base_image,
+                "--format",
+                "json",
+            ],
+            cwd=repo_root,
+        )
+        if inspect_result.returncode != 0:
+            pull_seconds = clock() - pull_started
+            raise StageError(
+                "acquisition failure",
+                f"image inspection failed for {platform_definition.base_image}",
+            )
+        image_id, repository_digest = _image_provenance(
+            inspect_result.stdout,
+            platform_definition.base_image,
+        )
+        pull_seconds = clock() - pull_started
+
+        build_started = clock()
+        build_result = runner.stream(
+            [
+                "podman",
+                "build",
+                "--pull=never",
+                "--platform",
+                f"linux/{requested_architecture}",
+                "--tag",
+                platform_definition.image,
+                "--file",
+                str(scenario_directory / platform_definition.containerfile),
+                str(scenario_directory),
+            ],
+            cwd=repo_root,
+            line_prefix=line_prefix,
+        )
+        build_seconds = clock() - build_started
+        if build_result.returncode != 0:
+            raise StageError(
+                "build failure",
+                f"test-image build failed for {platform_definition.name}",
+            )
+
+        molecule_started = clock()
+        molecule_environment = os.environ.copy()
+        molecule_environment["MOLECULE_EPHEMERAL_DIRECTORY"] = str(
+            repo_root
+            / ".tmp"
+            / "molecule"
+            / invocation_id
+            / platform_definition.name
+        )
+        molecule_result = runner.stream(
+            [
+                "molecule",
+                "test",
+                "--scenario-name",
+                "default",
+                "--platform-name",
+                platform_definition.name,
+                "--no-report",
+                "--no-command-borders",
+            ],
+            cwd=role_directory,
+            env=molecule_environment,
+            line_prefix=line_prefix,
+        )
+        molecule_seconds = clock() - molecule_started
+        if molecule_result.returncode != 0:
+            raise StageError(
+                "test failure",
+                f"Molecule lifecycle failed for {platform_definition.name}",
+            )
+    except StageError as error:
+        status = error.status
+        message = str(error)
+    except WorkerError as error:
+        status = "cleanup failure"
+        message = str(error)
+    finally:
+        cleanup_started = clock()
+        try:
+            remove_owned_container(repo_root, runner, platform_definition)
+        except WorkerError as cleanup_error:
+            primary = f"{status}: {message}"
+            status = "cleanup failure"
+            message = f"{primary}; cleanup failure: {cleanup_error}"
+        cleanup_seconds = clock() - cleanup_started
+
+    return PlatformResult(
+        platform=platform_definition.name,
+        status=status,
+        message=message,
+        image_id=image_id,
+        repository_digest=repository_digest,
+        pull_seconds=pull_seconds,
+        build_seconds=build_seconds,
+        molecule_seconds=molecule_seconds,
+        cleanup_seconds=cleanup_seconds,
+        platform_seconds=clock() - platform_started,
+    )
+
+
+def select_platforms(environment: Mapping[str, str]) -> tuple[Platform, ...]:
+    selected_name = environment.get("HOMELAB_MOLECULE_PLATFORM")
+    if not selected_name:
+        return PLATFORMS
+    selected = tuple(
+        platform_definition
+        for platform_definition in PLATFORMS
+        if platform_definition.name == selected_name
+    )
+    if not selected:
+        raise PreflightError(f"unknown Molecule platform: {selected_name}")
+    return selected
+
+
+def run_platforms(
+    platform_definitions: Sequence[Platform],
+    worker: Callable[[Platform], PlatformResult],
+) -> list[PlatformResult]:
+    with ThreadPoolExecutor(max_workers=len(platform_definitions)) as executor:
+        futures = [
+            executor.submit(worker, platform_definition)
+            for platform_definition in platform_definitions
+        ]
+        return [future.result() for future in futures]
+
+
+def _platform_by_name(name: str) -> Platform:
+    return next(
+        platform_definition
+        for platform_definition in PLATFORMS
+        if platform_definition.name == name
+    )
+
+
+def _terminal_summary(
+    host_plan: HostPlan,
+    results: Sequence[PlatformResult],
+    invocation_seconds: float,
+) -> str:
+    lines = [f"Podman: {host_plan.podman_version}"]
+    for result in results:
+        platform_definition = _platform_by_name(result.platform)
+        requested = host_plan.requested_architectures[result.platform]
+        execution_mode = (
+            "native" if requested == host_plan.host_architecture else "emulated"
+        )
+        lines.append(
+            f"{result.platform}: host={host_plan.host_architecture} "
+            f"requested={requested} {execution_mode} "
+            f"base={platform_definition.base_image} "
+            f"image={result.image_id or 'unavailable'} "
+            f"digest={result.repository_digest or 'unavailable'} "
+            f"pull={result.pull_seconds:.2f}s "
+            f"build={result.build_seconds:.2f}s "
+            f"molecule={result.molecule_seconds:.2f}s "
+            f"cleanup={result.cleanup_seconds:.2f}s "
+            f"total={result.platform_seconds:.2f}s "
+            f"result={result.status} message={result.message}"
+        )
+    lines.append(f"Invocation total: {invocation_seconds:.2f}s")
+    return "\n".join(lines)
+
+
+def _github_summary(
+    host_plan: HostPlan,
+    results: Sequence[PlatformResult],
+    invocation_seconds: float,
+) -> str:
+    lines = [
+        "### Molecule platform summary",
+        "",
+        f"- Podman: `{host_plan.podman_version}`",
+        f"- Invocation total: {invocation_seconds:.2f} seconds",
+        "",
+        "| Platform | Host | Requested | Mode | Pull | Build | Molecule | "
+        "Cleanup | Total | Result |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for result in results:
+        requested = host_plan.requested_architectures[result.platform]
+        execution_mode = (
+            "native" if requested == host_plan.host_architecture else "emulated"
+        )
+        lines.append(
+            f"| {result.platform} | {host_plan.host_architecture} | {requested} | "
+            f"{execution_mode} | {result.pull_seconds:.2f}s | "
+            f"{result.build_seconds:.2f}s | {result.molecule_seconds:.2f}s | "
+            f"{result.cleanup_seconds:.2f}s | {result.platform_seconds:.2f}s | "
+            f"{result.status} |"
+        )
+        platform_definition = _platform_by_name(result.platform)
+        lines.extend(
+            [
+                "",
+                f"- {result.platform} base: `{platform_definition.base_image}`",
+                f"- {result.platform} image ID: `{result.image_id or 'unavailable'}`",
+                f"- {result.platform} digest: "
+                f"`{result.repository_digest or 'unavailable'}`",
+                f"- {result.platform} Pull: {result.pull_seconds:.2f} seconds; "
+                f"Build: {result.build_seconds:.2f} seconds; "
+                f"Molecule: {result.molecule_seconds:.2f} seconds",
+            ]
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def emit_summary(
+    host_plan: HostPlan,
+    results: Sequence[PlatformResult],
+    invocation_seconds: float,
+    environment: Mapping[str, str],
+) -> None:
+    print(_terminal_summary(host_plan, results, invocation_seconds))
+
+    summary_value = environment.get("GITHUB_STEP_SUMMARY")
+    if not summary_value:
+        return
+    summary_path = Path(summary_value)
+    try:
+        metadata = summary_path.lstat()
+    except OSError:
+        return
+    if summary_path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+        return
+
+    flags = os.O_APPEND | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(summary_path, flags)
+    except OSError:
+        return
+    with os.fdopen(descriptor, "a", encoding="utf-8") as summary_file:
+        summary_file.write(_github_summary(host_plan, results, invocation_seconds))
+
+
 def run(arguments: Sequence[str] | None, runner: CommandRunner) -> int:
     parse_selector(arguments)
     repo_root = Path(__file__).resolve().parents[1]
+    invocation_started = time.monotonic()
     try:
-        preflight(repo_root, runner)
+        platform_definitions = select_platforms(os.environ)
+        host_plan = preflight(repo_root, runner)
         with invocation_lock(repo_root, runner):
-            pass
+            invocation_id = uuid.uuid4().hex
+            results = run_platforms(
+                platform_definitions,
+                lambda platform_definition: run_platform(
+                    platform_definition,
+                    host_plan,
+                    repo_root,
+                    runner,
+                    invocation_id,
+                ),
+            )
     except PreflightError as error:
         print(f"error: {error}", file=sys.stderr)
         return 1
-    return 0
+    emit_summary(
+        host_plan,
+        results,
+        time.monotonic() - invocation_started,
+        os.environ,
+    )
+    return 0 if all(result.success for result in results) else 1
 
 
 def main(arguments: Sequence[str] | None = None) -> int:

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -551,6 +551,9 @@ def run_platform(
         molecule_environment["ANSIBLE_COLLECTIONS_PATH"] = str(
             repo_root / ".ansible" / "collections"
         )
+        molecule_environment["HOMELAB_MOLECULE_PLATFORM"] = (
+            platform_definition.name
+        )
         molecule_result = runner.stream(
             [
                 "molecule",

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Protocol
+
+
+SELECTOR = "system_maintenance/default"
+
+
+@dataclass(frozen=True)
+class Platform:
+    name: str
+    base_image: str
+    image: str
+    container: str
+    containerfile: Path
+
+
+@dataclass(frozen=True)
+class HostPlan:
+    podman_version: str
+    host_architecture: str
+    requested_architectures: dict[str, str]
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandRunner(Protocol):
+    def capture(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> CommandResult:
+        raise NotImplementedError
+
+
+class SubprocessCommandRunner:
+    def capture(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> CommandResult:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=None if env is None else dict(env),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return CommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+
+class PreflightError(RuntimeError):
+    """A setup problem the operator can correct without a traceback."""
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Test system_maintenance in rootless Podman containers",
+    )
+    parser.add_argument(
+        "selector",
+        metavar=SELECTOR,
+        help=f"exact role/scenario selector; supported value: {SELECTOR}",
+    )
+    return parser
+
+
+def parse_selector(arguments: Sequence[str]) -> str:
+    parser = _parser()
+    parsed = parser.parse_args(arguments)
+    if parsed.selector != SELECTOR:
+        parser.error(f"unsupported selector {parsed.selector!r}; expected {SELECTOR}")
+    return parsed.selector
+
+
+def _runtime_recovery() -> str:
+    if platform.system() == "Darwin":
+        return "start the rootless Podman machine with: podman machine start"
+    return "make rootless Podman available to the current user"
+
+
+def _normalize_architecture(value: object) -> str:
+    normalized = str(value).strip().lower()
+    aliases = {
+        "aarch64": "arm64",
+        "arm64": "arm64",
+        "amd64": "amd64",
+        "x86_64": "amd64",
+    }
+    if normalized not in aliases:
+        raise PreflightError(f"unsupported Podman host architecture: {normalized}")
+    return aliases[normalized]
+
+
+def preflight(repo_root: Path, runner: CommandRunner) -> HostPlan:
+    dependency_result = runner.capture(
+        [sys.executable, "scripts/dependencies.py", "verify"],
+        cwd=repo_root,
+    )
+    if dependency_result.returncode != 0:
+        raise PreflightError(
+            "locked controller or Galaxy dependencies are unavailable; "
+            "run mise run bootstrap"
+        )
+
+    podman_path = shutil.which("podman")
+    if podman_path is None:
+        raise PreflightError(
+            "Podman is not available in PATH; install Podman for the current user"
+        )
+
+    version_result = runner.capture([podman_path, "--version"], cwd=repo_root)
+    if version_result.returncode != 0 or not version_result.stdout.strip():
+        raise PreflightError(f"Podman version inspection failed; {_runtime_recovery()}")
+
+    try:
+        info_result = runner.capture(
+            [podman_path, "info", "--format", "json"],
+            cwd=repo_root,
+            timeout=15.0,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise PreflightError(
+            f"Podman did not respond within 15 seconds; {_runtime_recovery()}"
+        ) from error
+    if info_result.returncode != 0:
+        raise PreflightError(f"Podman is not reachable; {_runtime_recovery()}")
+
+    try:
+        info = json.loads(info_result.stdout)
+        host = info["host"]
+        rootless = host["security"]["rootless"]
+        cgroup_version = str(host["cgroupVersion"]).lower().removeprefix("v")
+        host_architecture = _normalize_architecture(host["arch"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise PreflightError("Podman returned incomplete host information") from error
+
+    if rootless is not True:
+        raise PreflightError("Podman must run rootless as the current user")
+    if cgroup_version != "2":
+        raise PreflightError("Podman must provide cgroup v2")
+
+    requested_architectures = {
+        "debian13": host_architecture,
+        "rockylinux9": host_architecture,
+        "archlinux": "amd64",
+    }
+    return HostPlan(
+        podman_version=version_result.stdout.strip(),
+        host_architecture=host_architecture,
+        requested_architectures=requested_architectures,
+    )
+
+
+def lock_path(repo_root: Path, runner: CommandRunner) -> Path:
+    result = runner.capture(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=repo_root,
+    )
+    common_value = result.stdout.strip()
+    if result.returncode != 0 or not common_value:
+        raise PreflightError("Git could not resolve the repository invocation lock")
+    common_directory = Path(common_value)
+    if not common_directory.is_absolute():
+        common_directory = repo_root / common_directory
+    common_directory = common_directory.resolve()
+    digest = hashlib.sha256(
+        str(common_directory).encode("utf-8")
+    ).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / f"homelab-playbook-molecule-{digest}.lock"
+
+
+@contextmanager
+def invocation_lock(repo_root: Path, runner: CommandRunner) -> Iterator[None]:
+    path = lock_path(repo_root, runner)
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise PreflightError(f"could not open a safe lock file: {path}") from error
+
+    lock_file = os.fdopen(descriptor, "r+")
+    try:
+        metadata = os.fstat(lock_file.fileno())
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or metadata.st_mode & 0o077
+        ):
+            raise PreflightError(f"refusing unsafe lock file: {path}")
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise PreflightError(
+                "another Molecule test invocation is already running for this repository"
+            ) from error
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    finally:
+        lock_file.close()
+
+
+def run(arguments: Sequence[str] | None, runner: CommandRunner) -> int:
+    parse_selector(arguments)
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        preflight(repo_root, runner)
+        with invocation_lock(repo_root, runner):
+            pass
+    except PreflightError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    return run(arguments, SubprocessCommandRunner())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SCENARIO_DIRECTORY = (
+    REPOSITORY_ROOT / "roles" / "system_maintenance" / "molecule" / "default"
+)
+
+
+def load_yaml(name: str):
+    path = SCENARIO_DIRECTORY / name
+    if not path.is_file():
+        raise AssertionError(f"required Molecule scenario file is missing: {path}")
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+class MoleculeScenarioContractTests(unittest.TestCase):
+    def test_scenario_uses_the_ansible_native_lifecycle_and_least_privilege(
+        self,
+    ) -> None:
+        configuration = load_yaml("molecule.yml")
+
+        self.assertEqual(
+            {"name": "galaxy", "enabled": False},
+            configuration["dependency"],
+        )
+        self.assertEqual(
+            {"name": "default", "options": {"managed": True}},
+            configuration["driver"],
+        )
+        self.assertEqual(
+            [
+                "destroy",
+                "syntax",
+                "create",
+                "prepare",
+                "converge",
+                "idempotence",
+                "verify",
+                "cleanup",
+                "destroy",
+            ],
+            configuration["scenario"]["test_sequence"],
+        )
+
+        expected_platforms = {
+            "debian13": (
+                "localhost/homelab-playbook-system-maintenance-debian13:local",
+                "homelab-playbook-system-maintenance-debian13",
+            ),
+            "rockylinux9": (
+                "localhost/homelab-playbook-system-maintenance-rockylinux9:local",
+                "homelab-playbook-system-maintenance-rockylinux9",
+            ),
+            "archlinux": (
+                "localhost/homelab-playbook-system-maintenance-archlinux:local",
+                "homelab-playbook-system-maintenance-archlinux",
+            ),
+        }
+        platforms = {
+            platform["name"]: platform for platform in configuration["platforms"]
+        }
+        self.assertEqual(set(expected_platforms), set(platforms))
+        for name, (image, container_name) in expected_platforms.items():
+            with self.subTest(platform=name):
+                platform = platforms[name]
+                self.assertEqual(image, platform["image"])
+                self.assertEqual(container_name, platform["container_name"])
+                self.assertEqual(["molecule"], platform["groups"])
+                self.assertEqual("/sbin/init", platform["container_command"])
+                self.assertIs(platform["container_privileged"], False)
+                self.assertEqual("always", platform["container_systemd"])
+                self.assertEqual("never", platform["pull"])
+                self.assertTrue(
+                    {
+                        "cap_add",
+                        "capabilities",
+                        "devices",
+                        "volumes",
+                    }.isdisjoint(platform)
+                )
+
+    def test_create_and_destroy_use_only_the_podman_collection(self) -> None:
+        create_plays = load_yaml("create.yml")
+        destroy_plays = load_yaml("destroy.yml")
+
+        create_modules = {
+            key
+            for play in create_plays
+            for task in play["tasks"]
+            for key in task
+            if "." in key
+        }
+        destroy_modules = {
+            key
+            for play in destroy_plays
+            for task in play["tasks"]
+            for key in task
+            if "." in key
+        }
+        self.assertIn("containers.podman.podman_container", create_modules)
+        self.assertIn("containers.podman.podman_container", destroy_modules)
+        self.assertTrue(
+            all("docker" not in module.lower() for module in create_modules)
+        )
+        self.assertTrue(
+            all("docker" not in module.lower() for module in destroy_modules)
+        )
+
+    def test_converge_suppresses_only_reboot_and_verify_is_independent(self) -> None:
+        converge = load_yaml("converge.yml")[0]
+        verify = load_yaml("verify.yml")[0]
+
+        self.assertEqual("molecule", converge["hosts"])
+        self.assertEqual(
+            [
+                {
+                    "role": "system_maintenance",
+                    "system_maintenance_reboot_enabled": False,
+                }
+            ],
+            converge["roles"],
+        )
+        self.assertNotIn("roles", verify)
+        self.assertFalse(
+            any(
+                "ansible.builtin.include_role" in task
+                or "ansible.builtin.import_role" in task
+                for task in verify["tasks"]
+            )
+        )
+
+    def test_containerfiles_use_maintained_bases_without_role_evidence_package(
+        self,
+    ) -> None:
+        expected_bases = {
+            "Containerfile.debian13": "FROM docker.io/library/debian:13",
+            "Containerfile.rockylinux9": (
+                "FROM docker.io/rockylinux/rockylinux:9"
+            ),
+            "Containerfile.archlinux": (
+                "FROM docker.io/archlinux/archlinux:base"
+            ),
+        }
+        for name, expected_base in expected_bases.items():
+            with self.subTest(containerfile=name):
+                path = SCENARIO_DIRECTORY / name
+                self.assertTrue(path.is_file())
+                content = path.read_text(encoding="utf-8")
+                self.assertEqual(expected_base, content.splitlines()[0])
+                self.assertNotIn("tree", content.lower())
+                self.assertIn('CMD ["/sbin/init"]', content)
+                self.assertIn("STOPSIGNAL SIGRTMIN+3", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -72,7 +72,10 @@ class MoleculeScenarioContractTests(unittest.TestCase):
                 self.assertEqual(image, platform["image"])
                 self.assertEqual(container_name, platform["container_name"])
                 self.assertEqual(["molecule"], platform["groups"])
-                self.assertEqual("/sbin/init", platform["container_command"])
+                self.assertEqual(
+                    "/usr/lib/systemd/systemd",
+                    platform["container_command"],
+                )
                 self.assertIs(platform["container_privileged"], False)
                 self.assertEqual("always", platform["container_systemd"])
                 self.assertEqual("never", platform["pull"])
@@ -110,6 +113,48 @@ class MoleculeScenarioContractTests(unittest.TestCase):
         )
         self.assertTrue(
             all("docker" not in module.lower() for module in destroy_modules)
+        )
+
+    def test_controller_playbooks_select_the_worker_platform_from_environment(
+        self,
+    ) -> None:
+        for name in ("create.yml", "cleanup.yml", "destroy.yml"):
+            with self.subTest(playbook=name):
+                play = load_yaml(name)[0]
+                variables = play["vars"]
+                self.assertIn(
+                    "lookup('ansible.builtin.env', 'HOMELAB_MOLECULE_PLATFORM')",
+                    variables["system_maintenance_molecule_platform_name"],
+                )
+                self.assertIn(
+                    "selectattr('name', 'equalto',",
+                    variables["system_maintenance_molecule_platforms"],
+                )
+                assertions = [
+                    task["ansible.builtin.assert"]["that"]
+                    for task in play["tasks"]
+                    if "ansible.builtin.assert" in task
+                ]
+                self.assertTrue(
+                    any(
+                        "system_maintenance_molecule_platforms | length == 1"
+                        in conditions
+                        for conditions in assertions
+                    )
+                )
+
+        create_play = load_yaml("create.yml")[0]
+        instance_fact = next(
+            task["ansible.builtin.set_fact"]
+            for task in create_play["tasks"]
+            if "ansible.builtin.set_fact" in task
+        )
+        instance = instance_fact[
+            "system_maintenance_molecule_instance_configuration"
+        ][0]
+        self.assertEqual(
+            "{{ system_maintenance_molecule_platform.container_name }}",
+            instance["address"],
         )
 
     def test_converge_suppresses_only_reboot_and_verify_is_independent(self) -> None:
@@ -154,8 +199,14 @@ class MoleculeScenarioContractTests(unittest.TestCase):
                 content = path.read_text(encoding="utf-8")
                 self.assertEqual(expected_base, content.splitlines()[0])
                 self.assertNotIn("tree", content.lower())
-                self.assertIn('CMD ["/sbin/init"]', content)
+                self.assertIn('CMD ["/usr/lib/systemd/systemd"]', content)
                 self.assertIn("STOPSIGNAL SIGRTMIN+3", content)
+
+        arch_content = (
+            SCENARIO_DIRECTORY / "Containerfile.archlinux"
+        ).read_text(encoding="utf-8")
+        self.assertIn("--disable-sandbox-syscalls", arch_content)
+        self.assertNotIn("--disable-sandbox ", arch_content)
 
 
 if __name__ == "__main__":

--- a/tests/ansible/test_source_contracts.py
+++ b/tests/ansible/test_source_contracts.py
@@ -174,6 +174,63 @@ class SourceContractTests(unittest.TestCase):
             )
         )
 
+    def test_arch_maintenance_generates_the_configured_english_locale(self) -> None:
+        """Arch locale setup must use its native locale.gen source."""
+        tasks = load_tasks("roles/system_maintenance/tasks/setup-Archlinux.yml")
+
+        self.assertFalse(
+            any("community.general.locale_gen" in task for task in tasks)
+        )
+
+        inspect_task = next(
+            task for task in tasks if task["name"] == "Inspect generated locales"
+        )
+        self.assertEqual(
+            inspect_task["ansible.builtin.command"],
+            {"argv": ["locale", "-a"]},
+        )
+        self.assertEqual(
+            inspect_task["register"],
+            "system_maintenance_arch_available_locales",
+        )
+        self.assertIs(inspect_task["changed_when"], False)
+
+        definition_task = next(
+            task
+            for task in tasks
+            if task["name"] == "Enable the English locale definition"
+        )
+        self.assertEqual(
+            definition_task["ansible.builtin.lineinfile"],
+            {
+                "path": "/etc/locale.gen",
+                "regexp": r"^#?\s*en_US\.UTF-8\s+UTF-8$",
+                "line": "en_US.UTF-8 UTF-8",
+                "mode": "0644",
+            },
+        )
+        self.assertEqual(
+            definition_task["register"],
+            "system_maintenance_arch_locale_definition",
+        )
+
+        generate_task = next(
+            task for task in tasks if task["name"] == "Generate the English locale"
+        )
+        self.assertEqual(
+            generate_task["ansible.builtin.command"],
+            {"argv": ["locale-gen"]},
+        )
+        self.assertEqual(
+            generate_task["when"],
+            (
+                "system_maintenance_arch_locale_definition.changed or "
+                "'en_US.utf8' not in "
+                "system_maintenance_arch_available_locales.stdout_lines"
+            ),
+        )
+        self.assertIs(generate_task["changed_when"], True)
+
     def test_system_maintenance_reboots_are_enabled_by_default_and_controllable(
         self,
     ) -> None:

--- a/tests/ansible/test_source_contracts.py
+++ b/tests/ansible/test_source_contracts.py
@@ -174,6 +174,40 @@ class SourceContractTests(unittest.TestCase):
             )
         )
 
+    def test_system_maintenance_reboots_are_enabled_by_default_and_controllable(
+        self,
+    ) -> None:
+        """Container tests may suppress reboots without changing production."""
+        defaults_path = REPOSITORY_ROOT / "roles/system_maintenance/defaults/main.yml"
+        self.assertTrue(defaults_path.is_file())
+        defaults = load_yaml_documents(
+            "roles/system_maintenance/defaults/main.yml"
+        )[0]
+        self.assertEqual(
+            True,
+            defaults["system_maintenance_reboot_enabled"],
+        )
+
+        expected_conditions = {
+            "roles/system_maintenance/tasks/setup-Debian.yml": [
+                "system_maintenance_reboot_required_file.stat.exists",
+                "system_maintenance_reboot_enabled | bool",
+            ],
+            "roles/system_maintenance/tasks/setup-RedHat.yml": [
+                "system_maintenance_needs_restart.rc == 1",
+                "system_maintenance_reboot_enabled | bool",
+            ],
+        }
+        for task_path, conditions in expected_conditions.items():
+            with self.subTest(task_path=task_path):
+                reboot_tasks = [
+                    task
+                    for task in load_tasks(task_path)
+                    if task["name"] == "Reboot if required"
+                ]
+                self.assertEqual(1, len(reboot_tasks))
+                self.assertEqual(conditions, reboot_tasks[0]["when"])
+
     def test_update_pihole_has_no_end_play(self) -> None:
         """A Pi-hole command failure must fail normally instead of ending a play."""
         tasks = load_tasks("roles/update_pihole/tasks/main.yml")

--- a/tests/ci/test_classify.py
+++ b/tests/ci/test_classify.py
@@ -158,7 +158,8 @@ class PathClassificationTests(unittest.TestCase):
             "roles/enable_cgroup/tasks/main.yml": "ansible",
             "roles/kube_vip/tasks/main.yml": "ansible",
             "roles/prepare_cifs_storage/tasks/main.yml": "ansible",
-            "roles/system_maintenance/tasks/main.yml": "ansible",
+            "roles/system_maintenance/tasks/main.yml": "molecule",
+            "roles/system_maintenance/molecule/default/molecule.yml": "molecule",
             "roles/update_pihole/tasks/main.yml": "ansible",
         }
 
@@ -209,7 +210,7 @@ class PathClassificationTests(unittest.TestCase):
         self.assertEqual("full", result["depth"])
         self.assertTrue(result["run_fast"])
         self.assertTrue(result["run_ansible"])
-        self.assertFalse(result["run_molecule"])
+        self.assertTrue(result["run_molecule"])
         self.assertEqual(
             [
                 "README.md",
@@ -233,17 +234,37 @@ class PathClassificationTests(unittest.TestCase):
         self.assertEqual("full", invalid_result["depth"])
         self.assertEqual([""], invalid_result["paths"])
 
-    def test_reserved_molecule_depth_is_declared_but_never_selected(self) -> None:
+    def test_molecule_depth_selects_all_prerequisite_validation(self) -> None:
         self.assertEqual(
             {"fast": 0, "ansible": 1, "molecule": 2, "full": 3},
             classifier.DEPTH_ORDER,
         )
 
-        for paths in (["README.md"], ["roles/update_pihole/tasks/main.yml"], []):
-            with self.subTest(paths=paths):
-                result = classifier.classify_paths(list(paths))
-                self.assertNotEqual("molecule", result["depth"])
-                self.assertFalse(result["run_molecule"])
+        result = classifier.classify_paths(
+            ["roles/system_maintenance/tasks/main.yml"]
+        )
+
+        self.assertEqual("molecule", result["depth"])
+        self.assertTrue(result["run_fast"])
+        self.assertTrue(result["run_ansible"])
+        self.assertTrue(result["run_molecule"])
+
+    def test_only_molecule_and_full_depths_run_container_tests(self) -> None:
+        results = {
+            "fast": classifier.classify_paths(["README.md"]),
+            "ansible": classifier.classify_paths(
+                ["roles/update_pihole/tasks/main.yml"]
+            ),
+            "molecule": classifier.classify_paths(
+                ["roles/system_maintenance/tasks/main.yml"]
+            ),
+            "full": classifier.classify_paths(["scripts/ci/classify.py"]),
+        }
+
+        self.assertFalse(results["fast"]["run_molecule"])
+        self.assertFalse(results["ansible"]["run_molecule"])
+        self.assertTrue(results["molecule"]["run_molecule"])
+        self.assertTrue(results["full"]["run_molecule"])
 
 
 class OutputFormatTests(unittest.TestCase):
@@ -482,7 +503,7 @@ class GitDiscoveryTests(unittest.TestCase):
         self.assertEqual("full", payload["depth"])
         self.assertTrue(payload["run_fast"])
         self.assertTrue(payload["run_ansible"])
-        self.assertFalse(payload["run_molecule"])
+        self.assertTrue(payload["run_molecule"])
 
     def test_git_error_outside_repository_selects_full(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -624,14 +645,43 @@ class ClassifierCliTests(unittest.TestCase):
         self.assertIn("cannot de-escalate from ansible to fast", result.stderr)
         self.assertEqual("", result.stdout)
 
-    def test_force_depth_rejects_reserved_molecule(self) -> None:
+    def test_force_depth_escalates_fast_result_to_molecule(self) -> None:
+        self.repository.write("docs/new.md", "documentation\n")
+
         result = self.repository.run_python(
             CLASSIFIER_PATH,
-            ["--base", "HEAD", "--force-depth", "molecule"],
+            [
+                "--base",
+                "HEAD",
+                "--include-worktree",
+                "--force-depth",
+                "molecule",
+                "--format",
+                "json",
+            ],
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual("molecule", payload["depth"])
+        self.assertTrue(payload["run_molecule"])
+
+    def test_force_depth_rejects_molecule_to_ansible_deescalation(self) -> None:
+        self.repository.write("roles/system_maintenance/tasks/new.yml", "---\n")
+
+        result = self.repository.run_python(
+            CLASSIFIER_PATH,
+            [
+                "--base",
+                "HEAD",
+                "--include-worktree",
+                "--force-depth",
+                "ansible",
+            ],
         )
 
         self.assertEqual(2, result.returncode)
-        self.assertIn("invalid choice: 'molecule'", result.stderr)
+        self.assertIn("cannot de-escalate from molecule to ansible", result.stderr)
 
 
 class ChangedRunnerTests(unittest.TestCase):
@@ -684,7 +734,11 @@ class ChangedRunnerTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("Selected validation depth: full", result.stdout)
         self.assertIn("Escalated validation depth: fast -> full", result.stdout)
-        self.assertEqual(2, result.stdout.count("Would run:"))
+        self.assertEqual(3, result.stdout.count("Would run:"))
+        self.assertIn(
+            "Would run: mise run test:molecule -- system_maintenance/default",
+            result.stdout,
+        )
 
     def test_dry_run_rejects_requested_deescalation(self) -> None:
         self.repository.write("roles/update_pihole/tasks/new.yml", "---\n")
@@ -697,13 +751,24 @@ class ChangedRunnerTests(unittest.TestCase):
         self.assertIn("cannot de-escalate from ansible to fast", result.stderr)
         self.assertNotIn("Would run:", result.stdout)
 
-    def test_runner_rejects_reserved_molecule(self) -> None:
+    def test_molecule_dry_run_prints_fast_ansible_and_test_commands(self) -> None:
+        self.repository.write("roles/system_maintenance/tasks/new.yml", "---\n")
+
         result = self.run_changed(
-            "--dry-run", "--base", "HEAD", "--force-depth", "molecule"
+            "--dry-run",
+            "--base",
+            "HEAD",
         )
 
-        self.assertEqual(2, result.returncode)
-        self.assertIn("invalid choice: 'molecule'", result.stderr)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Selected validation depth: molecule", result.stdout)
+        self.assertEqual(3, result.stdout.count("Would run:"))
+        self.assertIn("Would run: mise run validate:fast", result.stdout)
+        self.assertIn("Would run: mise run validate:ansible", result.stdout)
+        self.assertIn(
+            "Would run: mise run test:molecule -- system_maintenance/default",
+            result.stdout,
+        )
 
     def test_runner_passes_resolved_range_and_local_union_mode_to_fast(self) -> None:
         self.repository.write("docs/new.md", "documentation\n")

--- a/tests/ci/test_command_lifecycle.py
+++ b/tests/ci/test_command_lifecycle.py
@@ -54,7 +54,13 @@ class CommandLifecycleTests(unittest.TestCase):
         }
 
         self.assertTrue(
-            {"validate:fast", "validate:ansible", "ci:changed", "ci"}
+            {
+                "validate:fast",
+                "validate:ansible",
+                "test:molecule",
+                "ci:changed",
+                "ci",
+            }
             <= task_names
         )
         self.assertTrue(
@@ -66,9 +72,21 @@ class CommandLifecycleTests(unittest.TestCase):
             <= task_names
         )
         self.assertTrue(
-            {"check:fast", "check:ansible", "check:molecule"}.isdisjoint(
-                published_names
-            )
+            {
+                "check:fast",
+                "check:ansible",
+                "check:molecule",
+                "validate:molecule",
+            }.isdisjoint(published_names)
+        )
+
+        molecule_task = next(
+            task for task in tasks if task["name"] == "test:molecule"
+        )
+        self.assertEqual([], molecule_task["aliases"])
+        self.assertEqual(
+            ["uv run --frozen --no-sync python scripts/molecule.py"],
+            molecule_task["run"],
         )
 
     def test_github_protection_tasks_publish_distinct_lifecycle_commands(

--- a/tests/ci/test_merge_gate.py
+++ b/tests/ci/test_merge_gate.py
@@ -129,45 +129,45 @@ class MergeGateReconciliationTests(unittest.TestCase):
         classify: str = "success",
         fast: str = "success",
         ansible: str = "success",
+        molecule: str = "success",
     ) -> None:
         self.assertEqual(
             [],
-            merge_gate.reconcile(depth, classify, fast, ansible),
+            merge_gate.reconcile(depth, classify, fast, ansible, molecule),
         )
 
-    def test_fast_depth_accepts_skipped_ansible(self) -> None:
-        self.assert_accepted("fast", ansible="skipped")
+    def test_fast_depth_accepts_skipped_ansible_and_molecule(self) -> None:
+        self.assert_accepted("fast", ansible="skipped", molecule="skipped")
 
-    def test_fast_depth_accepts_successful_shadow_ansible(self) -> None:
-        self.assert_accepted("fast", ansible="success")
+    def test_fast_depth_accepts_successful_shadow_jobs(self) -> None:
+        self.assert_accepted("fast", ansible="success", molecule="success")
 
-    def test_ansible_depth_requires_both_validation_jobs(self) -> None:
-        self.assert_accepted("ansible")
+    def test_ansible_depth_accepts_skipped_molecule(self) -> None:
+        self.assert_accepted("ansible", molecule="skipped")
 
-    def test_full_depth_requires_both_validation_jobs(self) -> None:
+    def test_molecule_and_full_depths_require_all_validation_jobs(self) -> None:
+        self.assert_accepted("molecule")
         self.assert_accepted("full")
-
-    def test_molecule_depth_fails_as_unimplemented(self) -> None:
-        self.assertEqual(
-            ["validation depth 'molecule' is not implemented"],
-            merge_gate.reconcile("molecule", "success", "success", "success"),
-        )
 
     def test_selected_fast_job_rejects_non_success_conclusions(self) -> None:
         for result in ("skipped", "failure", "cancelled"):
             with self.subTest(result=result):
                 self.assertEqual(
                     [f"fast job result is '{result}', expected 'success'"],
-                    merge_gate.reconcile("fast", "success", result, "skipped"),
+                    merge_gate.reconcile(
+                        "fast", "success", result, "skipped", "skipped"
+                    ),
                 )
 
     def test_selected_ansible_job_rejects_non_success_conclusions(self) -> None:
-        for depth in ("ansible", "full"):
+        for depth in ("ansible", "molecule", "full"):
             for result in ("skipped", "failure", "cancelled"):
                 with self.subTest(depth=depth, result=result):
                     self.assertEqual(
                         [f"ansible job result is '{result}', expected 'success'"],
-                        merge_gate.reconcile(depth, "success", "success", result),
+                        merge_gate.reconcile(
+                            depth, "success", "success", result, "success"
+                        ),
                     )
 
     def test_non_selected_ansible_rejects_failure_or_cancellation(self) -> None:
@@ -178,8 +178,35 @@ class MergeGateReconciliationTests(unittest.TestCase):
                         f"ansible job result is '{result}', expected 'success' or "
                         "'skipped'"
                     ],
-                    merge_gate.reconcile("fast", "success", "success", result),
+                    merge_gate.reconcile(
+                        "fast", "success", "success", result, "skipped"
+                    ),
                 )
+
+    def test_selected_molecule_job_rejects_non_success_conclusions(self) -> None:
+        for depth in ("molecule", "full"):
+            for result in ("skipped", "failure", "cancelled"):
+                with self.subTest(depth=depth, result=result):
+                    self.assertEqual(
+                        [f"molecule job result is '{result}', expected 'success'"],
+                        merge_gate.reconcile(
+                            depth, "success", "success", "success", result
+                        ),
+                    )
+
+    def test_non_selected_molecule_rejects_failure_or_cancellation(self) -> None:
+        for depth in ("fast", "ansible"):
+            for result in ("failure", "cancelled"):
+                with self.subTest(depth=depth, result=result):
+                    self.assertEqual(
+                        [
+                            f"molecule job result is '{result}', expected 'success' "
+                            "or 'skipped'"
+                        ],
+                        merge_gate.reconcile(
+                            depth, "success", "success", "success", result
+                        ),
+                    )
 
     def test_missing_or_unknown_depth_fails_closed(self) -> None:
         cases = {
@@ -190,13 +217,14 @@ class MergeGateReconciliationTests(unittest.TestCase):
             with self.subTest(depth=depth):
                 self.assertEqual(
                     [expected],
-                    merge_gate.reconcile(depth, "success", "success", "success"),
+                    merge_gate.reconcile(
+                        depth, "success", "success", "success", "success"
+                    ),
                 )
 
     def test_invalid_depths_still_report_classifier_and_fast_mismatches(self) -> None:
         cases = {
             "": "validation depth is missing",
-            "molecule": "validation depth 'molecule' is not implemented",
             "unexpected": "validation depth 'unexpected' is unknown",
         }
         for depth, depth_error in cases.items():
@@ -212,13 +240,16 @@ class MergeGateReconciliationTests(unittest.TestCase):
                         "failure",
                         "cancelled",
                         "failure",
+                        "failure",
                     ),
                 )
 
     def test_classifier_failure_fails_gate(self) -> None:
         self.assertEqual(
             ["classify job result is 'failure', expected 'success'"],
-            merge_gate.reconcile("full", "failure", "success", "success"),
+            merge_gate.reconcile(
+                "full", "failure", "success", "success", "success"
+            ),
         )
 
     def test_cli_prints_every_mismatch_and_exits_one(self) -> None:
@@ -234,6 +265,8 @@ class MergeGateReconciliationTests(unittest.TestCase):
                 "cancelled",
                 "--ansible-result",
                 "skipped",
+                "--molecule-result",
+                "failure",
             ],
             cwd=REPOSITORY_ROOT,
             check=False,
@@ -249,6 +282,7 @@ class MergeGateReconciliationTests(unittest.TestCase):
                     "classify job result is 'failure', expected 'success'",
                     "fast job result is 'cancelled', expected 'success'",
                     "ansible job result is 'skipped', expected 'success'",
+                    "molecule job result is 'failure', expected 'success' or 'skipped'",
                     "",
                 ]
             ),
@@ -260,7 +294,6 @@ class MergeGateReconciliationTests(unittest.TestCase):
     ) -> None:
         cases = {
             "": "validation depth is missing",
-            "molecule": "validation depth 'molecule' is not implemented",
             "unexpected": "validation depth 'unexpected' is unknown",
         }
         for depth, depth_error in cases.items():
@@ -276,6 +309,8 @@ class MergeGateReconciliationTests(unittest.TestCase):
                         "--fast-result",
                         "cancelled",
                         "--ansible-result",
+                        "failure",
+                        "--molecule-result",
                         "failure",
                     ],
                     cwd=REPOSITORY_ROOT,
@@ -309,6 +344,7 @@ class WorkflowContractTests(unittest.TestCase):
         cls.classify = indented_block(cls.workflow, "classify", 2)
         cls.fast = indented_block(cls.workflow, "fast", 2)
         cls.ansible = indented_block(cls.workflow, "ansible", 2)
+        cls.molecule = indented_block(cls.workflow, "molecule", 2)
         cls.merge_gate = indented_block(cls.workflow, "merge-gate", 2)
 
     def test_triggers_permissions_and_concurrency_are_always_present(self) -> None:
@@ -329,12 +365,12 @@ class WorkflowContractTests(unittest.TestCase):
             "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
         )
         mise = "jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c"
-        self.assertEqual(4, self.workflow.count(f"uses: {checkout}"))
-        self.assertEqual(4, self.workflow.count(f"uses: {mise}"))
-        self.assertEqual(4, self.workflow.count("persist-credentials: false"))
-        self.assertEqual(4, self.workflow.count("fetch-depth: 0"))
-        self.assertEqual(4, self.workflow.count("install: true"))
-        self.assertEqual(4, self.workflow.count("cache: true"))
+        self.assertEqual(5, self.workflow.count(f"uses: {checkout}"))
+        self.assertEqual(5, self.workflow.count(f"uses: {mise}"))
+        self.assertEqual(5, self.workflow.count("persist-credentials: false"))
+        self.assertEqual(5, self.workflow.count("fetch-depth: 0"))
+        self.assertEqual(5, self.workflow.count("install: true"))
+        self.assertEqual(5, self.workflow.count("cache: true"))
         for line in self.workflow.splitlines():
             if "uses:" in line:
                 self.assertRegex(line, r"@[0-9a-f]{40}(?:\s+#.*)?$")
@@ -455,6 +491,48 @@ class WorkflowContractTests(unittest.TestCase):
 
         self.assertTrue(workflow_observability_errors(mutated_workflow))
 
+    def test_molecule_runs_an_exact_bounded_three_platform_matrix(self) -> None:
+        self.assertIn("needs: classify", self.molecule)
+        self.assertEqual(
+            ["needs.classify.outputs.run_molecule == 'true'"],
+            direct_mapping_values(self.molecule, "if", 4),
+        )
+        self.assertIn("runs-on: ubuntu-24.04", self.molecule)
+        self.assertIn("timeout-minutes: 30", self.molecule)
+        expected_strategy = "\n".join(
+            [
+                "    strategy:",
+                "      fail-fast: false",
+                "      max-parallel: 3",
+                "      matrix:",
+                "        platform:",
+                "          - debian13",
+                "          - rockylinux9",
+                "          - archlinux",
+            ]
+        )
+        self.assertIn(expected_strategy, self.molecule)
+        self.assertEqual(1, self.molecule.count("mise run bootstrap"))
+        self.assertIn(
+            "HOMELAB_MOLECULE_PLATFORM: ${{ matrix.platform }}", self.molecule
+        )
+        self.assertEqual(
+            1,
+            self.molecule.count(
+                "run: mise run test:molecule -- system_maintenance/default"
+            ),
+        )
+        lowered = self.molecule.lower()
+        for forbidden in (
+            "sudo",
+            "docker",
+            "upload-artifact",
+            "download-artifact",
+            "apt-get",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, lowered)
+
     def test_merge_gate_always_reconciles_classifier_and_job_results(self) -> None:
         self.assertIn("name: merge-gate", self.merge_gate)
         self.assertEqual(
@@ -463,13 +541,15 @@ class WorkflowContractTests(unittest.TestCase):
         )
         self.assertIn("timeout-minutes: 2", self.merge_gate)
         self.assertIn(
-            "needs:\n      - classify\n      - fast\n      - ansible", self.merge_gate
+            "needs:\n      - classify\n      - fast\n      - ansible\n      - molecule",
+            self.merge_gate,
         )
         expected_environment = {
             "SELECTED_DEPTH: ${{ needs.classify.outputs.depth }}",
             "CLASSIFY_RESULT: ${{ needs.classify.result }}",
             "FAST_RESULT: ${{ needs.fast.result }}",
             "ANSIBLE_RESULT: ${{ needs.ansible.result }}",
+            "MOLECULE_RESULT: ${{ needs.molecule.result }}",
         }
         for variable in expected_environment:
             with self.subTest(variable=variable):
@@ -479,10 +559,14 @@ class WorkflowContractTests(unittest.TestCase):
             '--classify-result "$CLASSIFY_RESULT"',
             '--fast-result "$FAST_RESULT"',
             '--ansible-result "$ANSIBLE_RESULT"',
+            '--molecule-result "$MOLECULE_RESULT"',
         ):
             with self.subTest(argument=argument):
                 self.assertIn(argument, self.merge_gate)
         self.assertIn("REASONS: ${{ needs.classify.outputs.reasons }}", self.merge_gate)
+        self.assertIn(
+            "classify=%s, fast=%s, ansible=%s, molecule=%s", self.merge_gate
+        )
         self.assertIn('>> "$GITHUB_STEP_SUMMARY"', self.merge_gate)
         self.assertNotIn("upload-artifact", self.workflow)
         self.assertNotIn("junit", self.workflow.lower())

--- a/tests/ci/test_molecule_runner.py
+++ b/tests/ci/test_molecule_runner.py
@@ -681,6 +681,10 @@ class PlatformWorkerTests(unittest.TestCase):
             str(REPOSITORY_ROOT / ".ansible/collections"),
             molecule_call[2].get("ANSIBLE_COLLECTIONS_PATH"),
         )
+        self.assertEqual(
+            "debian13",
+            molecule_call[2].get("HOMELAB_MOLECULE_PLATFORM"),
+        )
 
     def test_worker_cleans_up_after_each_primary_stage_failure(self) -> None:
         cases = (

--- a/tests/ci/test_molecule_runner.py
+++ b/tests/ci/test_molecule_runner.py
@@ -673,6 +673,14 @@ class PlatformWorkerTests(unittest.TestCase):
             str(REPOSITORY_ROOT / ".tmp/molecule/run-123/debian13"),
             molecule_call[2]["MOLECULE_EPHEMERAL_DIRECTORY"],
         )
+        self.assertEqual(
+            str(REPOSITORY_ROOT / "roles"),
+            molecule_call[2].get("ANSIBLE_ROLES_PATH"),
+        )
+        self.assertEqual(
+            str(REPOSITORY_ROOT / ".ansible/collections"),
+            molecule_call[2].get("ANSIBLE_COLLECTIONS_PATH"),
+        )
 
     def test_worker_cleans_up_after_each_primary_stage_failure(self) -> None:
         cases = (

--- a/tests/ci/test_molecule_runner.py
+++ b/tests/ci/test_molecule_runner.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import importlib.util
+import hashlib
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from contextlib import redirect_stderr
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = REPOSITORY_ROOT / "scripts" / "molecule.py"
+
+
+def load_runner() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("molecule_runner", RUNNER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {RUNNER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner_module = load_runner()
+
+
+@dataclass(frozen=True)
+class FakeResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class FakeCommandRunner:
+    def __init__(self, *responses: FakeResult | Exception) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[list[str], Path, float | None]] = []
+
+    def capture(
+        self,
+        command: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> FakeResult:
+        del env
+        self.calls.append((list(command), cwd, timeout))
+        if not self.responses:
+            raise AssertionError(f"unexpected command: {command}")
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class RunnerCliTests(unittest.TestCase):
+    def run_cli(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(RUNNER_PATH), *arguments],
+            cwd=REPOSITORY_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_cli_rejects_every_input_except_the_registered_selector(self) -> None:
+        invalid_arguments = (
+            (),
+            ("unknown/default",),
+            ("system_maintenance/unknown",),
+            ("system_maintenance/default", "additional"),
+        )
+
+        for arguments in invalid_arguments:
+            with self.subTest(arguments=arguments):
+                result = self.run_cli(*arguments)
+
+                self.assertEqual(2, result.returncode)
+                self.assertIn("usage:", result.stderr.lower())
+                self.assertIn("system_maintenance/default", result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_expected_preflight_failure_exits_one_without_traceback(self) -> None:
+        function = getattr(runner_module, "run", None)
+        if function is None:
+            self.fail("runner must provide an injectable run function")
+        stderr = io.StringIO()
+        fake = FakeCommandRunner(FakeResult(returncode=1, stdout="stale"))
+
+        with redirect_stderr(stderr):
+            result = function(["system_maintenance/default"], fake)
+
+        self.assertEqual(1, result)
+        self.assertIn("mise run bootstrap", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+
+class PreflightTests(unittest.TestCase):
+    def podman_info(
+        self,
+        *,
+        architecture: str = "arm64",
+        rootless: bool = True,
+        cgroup_version: str = "v2",
+    ) -> str:
+        return json.dumps(
+            {
+                "host": {
+                    "arch": architecture,
+                    "cgroupVersion": cgroup_version,
+                    "security": {"rootless": rootless},
+                }
+            }
+        )
+
+    def call_preflight(self, fake: FakeCommandRunner):
+        function = getattr(runner_module, "preflight", None)
+        if function is None:
+            self.fail("runner must provide preflight")
+        with mock.patch("shutil.which", return_value="/usr/local/bin/podman"):
+            return function(REPOSITORY_ROOT, fake)
+
+    def successful_runner(
+        self,
+        *,
+        architecture: str = "arm64",
+        cgroup_version: str = "v2",
+    ) -> FakeCommandRunner:
+        return FakeCommandRunner(
+            FakeResult(stdout="Locked dependencies are current.\n"),
+            FakeResult(stdout="podman version 5.6.2\n"),
+            FakeResult(
+                stdout=self.podman_info(
+                    architecture=architecture,
+                    cgroup_version=cgroup_version,
+                )
+            ),
+        )
+
+    def test_preflight_uses_native_debian_and_rocky_but_emulates_arch_on_arm(
+        self,
+    ) -> None:
+        fake = self.successful_runner(architecture="aarch64")
+
+        plan = self.call_preflight(fake)
+
+        self.assertEqual("podman version 5.6.2", plan.podman_version)
+        self.assertEqual("arm64", plan.host_architecture)
+        self.assertEqual(
+            {
+                "debian13": "arm64",
+                "rockylinux9": "arm64",
+                "archlinux": "amd64",
+            },
+            plan.requested_architectures,
+        )
+        self.assertEqual(15.0, fake.calls[-1][2])
+
+    def test_preflight_normalizes_amd64_host_aliases(self) -> None:
+        for architecture in ("amd64", "x86_64"):
+            with self.subTest(architecture=architecture):
+                plan = self.call_preflight(
+                    self.successful_runner(architecture=architecture)
+                )
+
+                self.assertEqual("amd64", plan.host_architecture)
+                self.assertEqual(
+                    {
+                        "debian13": "amd64",
+                        "rockylinux9": "amd64",
+                        "archlinux": "amd64",
+                    },
+                    plan.requested_architectures,
+                )
+
+    def test_preflight_rejects_stale_dependencies_before_resolving_podman(
+        self,
+    ) -> None:
+        fake = FakeCommandRunner(FakeResult(returncode=1, stdout="stale"))
+        function = getattr(runner_module, "preflight", None)
+        if function is None:
+            self.fail("runner must provide preflight")
+
+        with mock.patch("shutil.which") as which:
+            with self.assertRaisesRegex(RuntimeError, "mise run bootstrap"):
+                function(REPOSITORY_ROOT, fake)
+
+        which.assert_not_called()
+        self.assertEqual(1, len(fake.calls))
+
+    def test_preflight_rejects_missing_podman(self) -> None:
+        fake = FakeCommandRunner(FakeResult())
+        function = getattr(runner_module, "preflight", None)
+        if function is None:
+            self.fail("runner must provide preflight")
+
+        with mock.patch("shutil.which", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "Podman"):
+                function(REPOSITORY_ROOT, fake)
+
+        self.assertEqual(1, len(fake.calls))
+
+    def test_preflight_requires_rootless_podman(self) -> None:
+        fake = FakeCommandRunner(
+            FakeResult(),
+            FakeResult(stdout="podman version 5.6.2"),
+            FakeResult(stdout=self.podman_info(rootless=False)),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "rootless"):
+            self.call_preflight(fake)
+
+    def test_preflight_accepts_only_cgroup_v2(self) -> None:
+        for cgroup_version in ("v1", "1", ""):
+            with self.subTest(cgroup_version=cgroup_version):
+                fake = self.successful_runner(cgroup_version=cgroup_version)
+
+                with self.assertRaisesRegex(RuntimeError, "cgroup v2"):
+                    self.call_preflight(fake)
+
+        for cgroup_version in ("v2", "2"):
+            with self.subTest(cgroup_version=cgroup_version):
+                plan = self.call_preflight(
+                    self.successful_runner(cgroup_version=cgroup_version)
+                )
+                self.assertEqual("arm64", plan.host_architecture)
+
+    def test_preflight_reports_platform_specific_runtime_recovery(self) -> None:
+        for operating_system, expected in (
+            ("Darwin", "podman machine start"),
+            ("Linux", "rootless Podman"),
+        ):
+            with self.subTest(operating_system=operating_system):
+                fake = FakeCommandRunner(
+                    FakeResult(),
+                    FakeResult(stdout="podman version 5.6.2"),
+                    FakeResult(returncode=125, stderr="service unavailable"),
+                )
+                with mock.patch("platform.system", return_value=operating_system):
+                    with self.assertRaisesRegex(RuntimeError, expected):
+                        self.call_preflight(fake)
+
+    def test_preflight_reports_timed_out_runtime_without_traceback_contract(
+        self,
+    ) -> None:
+        fake = FakeCommandRunner(
+            FakeResult(),
+            FakeResult(stdout="podman version 5.6.2"),
+            subprocess.TimeoutExpired(["podman", "info"], 15),
+        )
+
+        with mock.patch("platform.system", return_value="Darwin"):
+            with self.assertRaisesRegex(RuntimeError, "podman machine start"):
+                self.call_preflight(fake)
+
+    def test_preflight_rejects_unsupported_host_architecture(self) -> None:
+        fake = self.successful_runner(architecture="ppc64le")
+
+        with self.assertRaisesRegex(RuntimeError, "unsupported.*ppc64le"):
+            self.call_preflight(fake)
+
+
+class InvocationLockTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.temporary_root = Path(self.temporary_directory.name)
+        self.common_directory = self.temporary_root / "repository.git"
+        self.common_directory.mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def git_runner(self) -> FakeCommandRunner:
+        return FakeCommandRunner(
+            FakeResult(stdout=f"{self.common_directory}\n"),
+        )
+
+    def lock_path(self, repo_root: Path, fake: FakeCommandRunner) -> Path:
+        function = getattr(runner_module, "lock_path", None)
+        if function is None:
+            self.fail("runner must provide lock_path")
+        with mock.patch(
+            "tempfile.gettempdir",
+            return_value=str(self.temporary_root),
+        ):
+            return function(repo_root, fake)
+
+    def invocation_lock(self, fake: FakeCommandRunner):
+        function = getattr(runner_module, "invocation_lock", None)
+        if function is None:
+            self.fail("runner must provide invocation_lock")
+        return function(REPOSITORY_ROOT, fake)
+
+    def test_linked_worktrees_derive_one_lock_from_the_git_common_directory(
+        self,
+    ) -> None:
+        first_root = self.temporary_root / "first-worktree"
+        second_root = self.temporary_root / "second-worktree"
+        expected_digest = hashlib.sha256(
+            str(self.common_directory.resolve()).encode("utf-8")
+        ).hexdigest()[:16]
+
+        first = self.lock_path(first_root, self.git_runner())
+        second = self.lock_path(second_root, self.git_runner())
+
+        self.assertEqual(first, second)
+        self.assertEqual(
+            self.temporary_root
+            / f"homelab-playbook-molecule-{expected_digest}.lock",
+            first,
+        )
+
+    def test_invocation_lock_is_nonblocking_and_releases_after_success(
+        self,
+    ) -> None:
+        with mock.patch(
+            "tempfile.gettempdir",
+            return_value=str(self.temporary_root),
+        ):
+            with self.invocation_lock(self.git_runner()):
+                with self.assertRaisesRegex(RuntimeError, "already running"):
+                    with self.invocation_lock(self.git_runner()):
+                        self.fail("a second invocation acquired the same lock")
+
+            with self.invocation_lock(self.git_runner()):
+                pass
+
+    def test_invocation_lock_releases_after_an_exception(self) -> None:
+        with mock.patch(
+            "tempfile.gettempdir",
+            return_value=str(self.temporary_root),
+        ):
+            with self.assertRaisesRegex(ValueError, "test failure"):
+                with self.invocation_lock(self.git_runner()):
+                    raise ValueError("test failure")
+
+            with self.invocation_lock(self.git_runner()):
+                pass
+
+    def test_invocation_lock_rejects_a_symlink(self) -> None:
+        fake = self.git_runner()
+        path = self.lock_path(REPOSITORY_ROOT, fake)
+        path.symlink_to(self.temporary_root / "untrusted-target")
+
+        with mock.patch(
+            "tempfile.gettempdir",
+            return_value=str(self.temporary_root),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "safe lock file"):
+                with self.invocation_lock(self.git_runner()):
+                    self.fail("a symlink was accepted as an invocation lock")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_molecule_runner.py
+++ b/tests/ci/test_molecule_runner.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import importlib.util
 import hashlib
+import gc
 import io
 import json
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+import warnings
 
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -44,6 +47,18 @@ class FakeCommandRunner:
     def __init__(self, *responses: FakeResult | Exception) -> None:
         self.responses = list(responses)
         self.calls: list[tuple[list[str], Path, float | None]] = []
+        self.operations: list[tuple[str, list[str]]] = []
+        self.stream_calls: list[
+            tuple[list[str], Path, dict[str, str] | None, float | None, str]
+        ] = []
+
+    def next_response(self, command: list[str]) -> FakeResult:
+        if not self.responses:
+            raise AssertionError(f"unexpected command: {command}")
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
 
     def capture(
         self,
@@ -55,12 +70,24 @@ class FakeCommandRunner:
     ) -> FakeResult:
         del env
         self.calls.append((list(command), cwd, timeout))
-        if not self.responses:
-            raise AssertionError(f"unexpected command: {command}")
-        response = self.responses.pop(0)
-        if isinstance(response, Exception):
-            raise response
-        return response
+        self.operations.append(("capture", list(command)))
+        return self.next_response(list(command))
+
+    def stream(
+        self,
+        command: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+        line_prefix: str,
+    ) -> FakeResult:
+        copied_env = None if env is None else dict(env)
+        self.stream_calls.append(
+            (list(command), cwd, copied_env, timeout, line_prefix)
+        )
+        self.operations.append(("stream", list(command)))
+        return self.next_response(list(command))
 
 
 class RunnerCliTests(unittest.TestCase):
@@ -359,6 +386,626 @@ class InvocationLockTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "safe lock file"):
                 with self.invocation_lock(self.git_runner()):
                     self.fail("a symlink was accepted as an invocation lock")
+
+
+class ContainerOwnershipTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.platform = runner_module.Platform(
+            name="debian13",
+            base_image="docker.io/library/debian:13",
+            image="localhost/homelab-playbook-system-maintenance-debian13:local",
+            container="homelab-playbook-system-maintenance-debian13",
+            containerfile=Path("Containerfile.debian13"),
+        )
+
+    def call_remove(self, fake: FakeCommandRunner) -> bool:
+        function = getattr(runner_module, "remove_owned_container", None)
+        if function is None:
+            self.fail("runner must provide remove_owned_container")
+        return function(REPOSITORY_ROOT, fake, self.platform)
+
+    def owned_inspect(self, *, platform: str = "debian13") -> str:
+        return json.dumps(
+            [
+                {
+                    "Config": {
+                        "Labels": {
+                            "io.supermorphic.homelab-playbook.repository": (
+                                "homelab-playbook"
+                            ),
+                            "io.supermorphic.homelab-playbook.scenario": (
+                                "system_maintenance/default"
+                            ),
+                            "io.supermorphic.homelab-playbook.platform": platform,
+                        }
+                    }
+                }
+            ]
+        )
+
+    def test_absent_container_requires_no_removal(self) -> None:
+        fake = FakeCommandRunner(FakeResult(returncode=1))
+
+        removed = self.call_remove(fake)
+
+        self.assertIs(removed, False)
+        self.assertEqual(
+            [
+                (
+                    [
+                        "podman",
+                        "container",
+                        "exists",
+                        "homelab-playbook-system-maintenance-debian13",
+                    ],
+                    REPOSITORY_ROOT,
+                    None,
+                )
+            ],
+            fake.calls,
+        )
+
+    def test_owned_container_is_inspected_then_removed(self) -> None:
+        fake = FakeCommandRunner(
+            FakeResult(),
+            FakeResult(stdout=self.owned_inspect()),
+            FakeResult(),
+        )
+
+        removed = self.call_remove(fake)
+
+        self.assertIs(removed, True)
+        self.assertEqual(
+            [
+                [
+                    "podman",
+                    "container",
+                    "exists",
+                    "homelab-playbook-system-maintenance-debian13",
+                ],
+                [
+                    "podman",
+                    "container",
+                    "inspect",
+                    "homelab-playbook-system-maintenance-debian13",
+                    "--format",
+                    "json",
+                ],
+                [
+                    "podman",
+                    "rm",
+                    "--force",
+                    "homelab-playbook-system-maintenance-debian13",
+                ],
+            ],
+            [command for command, _, _ in fake.calls],
+        )
+
+    def test_colliding_container_is_never_removed(self) -> None:
+        fake = FakeCommandRunner(
+            FakeResult(),
+            FakeResult(stdout=self.owned_inspect(platform="rockylinux9")),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "collision"):
+            self.call_remove(fake)
+
+        self.assertEqual(2, len(fake.calls))
+
+    def test_container_inspection_error_is_not_treated_as_absence(self) -> None:
+        fake = FakeCommandRunner(
+            FakeResult(returncode=125, stderr="storage unavailable")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "inspect"):
+            self.call_remove(fake)
+
+
+class QueueClock:
+    def __init__(self, *values: float) -> None:
+        self.values = list(values)
+
+    def __call__(self) -> float:
+        if not self.values:
+            raise AssertionError("worker read the clock more often than expected")
+        return self.values.pop(0)
+
+
+class PlatformWorkerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.platform = runner_module.Platform(
+            name="debian13",
+            base_image="docker.io/library/debian:13",
+            image="localhost/homelab-playbook-system-maintenance-debian13:local",
+            container="homelab-playbook-system-maintenance-debian13",
+            containerfile=Path("Containerfile.debian13"),
+        )
+        self.host_plan = runner_module.HostPlan(
+            podman_version="podman version 5.6.2",
+            host_architecture="arm64",
+            requested_architectures={"debian13": "arm64"},
+        )
+
+    def owned_inspect(self) -> str:
+        return ContainerOwnershipTests().owned_inspect()
+
+    def image_inspect(self) -> str:
+        return json.dumps(
+            [
+                {
+                    "Id": "sha256:base-image-id",
+                    "RepoDigests": [
+                        "docker.io/library/debian@sha256:observed-digest"
+                    ],
+                }
+            ]
+        )
+
+    def call_worker(
+        self,
+        fake: FakeCommandRunner,
+        clock: QueueClock,
+    ):
+        function = getattr(runner_module, "run_platform", None)
+        if function is None:
+            self.fail("runner must provide run_platform")
+        return function(
+            self.platform,
+            self.host_plan,
+            REPOSITORY_ROOT,
+            fake,
+            "run-123",
+            clock,
+        )
+
+    def test_worker_pulls_builds_and_tests_one_platform_with_exact_policy(
+        self,
+    ) -> None:
+        fake = FakeCommandRunner(
+            FakeResult(returncode=1),
+            FakeResult(),
+            FakeResult(stdout=self.image_inspect()),
+            FakeResult(),
+            FakeResult(),
+            FakeResult(returncode=1),
+        )
+        clock = QueueClock(0, 1, 3, 4, 7, 8, 13, 14, 15, 16)
+        scenario_directory = (
+            REPOSITORY_ROOT
+            / "roles"
+            / "system_maintenance"
+            / "molecule"
+            / "default"
+        )
+
+        result = self.call_worker(fake, clock)
+
+        self.assertIs(result.success, True)
+        self.assertEqual("pass", result.status)
+        self.assertEqual("sha256:base-image-id", result.image_id)
+        self.assertEqual(
+            "docker.io/library/debian@sha256:observed-digest",
+            result.repository_digest,
+        )
+        self.assertEqual(2, result.pull_seconds)
+        self.assertEqual(3, result.build_seconds)
+        self.assertEqual(5, result.molecule_seconds)
+        self.assertEqual(1, result.cleanup_seconds)
+        self.assertEqual(16, result.platform_seconds)
+        self.assertEqual(
+            [
+                (
+                    "capture",
+                    [
+                        "podman",
+                        "container",
+                        "exists",
+                        "homelab-playbook-system-maintenance-debian13",
+                    ],
+                ),
+                (
+                    "stream",
+                    [
+                        "podman",
+                        "pull",
+                        "--policy=always",
+                        "--retry=3",
+                        "--platform",
+                        "linux/arm64",
+                        "docker.io/library/debian:13",
+                    ],
+                ),
+                (
+                    "capture",
+                    [
+                        "podman",
+                        "image",
+                        "inspect",
+                        "docker.io/library/debian:13",
+                        "--format",
+                        "json",
+                    ],
+                ),
+                (
+                    "stream",
+                    [
+                        "podman",
+                        "build",
+                        "--pull=never",
+                        "--platform",
+                        "linux/arm64",
+                        "--tag",
+                        "localhost/homelab-playbook-system-maintenance-debian13:local",
+                        "--file",
+                        str(scenario_directory / "Containerfile.debian13"),
+                        str(scenario_directory),
+                    ],
+                ),
+                (
+                    "stream",
+                    [
+                        "molecule",
+                        "test",
+                        "--scenario-name",
+                        "default",
+                        "--platform-name",
+                        "debian13",
+                        "--no-report",
+                        "--no-command-borders",
+                    ],
+                ),
+                (
+                    "capture",
+                    [
+                        "podman",
+                        "container",
+                        "exists",
+                        "homelab-playbook-system-maintenance-debian13",
+                    ],
+                ),
+            ],
+            fake.operations,
+        )
+        molecule_call = fake.stream_calls[2]
+        self.assertEqual(REPOSITORY_ROOT / "roles/system_maintenance", molecule_call[1])
+        self.assertEqual("[debian13]", molecule_call[4])
+        self.assertEqual(
+            str(REPOSITORY_ROOT / ".tmp/molecule/run-123/debian13"),
+            molecule_call[2]["MOLECULE_EPHEMERAL_DIRECTORY"],
+        )
+
+    def test_worker_cleans_up_after_each_primary_stage_failure(self) -> None:
+        cases = (
+            (
+                "acquisition failure",
+                [
+                    FakeResult(returncode=1),
+                    FakeResult(returncode=1, stderr="pull failed"),
+                    FakeResult(returncode=1),
+                ],
+            ),
+            (
+                "build failure",
+                [
+                    FakeResult(returncode=1),
+                    FakeResult(),
+                    FakeResult(stdout=self.image_inspect()),
+                    FakeResult(returncode=1, stderr="build failed"),
+                    FakeResult(returncode=1),
+                ],
+            ),
+            (
+                "test failure",
+                [
+                    FakeResult(returncode=1),
+                    FakeResult(),
+                    FakeResult(stdout=self.image_inspect()),
+                    FakeResult(),
+                    FakeResult(returncode=1, stderr="molecule failed"),
+                    FakeResult(returncode=1),
+                ],
+            ),
+        )
+        for expected_status, responses in cases:
+            with self.subTest(expected_status=expected_status):
+                fake = FakeCommandRunner(*responses)
+
+                result = self.call_worker(
+                    fake,
+                    QueueClock(*range(20)),
+                )
+
+                self.assertIs(result.success, False)
+                self.assertEqual(expected_status, result.status)
+                self.assertEqual(
+                    [
+                        "podman",
+                        "container",
+                        "exists",
+                        "homelab-playbook-system-maintenance-debian13",
+                    ],
+                    fake.operations[-1][1],
+                )
+
+    def test_cleanup_failure_preserves_the_primary_failure(self) -> None:
+        fake = FakeCommandRunner(
+            FakeResult(returncode=1),
+            FakeResult(returncode=1, stderr="registry unavailable"),
+            FakeResult(),
+            FakeResult(stdout=self.owned_inspect()),
+            FakeResult(returncode=1, stderr="remove failed"),
+        )
+
+        result = self.call_worker(fake, QueueClock(*range(20)))
+
+        self.assertEqual("cleanup failure", result.status)
+        self.assertIn("acquisition failure", result.message)
+        self.assertIn("could not remove owned container", result.message)
+
+
+class ParallelExecutionTests(unittest.TestCase):
+    def platform_result(self, platform: str, status: str = "pass"):
+        return runner_module.PlatformResult(
+            platform=platform,
+            status=status,
+            message="test result",
+            image_id="sha256:image",
+            repository_digest=None,
+            pull_seconds=1,
+            build_seconds=2,
+            molecule_seconds=3,
+            cleanup_seconds=1,
+            platform_seconds=7,
+        )
+
+    def registered_platforms(self):
+        value = getattr(runner_module, "PLATFORMS", None)
+        if value is None:
+            self.fail("runner must register the platform matrix")
+        return value
+
+    def test_registered_platforms_have_stable_names_and_images(self) -> None:
+        platforms = self.registered_platforms()
+
+        self.assertEqual(
+            [
+                (
+                    "debian13",
+                    "docker.io/library/debian:13",
+                    "localhost/homelab-playbook-system-maintenance-debian13:local",
+                    "homelab-playbook-system-maintenance-debian13",
+                    "Containerfile.debian13",
+                ),
+                (
+                    "rockylinux9",
+                    "docker.io/rockylinux/rockylinux:9",
+                    "localhost/homelab-playbook-system-maintenance-rockylinux9:local",
+                    "homelab-playbook-system-maintenance-rockylinux9",
+                    "Containerfile.rockylinux9",
+                ),
+                (
+                    "archlinux",
+                    "docker.io/archlinux/archlinux:base",
+                    "localhost/homelab-playbook-system-maintenance-archlinux:local",
+                    "homelab-playbook-system-maintenance-archlinux",
+                    "Containerfile.archlinux",
+                ),
+            ],
+            [
+                (
+                    platform.name,
+                    platform.base_image,
+                    platform.image,
+                    platform.container,
+                    str(platform.containerfile),
+                )
+                for platform in platforms
+            ],
+        )
+
+    def test_local_selection_runs_all_platforms_and_workflow_selects_one(
+        self,
+    ) -> None:
+        function = getattr(runner_module, "select_platforms", None)
+        if function is None:
+            self.fail("runner must provide select_platforms")
+
+        all_platforms = function({})
+        selected = function({"HOMELAB_MOLECULE_PLATFORM": "rockylinux9"})
+
+        self.assertEqual(
+            ["debian13", "rockylinux9", "archlinux"],
+            [platform.name for platform in all_platforms],
+        )
+        self.assertEqual(["rockylinux9"], [platform.name for platform in selected])
+
+    def test_unknown_workflow_platform_fails_before_any_command(self) -> None:
+        fake = FakeCommandRunner()
+        stderr = io.StringIO()
+
+        with mock.patch.dict(
+            "os.environ",
+            {"HOMELAB_MOLECULE_PLATFORM": "unknown"},
+            clear=True,
+        ):
+            with redirect_stderr(stderr):
+                result = runner_module.run(["system_maintenance/default"], fake)
+
+        self.assertEqual(1, result)
+        self.assertIn("unknown Molecule platform", stderr.getvalue())
+        self.assertEqual([], fake.operations)
+
+    def test_all_workers_start_before_any_worker_can_finish(self) -> None:
+        function = getattr(runner_module, "run_platforms", None)
+        if function is None:
+            self.fail("runner must provide run_platforms")
+        platforms = self.registered_platforms()
+        started: set[str] = set()
+        started_lock = threading.Lock()
+        all_started = threading.Event()
+
+        def worker(platform):
+            with started_lock:
+                started.add(platform.name)
+                if len(started) == 3:
+                    all_started.set()
+            if not all_started.wait(timeout=2):
+                raise AssertionError("platform workers did not overlap")
+            return self.platform_result(platform.name)
+
+        results = function(platforms, worker)
+
+        self.assertEqual(
+            {"debian13", "rockylinux9", "archlinux"},
+            {result.platform for result in results},
+        )
+
+    def test_parallel_execution_waits_for_results_after_one_failure(self) -> None:
+        function = getattr(runner_module, "run_platforms", None)
+        if function is None:
+            self.fail("runner must provide run_platforms")
+        completed: set[str] = set()
+        completed_lock = threading.Lock()
+
+        def worker(platform):
+            with completed_lock:
+                completed.add(platform.name)
+            status = "test failure" if platform.name == "debian13" else "pass"
+            return self.platform_result(platform.name, status)
+
+        results = function(self.registered_platforms(), worker)
+
+        self.assertEqual(
+            {"debian13", "rockylinux9", "archlinux"},
+            completed,
+        )
+        self.assertEqual(3, len(results))
+        failed_result = next(
+            result for result in results if result.platform == "debian13"
+        )
+        self.assertFalse(failed_result.success)
+
+
+class OutputTests(unittest.TestCase):
+    def result(self):
+        return runner_module.PlatformResult(
+            platform="archlinux",
+            status="pass",
+            message="all Molecule phases passed",
+            image_id="sha256:base-image-id",
+            repository_digest=(
+                "docker.io/archlinux/archlinux@sha256:observed-digest"
+            ),
+            pull_seconds=1.25,
+            build_seconds=2.5,
+            molecule_seconds=3.75,
+            cleanup_seconds=0.5,
+            platform_seconds=8.0,
+        )
+
+    def host_plan(self):
+        return runner_module.HostPlan(
+            podman_version="podman version 5.6.2",
+            host_architecture="arm64",
+            requested_architectures={"archlinux": "amd64"},
+        )
+
+    def test_subprocess_stream_prefixes_every_combined_output_line(self) -> None:
+        command_runner = runner_module.SubprocessCommandRunner()
+        stream = getattr(command_runner, "stream", None)
+        if stream is None:
+            self.fail("subprocess runner must provide stream")
+        output = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as directory:
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always", ResourceWarning)
+                with redirect_stdout(output):
+                    result = stream(
+                        [
+                            sys.executable,
+                            "-c",
+                            (
+                                "import sys; print('standard output'); "
+                                "print('standard error', file=sys.stderr)"
+                            ),
+                        ],
+                        cwd=Path(directory),
+                        line_prefix="[debian13]",
+                    )
+                gc.collect()
+
+        self.assertEqual(0, result.returncode)
+        self.assertEqual([], captured_warnings)
+        self.assertEqual(
+            {
+                "[debian13] standard output",
+                "[debian13] standard error",
+            },
+            set(output.getvalue().splitlines()),
+        )
+
+    def test_summary_reports_provenance_architecture_timings_and_result(
+        self,
+    ) -> None:
+        function = getattr(runner_module, "emit_summary", None)
+        if function is None:
+            self.fail("runner must provide emit_summary")
+        output = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as directory:
+            summary_path = Path(directory) / "github-summary.md"
+            summary_path.touch(mode=0o600)
+            environment = {"GITHUB_STEP_SUMMARY": str(summary_path)}
+            with redirect_stdout(output):
+                function(self.host_plan(), [self.result()], 12.5, environment)
+            github_summary = summary_path.read_text(encoding="utf-8")
+
+        terminal_summary = output.getvalue()
+        for fragment in (
+            "podman version 5.6.2",
+            "archlinux",
+            "host=arm64",
+            "requested=amd64",
+            "emulated",
+            "docker.io/archlinux/archlinux:base",
+            "sha256:base-image-id",
+            "docker.io/archlinux/archlinux@sha256:observed-digest",
+            "pull=1.25s",
+            "build=2.50s",
+            "molecule=3.75s",
+            "cleanup=0.50s",
+            "total=8.00s",
+            "result=pass",
+            "Invocation total: 12.50s",
+        ):
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, terminal_summary)
+        self.assertIn("### Molecule platform summary", github_summary)
+        self.assertIn("| archlinux | arm64 | amd64 | emulated |", github_summary)
+        self.assertIn("Build: 2.50 seconds", github_summary)
+        self.assertIn("Invocation total: 12.50 seconds", github_summary)
+
+    def test_summary_never_follows_a_github_summary_symlink(self) -> None:
+        function = getattr(runner_module, "emit_summary", None)
+        if function is None:
+            self.fail("runner must provide emit_summary")
+
+        with tempfile.TemporaryDirectory() as directory:
+            directory_path = Path(directory)
+            target = directory_path / "target.md"
+            target.write_text("operator content\n", encoding="utf-8")
+            symlink = directory_path / "summary.md"
+            symlink.symlink_to(target)
+            with redirect_stdout(io.StringIO()):
+                function(
+                    self.host_plan(),
+                    [self.result()],
+                    12.5,
+                    {"GITHUB_STEP_SUMMARY": str(symlink)},
+                )
+
+            self.assertEqual("operator content\n", target.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_molecule_runner.py
+++ b/tests/ci/test_molecule_runner.py
@@ -815,21 +815,41 @@ class ParallelExecutionTests(unittest.TestCase):
             ],
         )
 
-    def test_local_selection_runs_all_platforms_and_workflow_selects_one(
-        self,
-    ) -> None:
+    def test_arm64_default_selection_skips_archlinux(self) -> None:
         function = getattr(runner_module, "select_platforms", None)
         if function is None:
             self.fail("runner must provide select_platforms")
 
-        all_platforms = function({})
-        selected = function({"HOMELAB_MOLECULE_PLATFORM": "rockylinux9"})
+        selected = function({}, "arm64")
+
+        self.assertEqual(
+            ["debian13", "rockylinux9"],
+            [platform.name for platform in selected],
+        )
+
+    def test_amd64_default_selection_runs_all_platforms(self) -> None:
+        function = getattr(runner_module, "select_platforms", None)
+        if function is None:
+            self.fail("runner must provide select_platforms")
+
+        selected = function({}, "amd64")
 
         self.assertEqual(
             ["debian13", "rockylinux9", "archlinux"],
-            [platform.name for platform in all_platforms],
+            [platform.name for platform in selected],
         )
-        self.assertEqual(["rockylinux9"], [platform.name for platform in selected])
+
+    def test_explicit_platform_selection_overrides_host_default(self) -> None:
+        function = getattr(runner_module, "select_platforms", None)
+        if function is None:
+            self.fail("runner must provide select_platforms")
+
+        selected = function(
+            {"HOMELAB_MOLECULE_PLATFORM": "archlinux"},
+            "arm64",
+        )
+
+        self.assertEqual(["archlinux"], [platform.name for platform in selected])
 
     def test_unknown_workflow_platform_fails_before_any_command(self) -> None:
         fake = FakeCommandRunner()
@@ -899,9 +919,9 @@ class ParallelExecutionTests(unittest.TestCase):
 
 
 class OutputTests(unittest.TestCase):
-    def result(self):
+    def result(self, platform: str = "archlinux"):
         return runner_module.PlatformResult(
-            platform="archlinux",
+            platform=platform,
             status="pass",
             message="all Molecule phases passed",
             image_id="sha256:base-image-id",
@@ -919,7 +939,11 @@ class OutputTests(unittest.TestCase):
         return runner_module.HostPlan(
             podman_version="podman version 5.6.2",
             host_architecture="arm64",
-            requested_architectures={"archlinux": "amd64"},
+            requested_architectures={
+                "debian13": "arm64",
+                "rockylinux9": "arm64",
+                "archlinux": "amd64",
+            },
         )
 
     def test_subprocess_stream_prefixes_every_combined_output_line(self) -> None:
@@ -997,6 +1021,22 @@ class OutputTests(unittest.TestCase):
         self.assertIn("| archlinux | arm64 | amd64 | emulated |", github_summary)
         self.assertIn("Build: 2.50 seconds", github_summary)
         self.assertIn("Invocation total: 12.50 seconds", github_summary)
+
+    def test_arm64_default_summary_reports_archlinux_skip(self) -> None:
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            runner_module.emit_summary(
+                self.host_plan(),
+                [self.result("debian13"), self.result("rockylinux9")],
+                12.5,
+                {},
+            )
+
+        self.assertIn(
+            "archlinux: skipped on arm64; GitHub CI runs it on native amd64",
+            output.getvalue(),
+        )
 
     def test_summary_never_follows_a_github_summary_symlink(self) -> None:
         function = getattr(runner_module, "emit_summary", None)

--- a/tests/toolchain/test_dependencies.py
+++ b/tests/toolchain/test_dependencies.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 from types import ModuleType
@@ -36,6 +37,23 @@ def load_dependencies() -> ModuleType:
 
 
 dependencies = load_dependencies()
+
+
+class RepositoryDependencyContractTests(unittest.TestCase):
+    def test_molecule_controller_dependency_is_locked_and_bootstrapped(self) -> None:
+        with (REPO_ROOT / "pyproject.toml").open("rb") as source:
+            project = tomllib.load(source)
+
+        groups = project["dependency-groups"]
+        self.assertEqual(["molecule==26.6.0"], groups.get("molecule"))
+        self.assertIn({"include-group": "molecule"}, groups["dev"])
+
+    def test_podman_collection_is_exactly_pinned(self) -> None:
+        collections = dependencies.required_collections(
+            REPO_ROOT / "requirements.yml"
+        )
+
+        self.assertIn(("containers.podman", "1.20.2"), collections)
 
 
 class DependencyVerificationTests(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,18 @@ wheels = [
 ]
 
 [[package]]
+name = "enrich"
+version = "1.2.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/77/cb9b3d6f2e2e5f8104e907ea4c4d575267238f52c51cf9f864b865a99710/enrich-1.2.7.tar.gz", hash = "sha256:0a2ab0d2931dff8947012602d1234d2a3ee002d9a355b5d70be6bf5466008893", size = 16918, upload-time = "2022-01-10T15:30:33.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/67/aecd1d435dbbdcea21a197d708e9ff0bcc7306c2847c6c87cc1a91e2cca4/enrich-1.2.7-py3-none-any.whl", hash = "sha256:f29b2c8c124b4dbd7c975ab5c3568f6c7a47938ea3b7d2106c8a3bd346545e4f", size = 8717, upload-time = "2022-01-10T15:30:32.723Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.32.4"
 source = { registry = "https://pypi.org/simple" }
@@ -215,6 +227,7 @@ dev = [
     { name = "ansible-core" },
     { name = "ansible-lint" },
     { name = "codespell" },
+    { name = "molecule" },
     { name = "pyyaml" },
     { name = "yamllint" },
     { name = "zizmor" },
@@ -223,6 +236,9 @@ fast = [
     { name = "codespell" },
     { name = "yamllint" },
     { name = "zizmor" },
+]
+molecule = [
+    { name = "molecule" },
 ]
 
 [package.metadata]
@@ -237,6 +253,7 @@ dev = [
     { name = "ansible-core", specifier = "==2.21.3" },
     { name = "ansible-lint", specifier = "==26.8.0" },
     { name = "codespell", specifier = "==2.4.3" },
+    { name = "molecule", specifier = "==26.6.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "yamllint", specifier = "==1.38.0" },
     { name = "zizmor", specifier = "==1.29.0" },
@@ -246,6 +263,7 @@ fast = [
     { name = "yamllint", specifier = "==1.38.0" },
     { name = "zizmor", specifier = "==1.29.0" },
 ]
+molecule = [{ name = "molecule", specifier = "==26.6.0" }]
 
 [[package]]
 name = "jinja2"
@@ -287,6 +305,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -314,6 +344,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "molecule"
+version = "26.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ansible-compat" },
+    { name = "ansible-core" },
+    { name = "click" },
+    { name = "enrich" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/81/7391315d9e10d7a37bb11d0d83d5d03303f698292465e3c1620028a3abf7/molecule-26.6.0.tar.gz", hash = "sha256:1870c5f5442403d77b5953d344382265a521eb4948885260c0cac084aa3dec02", size = 4717402, upload-time = "2026-06-30T11:59:11.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/15/cebabfd858a470e4497a7c4fa6edec16246a7b2c7cb6f937388ac4d76a59/molecule-26.6.0-py3-none-any.whl", hash = "sha256:e0d63011f1f044030a0c769178f4800271a2a8137f51124b18d673e576a88c52", size = 162387, upload-time = "2026-06-30T11:59:09.345Z" },
 ]
 
 [[package]]
@@ -353,12 +414,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
 ]
 
 [[package]]
@@ -413,6 +492,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/14/4669927e06631070edb968c78fdb6ce8992e27c9ab2cde4b3993e22ac7af/resolvelib-1.2.1.tar.gz", hash = "sha256:7d08a2022f6e16ce405d60b68c390f054efcfd0477d4b9bd019cc941c28fad1c", size = 24575, upload-time = "2025-10-11T01:07:44.582Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/23/c941a0d0353681ca138489983c4309e0f5095dfd902e1357004f2357ddf2/resolvelib-1.2.1-py3-none-any.whl", hash = "sha256:fb06b66c8da04172d9e72a21d7d06186d8919e32ae5ab5cdf5b9d920be805ac2", size = 18737, upload-time = "2025-10-11T01:07:43.081Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a Podman-only, rootless Molecule scenario for the `system_maintenance` role on Debian 13, Rocky Linux 9, and Arch Linux.
- Pull maintained upstream tags, build minimal systemd test images, run local platforms in parallel, and report pull, build, Molecule, cleanup, and total durations.
- Add full-depth CI classification and a native AMD64 GitHub matrix for all three platforms.
- Document the `test:molecule` command and repository command lifecycle.

## Validation

- `mise run ci:changed`
- Local ARM64: Debian 13 passed in 69.99 seconds.
- Local ARM64: Rocky Linux 9 passed in 93.02 seconds.
- Local invocation completed in 93.38 seconds.
- Arch Linux is skipped locally on ARM64 and runs in the native AMD64 GitHub matrix.

Closes #11