### PR TITLE
Stabilize package upgrade idempotence tests

### DIFF
--- a/docs/specs/002-multi-os-molecule-validation.md
+++ b/docs/specs/002-multi-os-molecule-validation.md
@@ -42,7 +42,8 @@ behavior, change-directed validation, and container-only boundaries.
 - Debian 13, Rocky Linux 9, and Arch Linux container platforms;
 - rootless Podman preflight, image acquisition, image building, container
   lifecycle, and cleanup;
-- converge, idempotence, and independent verification phases;
+- converge, deterministic-task idempotence, and independent verification
+  phases;
 - explicit suppression of real reboot attempts during container tests while
   retaining the production default;
 - a public scenario test command and shared per-platform worker;
@@ -293,8 +294,16 @@ role behavior.
 ## Verification contract
 
 Molecule's idempotence phase runs the role a second time and requires no changed
-tasks. Verification then uses Ansible modules and commands that observe the
-result rather than calling the role again.
+deterministic tasks. Each operating system's live full-upgrade task carries
+Molecule's `molecule-idempotence-notest` tag. Molecule runs these tasks during
+convergence and automatically skips that tag during idempotence. This prevents a
+package or repository-metadata publication between the two runs from being
+reported as role non-idempotence. Package installation, cleanup, configuration,
+reboot-signal inspection, and all other maintenance tasks remain part of the
+strict second pass.
+
+Verification then uses Ansible modules and commands that observe the result
+rather than calling the role again.
 
 The initial assertions cover current role-owned invariants:
 
@@ -489,8 +498,11 @@ Issue #11 is complete when:
    local image identity;
 7. base and built images remain after local testing, while exact label-owned
    scenario containers are destroyed after both success and failure;
-8. converge, idempotence, and independent verification pass for each selected
-   operating system, including Arch in GitHub's AMD64 matrix;
+8. converge, deterministic-task idempotence, and independent verification pass
+   for each selected operating system, including Arch in GitHub's AMD64 matrix;
+   live full-upgrade tasks run during converge and are excluded only from the
+   idempotence pass because maintained package repositories can change during a
+   scenario run;
 9. the role exposes an explicit reboot control whose production default remains
    enabled and whose scenario value prevents actual container reboot;
 10. verification covers representative current role invariants, including Rocky

--- a/roles/system_maintenance/tasks/setup-Archlinux.yml
+++ b/roles/system_maintenance/tasks/setup-Archlinux.yml
@@ -3,6 +3,8 @@
   community.general.pacman:
     update_cache: true
     upgrade: true
+  tags:
+    - molecule-idempotence-notest
 
 - name: Install common packages on Arch Linux
   community.general.pacman:

--- a/roles/system_maintenance/tasks/setup-Debian.yml
+++ b/roles/system_maintenance/tasks/setup-Debian.yml
@@ -6,6 +6,8 @@
     force_apt_get: true
   register: system_maintenance_apt_upgrade
   changed_when: system_maintenance_apt_upgrade.changed
+  tags:
+    - molecule-idempotence-notest
 
 - name: Autoremove unused packages
   ansible.builtin.apt:

--- a/roles/system_maintenance/tasks/setup-RedHat.yml
+++ b/roles/system_maintenance/tasks/setup-RedHat.yml
@@ -20,6 +20,8 @@
     state: latest
     update_cache: true
     update_only: true
+  tags:
+    - molecule-idempotence-notest
 
 - name: Remove unneeded packages
   ansible.builtin.dnf:

--- a/tests/ansible/test_source_contracts.py
+++ b/tests/ansible/test_source_contracts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import configparser
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -264,6 +265,83 @@ class SourceContractTests(unittest.TestCase):
                 ]
                 self.assertEqual(1, len(reboot_tasks))
                 self.assertEqual(conditions, reboot_tasks[0]["when"])
+
+    def test_system_maintenance_idempotence_skips_only_live_upgrades(self) -> None:
+        """Live upgrades must run during converge but not strict idempotence."""
+        imported_task_files = [
+            "setup-Debian.yml",
+            "setup-RedHat.yml",
+            "setup-Archlinux.yml",
+        ]
+        playbook = [
+            {
+                "name": "List system maintenance tasks",
+                "hosts": "localhost",
+                "gather_facts": False,
+                "tasks": [
+                    {
+                        "name": f"Import {task_file}",
+                        "ansible.builtin.import_tasks": str(
+                            REPOSITORY_ROOT
+                            / "roles/system_maintenance/tasks"
+                            / task_file
+                        ),
+                    }
+                    for task_file in imported_task_files
+                ],
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            playbook_path = Path(temporary_directory) / "list-maintenance.yml"
+            playbook_path.write_text(
+                yaml.safe_dump(playbook, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            def list_tasks(*extra_arguments: str) -> str:
+                result = subprocess.run(
+                    [
+                        "ansible-playbook",
+                        str(playbook_path),
+                        "--inventory",
+                        "localhost,",
+                        "--connection",
+                        "local",
+                        "--list-tasks",
+                        *extra_arguments,
+                    ],
+                    cwd=REPOSITORY_ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+                return result.stdout
+
+            converge_tasks = list_tasks()
+            idempotence_tasks = list_tasks(
+                "--skip-tags", "molecule-idempotence-notest"
+            )
+
+        live_upgrade_tasks = [
+            "Update package cache and upgrade all packages",
+            "Fully update installed packages",
+            "Upgrade all packages (full system upgrade)",
+        ]
+        for task_name in live_upgrade_tasks:
+            with self.subTest(task_name=task_name):
+                self.assertIn(task_name, converge_tasks)
+                self.assertNotIn(task_name, idempotence_tasks)
+
+        stable_tasks = [
+            "Autoremove unused packages",
+            "Retain the two most recent kernels",
+            "Enable the English locale definition",
+        ]
+        for task_name in stable_tasks:
+            with self.subTest(task_name=task_name):
+                self.assertIn(task_name, idempotence_tasks)
 
     def test_update_pihole_has_no_end_play(self) -> None:
         """A Pi-hole command failure must fail normally instead of ending a play."""


### PR DESCRIPTION
## Summary

- keep live Debian, Rocky Linux, and Arch Linux full upgrades in Molecule convergence
- exclude only those repository-dependent upgrade tasks from the strict idempotence pass
- add an executable Ansible contract test for converge and idempotence task selection
- document deterministic-task idempotence in specification 002

## Validation

- `mise run ci:changed`
- independent code review: ready to merge with no findings

Local Molecule validation passed for Debian 13 and Rocky Linux 9 on ARM64. Arch Linux remains covered by the GitHub AMD64 matrix; the offline contract test exercises its real task selection locally.
