### PR TITLE
Fix Debian 13 OS provisioning regressions

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,4 @@ collections_path = ./.ansible/collections
 retry_files_enabled = false
 nocows = 1
 interpreter_python = auto_silent
+inject_facts_as_vars = false

--- a/playbooks/os/maintain.yml
+++ b/playbooks/os/maintain.yml
@@ -32,10 +32,10 @@
       ansible.builtin.assert:
         that:
           - >-
-            (ansible_distribution == 'Debian' and
-             ansible_distribution_major_version == '13') or
-            (ansible_distribution == 'Rocky' and
-             ansible_distribution_major_version == '9')
+            (ansible_facts['distribution'] == 'Debian' and
+             ansible_facts['distribution_major_version'] == '13') or
+            (ansible_facts['distribution'] == 'Rocky' and
+             ansible_facts['distribution_major_version'] == '9')
         fail_msg: >-
           os maintenance supports Debian 13 and Rocky Linux 9 only
 
@@ -90,7 +90,6 @@
 
     - name: Reset the connection after an Ansible-controlled reboot
       ansible.builtin.meta: reset_connection
-      when: os_reboot_performed | bool
 
     - name: Gather facts after an Ansible-controlled reboot
       ansible.builtin.setup:

--- a/playbooks/os/provision.yml
+++ b/playbooks/os/provision.yml
@@ -18,9 +18,9 @@
     - name: Validate complete provisioning platform support
       ansible.builtin.assert:
         that:
-          - ansible_os_family in ['Debian', 'RedHat']
+          - ansible_facts['os_family'] in ['Debian', 'RedHat']
         fail_msg: >-
-          os provision does not support {{ ansible_os_family }} because its
+          os provision does not support {{ ansible_facts['os_family'] }} because its
           complete security baseline supports only Debian and RedHat
 
     - name: Validate complete provisioning security baseline inputs
@@ -85,7 +85,6 @@
 
     - name: Reset the connection after an Ansible-controlled reboot
       ansible.builtin.meta: reset_connection
-      when: os_reboot_performed | bool
 
     - name: Gather facts after an Ansible-controlled reboot
       ansible.builtin.setup:

--- a/roles/enable_cgroup/tasks/main.yml
+++ b/roles/enable_cgroup/tasks/main.yml
@@ -5,7 +5,7 @@
   register: enable_cgroup_cmdline_check
   changed_when: false
   when:
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
     - ansible_facts['architecture'] in ['armv7l', 'aarch64']
 
 - name: Manage cgroup kernel parameters

--- a/roles/get_kubeconfig/tasks/main.yml
+++ b/roles/get_kubeconfig/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create kube directory
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.kube"
+    path: "{{ ansible_facts['user_dir'] }}/.kube"
     state: directory
     mode: '0700'
 
@@ -25,7 +25,7 @@
 - name: Copy the kubeconfig file to ansible host
   ansible.builtin.copy:
     src: /tmp/kubeconfig
-    dest: "{{ ansible_user_dir }}/.kube/config"
+    dest: "{{ ansible_facts['user_dir'] }}/.kube/config"
     mode: '0600'
 
 - name: Configure kubectl cluster for K3s VIP address
@@ -33,7 +33,7 @@
     kubectl config set-cluster default
       --server https://{{ get_kubeconfig_vip_address }}:6443
   environment:
-    KUBECONFIG: "{{ ansible_user_dir }}/.kube/config"
+    KUBECONFIG: "{{ ansible_facts['user_dir'] }}/.kube/config"
   changed_when: true
 
 - name: Clean tmp kubeconfig

--- a/roles/os_baseline_verify/tasks/access.yml
+++ b/roles/os_baseline_verify/tasks/access.yml
@@ -25,10 +25,10 @@
          | reject('equalto', '') | list | sort }}
   ansible.builtin.assert:
     that:
-      - "'ansible' in getent_passwd"
-      - "'ansible' in getent_shadow"
-      - getent_passwd.ansible[5] == '/bin/bash'
-      - getent_shadow.ansible[0] is match('^[!*]')
+      - "'ansible' in ansible_facts['getent_passwd']"
+      - "'ansible' in ansible_facts['getent_shadow']"
+      - ansible_facts['getent_passwd'].ansible[5] == '/bin/bash'
+      - ansible_facts['getent_shadow'].ansible[0] is match('^[!*]')
       - >-
         os_baseline_verify_authorized_key_lines
         == (os_baseline_verify_expected_authorized_keys

--- a/roles/os_baseline_verify/tasks/firewall.yml
+++ b/roles/os_baseline_verify/tasks/firewall.yml
@@ -92,7 +92,7 @@
              os_baseline_verify_permanent_firewall_policies.stdout,
              os_baseline_verify_management.interface
                if os_baseline_verify_runtime_controls | bool else '',
-             ansible_os_family
+             ansible_facts['os_family']
            ) }}
   ansible.builtin.assert:
     that:
@@ -187,7 +187,7 @@
              os_baseline_verify_runtime_firewall_direct.results,
              os_baseline_verify_runtime_firewall_policies.stdout,
              os_baseline_verify_management.interface,
-             ansible_os_family
+             ansible_facts['os_family']
            ) }}
   ansible.builtin.assert:
     that:

--- a/roles/os_baseline_verify/tasks/main.yml
+++ b/roles/os_baseline_verify/tasks/main.yml
@@ -3,10 +3,10 @@
   ansible.builtin.assert:
     that:
       - >-
-        (ansible_distribution == 'Debian' and
-         ansible_distribution_major_version == '13') or
-        (ansible_distribution == 'Rocky' and
-         ansible_distribution_major_version == '9')
+        (ansible_facts['distribution'] == 'Debian' and
+         ansible_facts['distribution_major_version'] == '13') or
+        (ansible_facts['distribution'] == 'Rocky' and
+         ansible_facts['distribution_major_version'] == '9')
     fail_msg: OS baseline verification supports Debian 13 and Rocky Linux 9 only
 
 - name: Validate OS baseline verification inputs

--- a/roles/os_baseline_verify/tasks/platform.yml
+++ b/roles/os_baseline_verify/tasks/platform.yml
@@ -7,7 +7,7 @@
   ansible.builtin.slurp:
     src: "{{ item }}"
   loop: >-
-    {{ ['/etc/selinux/config'] if ansible_os_family == 'RedHat'
+    {{ ['/etc/selinux/config'] if ansible_facts['os_family'] == 'RedHat'
        else ['/etc/apparmor/parser.conf', '/etc/apparmor.d/abstractions/base'] }}
   register: os_baseline_verify_platform_configuration
 
@@ -16,7 +16,7 @@
     argv: [/usr/bin/dpkg-query, -L, apparmor, apparmor-profiles]
   register: os_baseline_verify_apparmor_distribution_files
   changed_when: false
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Verify native MAC and time package evidence
   vars:
@@ -25,13 +25,13 @@
   ansible.builtin.assert:
     that:
       - >-
-        ('chrony' in ansible_facts.packages if ansible_os_family == 'RedHat'
+        ('chrony' in ansible_facts.packages if ansible_facts['os_family'] == 'RedHat'
          else 'systemd-timesyncd' in ansible_facts.packages)
       - >-
         ('selinux-policy-targeted' in ansible_facts.packages and
          os_baseline_verify_mac_values.SELINUX | default('') == 'enforcing' and
          os_baseline_verify_mac_values.SELINUXTYPE | default('') == 'targeted')
-        if ansible_os_family == 'RedHat'
+        if ansible_facts['os_family'] == 'RedHat'
         else ('apparmor' in ansible_facts.packages and 'apparmor-utils' in ansible_facts.packages and 'apparmor-profiles' in ansible_facts.packages and
               os_baseline_verify_platform_configuration.results[0].content | b64decode | length > 0 and
               os_baseline_verify_platform_configuration.results[1].content | b64decode | length > 0 and
@@ -45,7 +45,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
 
 - name: Verify Rocky SELinux relabel recovery action
   ansible.builtin.assert:
@@ -54,7 +54,7 @@
     fail_msg: SELinux is Disabled; reboot the host to complete the authorized relabel.
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
     - security_baseline_reboot_required | default(false) | bool
 
 - name: Verify Rocky SELinux enforcement
@@ -64,7 +64,7 @@
     fail_msg: Rocky SELinux is not enforcing
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
     - >-
       not (os_baseline_verify_selinux_state.stdout | trim == 'Disabled'
            and security_baseline_reboot_required | default(false) | bool)
@@ -76,7 +76,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Read Debian AppArmor service enablement
   ansible.builtin.command:
@@ -85,7 +85,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Read Debian AppArmor enforcing profile state
   ansible.builtin.command:
@@ -94,7 +94,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Verify Debian AppArmor enforcing profiles
   vars:
@@ -114,7 +114,7 @@
     fail_msg: Debian AppArmor is not enabled with loaded profiles
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Read Debian time service enablement
   ansible.builtin.command:
@@ -122,7 +122,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Read Debian time service activity
   ansible.builtin.command:
@@ -130,7 +130,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Read Debian time synchronization state
   ansible.builtin.command:
@@ -139,7 +139,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Verify Debian time synchronization
   ansible.builtin.assert:
@@ -148,7 +148,7 @@
     fail_msg: systemd-timesyncd is not synchronized
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Read Rocky time service enablement
   ansible.builtin.command:
@@ -156,7 +156,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
 
 - name: Read Rocky time service activity
   ansible.builtin.command:
@@ -164,7 +164,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
 
 - name: Read Rocky chrony tracking state
   ansible.builtin.command:
@@ -173,7 +173,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
 
 - name: Read Rocky chrony source state
   ansible.builtin.command:
@@ -182,7 +182,7 @@
   changed_when: false
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
 
 - name: Verify Rocky chrony synchronization
   ansible.builtin.assert:
@@ -194,4 +194,4 @@
     fail_msg: Chrony is not synchronized with an accepted source
   when:
     - os_baseline_verify_runtime_controls | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'

--- a/roles/os_baseline_verify/tasks/updates.yml
+++ b/roles/os_baseline_verify/tasks/updates.yml
@@ -4,7 +4,7 @@
     argv: [/usr/bin/apt-config, dump]
   register: os_baseline_verify_debian_updater_configuration
   changed_when: false
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Verify Debian security-only updater configuration
   vars:
@@ -24,13 +24,13 @@
       - os_baseline_verify_debian_policy.scalar['Unattended-Upgrade::Automatic-Reboot-Time'] == system_maintenance_security_reboot_time
       - os_baseline_verify_debian_policy.scalar['Unattended-Upgrade::Remove-Unused-Dependencies'] == 'false'
     fail_msg: Debian automatic updates are not restricted to the configured security policy
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Read Rocky automatic DNF configuration
   ansible.builtin.slurp:
     src: /etc/dnf/automatic.conf
   register: os_baseline_verify_rocky_updater_configuration
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Verify Rocky security-only updater configuration
   vars:
@@ -44,7 +44,7 @@
       - os_baseline_verify_rocky_updater.commands.reboot == ('when-needed' if system_maintenance_native_reboot_enabled | bool else 'never')
       - os_baseline_verify_rocky_updater.emitters.emit_via == 'stdio'
     fail_msg: Rocky automatic updates are not restricted to the configured security policy
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Read native security update timer enablement
   ansible.builtin.command:
@@ -52,7 +52,7 @@
       - /usr/bin/systemctl
       - is-enabled
       - >-
-        {{ 'apt-daily-upgrade.timer' if ansible_os_family == 'Debian'
+        {{ 'apt-daily-upgrade.timer' if ansible_facts['os_family'] == 'Debian'
            else 'dnf-automatic.timer' }}
   register: os_baseline_verify_updater_timer
   changed_when: false
@@ -65,7 +65,7 @@
       - cat-config
       - >-
         {{ 'systemd/system/apt-daily-upgrade.timer'
-           if ansible_os_family == 'Debian'
+           if ansible_facts['os_family'] == 'Debian'
            else 'systemd/system/dnf-automatic.timer' }}
   register: os_baseline_verify_updater_timer_configuration
   changed_when: false
@@ -93,31 +93,31 @@
     argv: [/usr/bin/dpkg, --audit]
   register: os_baseline_verify_debian_package_health
   changed_when: false
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Verify Debian package manager health
   ansible.builtin.assert:
     that:
       - os_baseline_verify_debian_package_health.stdout | trim == ''
     fail_msg: dpkg reports packages requiring repair
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Check Rocky package manager health
   ansible.builtin.command:
     argv: [/usr/bin/dnf, check]
   changed_when: false
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Read Debian reboot-required marker
   ansible.builtin.stat:
     path: /var/run/reboot-required
   register: os_baseline_verify_debian_reboot_marker
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Record Debian reboot-required state
   ansible.builtin.set_fact:
     os_baseline_reboot_required: "{{ os_baseline_verify_debian_reboot_marker.stat.exists }}"  # noqa var-naming[no-role-prefix] - Required public fact.
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Read Rocky reboot-required state
   ansible.builtin.command:
@@ -125,12 +125,12 @@
   register: os_baseline_verify_rocky_reboot_state
   changed_when: false
   failed_when: os_baseline_verify_rocky_reboot_state.rc not in [0, 1]
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Record Rocky reboot-required state
   ansible.builtin.set_fact:
     os_baseline_reboot_required: "{{ os_baseline_verify_rocky_reboot_state.rc == 1 }}"  # noqa var-naming[no-role-prefix] - Required public fact.
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Report reboot-required state
   ansible.builtin.debug:

--- a/roles/os_bootstrap/tasks/main.yml
+++ b/roles/os_bootstrap/tasks/main.yml
@@ -42,10 +42,10 @@
       ansible.builtin.assert:
         that:
           - >-
-            (ansible_distribution == 'Debian' and
-             ansible_distribution_major_version == '13') or
-            (ansible_distribution == 'Rocky' and
-             ansible_distribution_major_version == '9')
+            (ansible_facts['distribution'] == 'Debian' and
+             ansible_facts['distribution_major_version'] == '13') or
+            (ansible_facts['distribution'] == 'Rocky' and
+             ansible_facts['distribution_major_version'] == '9')
         fail_msg: >-
           complete provisioning supports Debian 13 and Rocky Linux 9 only
 

--- a/roles/prepare_cifs_storage/tasks/main.yml
+++ b/roles/prepare_cifs_storage/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Include setup tasks for specific OS families
-  ansible.builtin.include_tasks: setup-{{ ansible_os_family }}.yml
-  when: ansible_os_family in ['Debian']
+  ansible.builtin.include_tasks: setup-{{ ansible_facts['os_family'] }}.yml
+  when: ansible_facts['os_family'] in ['Debian']

--- a/roles/security_baseline/files/validate_repository_trust.py
+++ b/roles/security_baseline/files/validate_repository_trust.py
@@ -13,7 +13,10 @@ from collections.abc import Mapping
 
 
 DEBIAN_ALLOWED_HOSTS = {"deb.debian.org", "security.debian.org"}
-DEBIAN_ARCHIVE_KEYRING = "/usr/share/keyrings/debian-archive-keyring.gpg"
+DEBIAN_ARCHIVE_KEYRINGS = {
+    "/usr/share/keyrings/debian-archive-keyring.gpg",
+    "/usr/share/keyrings/debian-archive-keyring.pgp",
+}
 DEBIAN_GLOBAL_BYPASSES = {
     "Acquire::AllowInsecureRepositories",
     "Acquire::AllowWeakRepositories",
@@ -78,9 +81,9 @@ def _apt_path(config: Mapping[str, str], leaf: str) -> str:
 
 def _require_debian_archive_key(value: str, root: pathlib.Path) -> None:
     keys = value.split()
-    if keys != [DEBIAN_ARCHIVE_KEYRING]:
+    if len(keys) != 1 or keys[0] not in DEBIAN_ARCHIVE_KEYRINGS:
         raise ValueError("Debian source does not use the distribution archive keyring")
-    if not _rooted(root, DEBIAN_ARCHIVE_KEYRING).is_file():
+    if not _rooted(root, keys[0]).is_file():
         raise ValueError("Debian distribution archive keyring is absent")
 
 

--- a/roles/security_baseline/tasks/firewall.yml
+++ b/roles/security_baseline/tasks/firewall.yml
@@ -71,7 +71,7 @@
              security_baseline_firewall_management.interface
                if security_baseline_apply_firewall_runtime | bool else '',
              true,
-             ansible_os_family
+             ansible_facts['os_family']
            ) }}
   ansible.builtin.assert:
     that:
@@ -105,7 +105,7 @@
              security_baseline_firewall_runtime_global_before.policies,
              security_baseline_firewall_management.interface | default(''),
              true,
-             ansible_os_family
+             ansible_facts['os_family']
            ) }}
   ansible.builtin.assert:
     that:
@@ -369,7 +369,6 @@
 
 - name: Reset connection after management interface binding
   ansible.builtin.meta: reset_connection
-  when: security_baseline_apply_firewall_runtime | bool
 
 - name: Prove desired management path before removing stale firewall rules
   ansible.builtin.wait_for_connection:
@@ -660,7 +659,7 @@
              security_baseline_firewall_management.interface
                if security_baseline_apply_firewall_runtime | bool else '',
              false,
-             ansible_os_family
+             ansible_facts['os_family']
            ) }}
   ansible.builtin.assert:
     that:
@@ -692,7 +691,7 @@
              security_baseline_firewall_runtime_global_after.policies,
              security_baseline_firewall_management.interface,
              false,
-             ansible_os_family
+             ansible_facts['os_family']
            ) }}
   ansible.builtin.assert:
     that:
@@ -729,7 +728,6 @@
 
 - name: Reset connection after exact firewall reconciliation
   ansible.builtin.meta: reset_connection
-  when: security_baseline_apply_firewall_runtime | bool
 
 - name: Prove a new connection through exact firewall policy
   ansible.builtin.wait_for_connection:

--- a/roles/security_baseline/tasks/logging.yml
+++ b/roles/security_baseline/tasks/logging.yml
@@ -75,13 +75,13 @@
     - name: Validate audit package platform support
       ansible.builtin.assert:
         that:
-          - ansible_os_family in security_baseline_audit_packages
+          - ansible_facts['os_family'] in security_baseline_audit_packages
         fail_msg: >-
-          Unsupported audit package platform: {{ ansible_os_family }}
+          Unsupported audit package platform: {{ ansible_facts['os_family'] }}
 
     - name: Install platform audit package
       ansible.builtin.package:
-        name: "{{ security_baseline_audit_packages[ansible_os_family] }}"
+        name: "{{ security_baseline_audit_packages[ansible_facts['os_family']] }}"
         state: present
 
 - name: Enable and start auditd with vendor rules

--- a/roles/security_baseline/tasks/mac.yml
+++ b/roles/security_baseline/tasks/mac.yml
@@ -5,18 +5,18 @@
       - policycoreutils
       - selinux-policy-targeted
     state: present
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Read Rocky SELinux state
   ansible.builtin.command:
     argv: [/usr/sbin/getenforce]
   register: security_baseline_selinux_state
   changed_when: false
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Prepare disabled Rocky SELinux for a permissive relabel boot
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
     - security_baseline_apply_kernel_controls | bool
     - security_baseline_selinux_state.stdout | trim == 'Disabled'
   block:
@@ -47,7 +47,7 @@
     update_kernel_param: true
   register: security_baseline_selinux_enforcing
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
     - security_baseline_apply_kernel_controls | bool
     - security_baseline_selinux_state.stdout | trim in ['Permissive', 'Enforcing']
 
@@ -58,7 +58,7 @@
          or (security_baseline_selinux_enforcing.reboot_required
              | default(false) | bool) }}
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
     - security_baseline_apply_kernel_controls | bool
     - security_baseline_selinux_state.stdout | trim in ['Permissive', 'Enforcing']
 
@@ -70,7 +70,7 @@
       - apparmor-profiles
     state: present
   when:
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Enable and start Debian AppArmor
   ansible.builtin.systemd_service:
@@ -78,5 +78,5 @@
     enabled: true
     state: started
   when:
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
     - security_baseline_apply_kernel_controls | bool

--- a/roles/security_baseline/tasks/main.yml
+++ b/roles/security_baseline/tasks/main.yml
@@ -7,10 +7,10 @@
   ansible.builtin.assert:
     that:
       - >-
-        (ansible_distribution == 'Debian' and
-         ansible_distribution_major_version == '13') or
-        (ansible_distribution == 'Rocky' and
-         ansible_distribution_major_version == '9')
+        (ansible_facts['distribution'] == 'Debian' and
+         ansible_facts['distribution_major_version'] == '13') or
+        (ansible_facts['distribution'] == 'Rocky' and
+         ansible_facts['distribution_major_version'] == '9')
       - ansible_user | default('') == 'ansible'
       - security_baseline_authorized_keys | length > 0
       - security_baseline_management_sources | length > 0

--- a/roles/security_baseline/tasks/maintenance-preflight.yml
+++ b/roles/security_baseline/tasks/maintenance-preflight.yml
@@ -1,7 +1,7 @@
 ---
 - name: Verify effective distribution repository trust
   ansible.builtin.script:
-    cmd: validate_repository_trust.py "{{ ansible_os_family }}"
+    cmd: validate_repository_trust.py "{{ ansible_facts['os_family'] }}"
     executable: /usr/bin/python3
   changed_when: false
 
@@ -10,17 +10,17 @@
     argv: [/usr/bin/dpkg, --audit]
   register: security_baseline_maintenance_debian_package_health
   changed_when: false
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Require consistent Debian package manager state
   ansible.builtin.assert:
     that:
       - security_baseline_maintenance_debian_package_health.stdout | trim == ''
     fail_msg: dpkg reports packages requiring repair; no update was started
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Check Rocky package manager consistency
   ansible.builtin.command:
     argv: [/usr/bin/dnf, check]
   changed_when: false
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/security_baseline/tasks/pre-update.yml
+++ b/roles/security_baseline/tasks/pre-update.yml
@@ -10,11 +10,11 @@
   loop:
     - gpgcheck
     - localpkg_gpgcheck
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Validate effective distribution repository trust
   ansible.builtin.script:
-    cmd: validate_repository_trust.py "{{ ansible_os_family }}"
+    cmd: validate_repository_trust.py "{{ ansible_facts['os_family'] }}"
     executable: /usr/bin/python3
   changed_when: false
 
@@ -26,7 +26,7 @@
     state: present
     fail_on_autoremove: true
     lock_timeout: 300
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install Rocky repository trust and time packages
   ansible.builtin.dnf:
@@ -35,11 +35,11 @@
       - chrony
     state: present
     lock_timeout: 300
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Enable and start platform time synchronization
   ansible.builtin.systemd_service:
-    name: "{{ 'systemd-timesyncd' if ansible_os_family == 'Debian' else 'chronyd' }}"
+    name: "{{ 'systemd-timesyncd' if ansible_facts['os_family'] == 'Debian' else 'chronyd' }}"
     enabled: true
     state: started
   when: security_baseline_apply_time_runtime | bool

--- a/roles/semaphore/tasks/main.yml
+++ b/roles/semaphore/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Ensure compose directory exists
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/compose/{{ role_name }}"
+    path: "{{ ansible_facts['user_dir'] }}/compose/{{ role_name }}"
     state: directory
     mode: '0755'
 
 - name: Deploy Docker Compose file
   ansible.builtin.template:
     src: docker-compose.yml.j2
-    dest: "{{ ansible_user_dir }}/compose/{{ role_name }}/docker-compose.yml"
+    dest: "{{ ansible_facts['user_dir'] }}/compose/{{ role_name }}/docker-compose.yml"
     mode: '0644'

--- a/roles/system_maintenance/molecule/baseline/Containerfile.debian13
+++ b/roles/system_maintenance/molecule/baseline/Containerfile.debian13
@@ -10,9 +10,6 @@ RUN apt-get update \
         passwd \
         sudo \
         systemd \
-    && sed -i \
-        's#/usr/share/keyrings/debian-archive-keyring\.pgp#/usr/share/keyrings/debian-archive-keyring.gpg#g' \
-        /etc/apt/sources.list.d/debian.sources \
     && useradd --create-home --shell /bin/bash ansible \
     && passwd --lock ansible \
     && install --directory --mode=0750 /etc/sudoers.d \

--- a/roles/system_maintenance/molecule/baseline/verify.yml
+++ b/roles/system_maintenance/molecule/baseline/verify.yml
@@ -250,7 +250,7 @@
                  system_maintenance_molecule_baseline_direct_firewall.results,
                  system_maintenance_molecule_baseline_firewall_bindings.stdout,
                  system_maintenance_molecule_baseline_firewall_policies.stdout,
-                 ansible_os_family) }}
+                 ansible_facts['os_family']) }}
       ansible.builtin.assert:
         that:
           - system_maintenance_molecule_baseline_firewall_problems | length == 0
@@ -261,13 +261,13 @@
       ansible.builtin.slurp:
         src: /etc/apparmor/parser.conf
       register: system_maintenance_molecule_baseline_apparmor_configuration
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Read Rocky SELinux configuration evidence
       ansible.builtin.slurp:
         src: /etc/selinux/config
       register: system_maintenance_molecule_baseline_selinux_configuration
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Verify platform-native MAC and time provider packages
       ansible.builtin.assert:
@@ -276,7 +276,7 @@
             ('apparmor' in ansible_facts.packages and
              'systemd-timesyncd' in ansible_facts.packages and
              system_maintenance_molecule_baseline_apparmor_configuration.content | b64decode | length > 0)
-            if ansible_os_family == 'Debian'
+            if ansible_facts['os_family'] == 'Debian'
             else
             ('selinux-policy-targeted' in ansible_facts.packages and
              'chrony' in ansible_facts.packages and
@@ -307,13 +307,13 @@
         argv: [/usr/bin/apt-config, dump]
       register: system_maintenance_molecule_baseline_debian_updater
       changed_when: false
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Read Rocky dnf-automatic policy
       ansible.builtin.slurp:
         src: /etc/dnf/automatic.conf
       register: system_maintenance_molecule_baseline_rocky_updater
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Read native security updater timer configuration
       ansible.builtin.command:
@@ -322,7 +322,7 @@
           - cat-config
           - >-
             {{ 'systemd/system/apt-daily-upgrade.timer'
-               if ansible_os_family == 'Debian'
+               if ansible_facts['os_family'] == 'Debian'
                else 'systemd/system/dnf-automatic.timer' }}
       register: system_maintenance_molecule_baseline_updater_timer
       changed_when: false
@@ -334,7 +334,7 @@
           - is-enabled
           - >-
             {{ 'apt-daily-upgrade.timer'
-               if ansible_os_family == 'Debian'
+               if ansible_facts['os_family'] == 'Debian'
                else 'dnf-automatic.timer' }}
       register: system_maintenance_molecule_baseline_updater_timer_enabled
       changed_when: false
@@ -346,7 +346,7 @@
               | system_maintenance_molecule_baseline_debian_updater_errors(
                   system_maintenance_molecule_baseline_updater_timer.stdout,
                   system_maintenance_molecule_baseline_updater_timer_enabled.stdout))
-             if ansible_os_family == 'Debian'
+             if ansible_facts['os_family'] == 'Debian'
              else
              (system_maintenance_molecule_baseline_rocky_updater.content
               | b64decode
@@ -360,7 +360,7 @@
     - name: Verify the minimum package set and excluded ownership
       ansible.builtin.assert:
         that:
-          - system_maintenance_molecule_baseline_minimum_packages[ansible_os_family] | difference(ansible_facts.packages.keys()) | length == 0
+          - system_maintenance_molecule_baseline_minimum_packages[ansible_facts['os_family']] | difference(ansible_facts.packages.keys()) | length == 0
           - "'epel-release' not in ansible_facts.packages"
           - "'fail2ban' not in ansible_facts.packages"
 

--- a/roles/system_maintenance/molecule/default/verify.yml
+++ b/roles/system_maintenance/molecule/default/verify.yml
@@ -56,7 +56,7 @@
     - name: Assert Debian native security maintenance
       ansible.builtin.assert:
         that:
-          - ansible_os_family == 'Debian'
+          - ansible_facts['os_family'] == 'Debian'
           - "'unattended-upgrades' in ansible_facts.packages"
           - system_maintenance_molecule_debian_timer.stdout | trim == 'enabled'
           - >-
@@ -86,7 +86,7 @@
     - name: Assert Rocky native security maintenance
       ansible.builtin.assert:
         that:
-          - ansible_os_family == 'RedHat'
+          - ansible_facts['os_family'] == 'RedHat'
           - "'dnf-automatic' in ansible_facts.packages"
           - system_maintenance_molecule_rocky_timer.stdout | trim == 'enabled'
           - >-

--- a/roles/system_maintenance/tasks/automatic-updates.yml
+++ b/roles/system_maintenance/tasks/automatic-updates.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include automatic security update tasks for the operating system family
-  ansible.builtin.include_tasks: 'automatic-updates-{{ ansible_os_family }}.yml'
+  ansible.builtin.include_tasks: "automatic-updates-{{ ansible_facts['os_family'] }}.yml"
   when:
     - system_maintenance_configure_automatic_updates | bool
-    - ansible_os_family in ['Debian', 'RedHat']
+    - ansible_facts['os_family'] in ['Debian', 'RedHat']

--- a/roles/system_maintenance/tasks/full-update.yml
+++ b/roles/system_maintenance/tasks/full-update.yml
@@ -1,3 +1,3 @@
 ---
 - name: Include full update tasks for the operating system family
-  ansible.builtin.include_tasks: 'setup-{{ ansible_os_family }}.yml'
+  ansible.builtin.include_tasks: "setup-{{ ansible_facts['os_family'] }}.yml"

--- a/roles/system_maintenance/tasks/main.yml
+++ b/roles/system_maintenance/tasks/main.yml
@@ -2,10 +2,10 @@
 - name: Assert the host uses the supported operating system family
   ansible.builtin.assert:
     that:
-    - ansible_os_family in ['Debian', 'RedHat']
+    - ansible_facts['os_family'] in ['Debian', 'RedHat']
     fail_msg: >-
       system-maintenance does not support operating-system family
-      received {{ ansible_os_family }}
+      received {{ ansible_facts['os_family'] }}
 
 - name: Run the explicit full update
   ansible.builtin.import_tasks: full-update.yml

--- a/roles/system_maintenance/tasks/reboot-state.yml
+++ b/roles/system_maintenance/tasks/reboot-state.yml
@@ -1,4 +1,4 @@
 ---
 - name: Include reboot-state tasks for the operating system family
-  ansible.builtin.include_tasks: 'reboot-state-{{ ansible_os_family }}.yml'
-  when: ansible_os_family in ['Debian', 'RedHat']
+  ansible.builtin.include_tasks: "reboot-state-{{ ansible_facts['os_family'] }}.yml"
+  when: ansible_facts['os_family'] in ['Debian', 'RedHat']

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -603,6 +603,7 @@ def run_platform(
         molecule_environment["ANSIBLE_COLLECTIONS_PATH"] = str(
             repo_root / ".ansible" / "collections"
         )
+        molecule_environment["ANSIBLE_INJECT_FACT_VARS"] = "False"
         molecule_environment["HOMELAB_MOLECULE_PLATFORM"] = (
             platform_definition.name
         )

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -440,7 +440,6 @@ class MoleculeScenarioContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertNotIn("python3", debian)
-        self.assertIn("debian-archive-keyring.gpg", debian)
         self.assertIn("python3", rocky)
         self.assertIn("rm -f /usr/bin/python3", rocky)
         self.assertNotIn("/usr/libexec/platform-python", rocky.split("rm -f", 1)[1])

--- a/tests/ansible/test_platform_control_contracts.py
+++ b/tests/ansible/test_platform_control_contracts.py
@@ -79,6 +79,21 @@ Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
             apt_config = self.write_debian_fixture(root, stanza)
             self.repository_trust.validate_debian_configuration(apt_config, root)
 
+    def test_debian_accepts_installer_archive_keyring(self) -> None:
+        stanza = """\
+Types: deb
+URIs: https://deb.debian.org/debian
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.pgp
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            apt_config = self.write_debian_fixture(root, stanza)
+            keyring = root / "usr/share/keyrings/debian-archive-keyring.pgp"
+            keyring.touch()
+            self.repository_trust.validate_debian_configuration(apt_config, root)
+
     def test_debian_rejects_each_source_authentication_bypass(self) -> None:
         bypasses = (
             "Trusted: yes",
@@ -962,6 +977,13 @@ homelab (active)
             "Verify runtime and permanent default firewall zones"
         )
         final_proof = names.index("Prove a new connection through exact firewall policy")
+        reset_tasks = [
+            task
+            for task in tasks
+            if task.get("ansible.builtin.meta") == "reset_connection"
+        ]
+        self.assertEqual(2, len(reset_tasks))
+        self.assertTrue(all("when" not in task for task in reset_tasks))
         self.assertLess(binding_proof, first_proof)
         self.assertLess(first_proof, cleanup)
         self.assertLess(cleanup, exact)
@@ -1059,11 +1081,11 @@ SystemMaxUse=128M
         )
         validate, install = audit["block"]
         self.assertIn(
-            "ansible_os_family in security_baseline_audit_packages",
+            "ansible_facts['os_family'] in security_baseline_audit_packages",
             validate["ansible.builtin.assert"]["that"],
         )
         self.assertEqual(
-            "{{ security_baseline_audit_packages[ansible_os_family] }}",
+            "{{ security_baseline_audit_packages[ansible_facts['os_family']] }}",
             install["ansible.builtin.package"]["name"],
         )
 
@@ -1078,7 +1100,7 @@ SystemMaxUse=128M
             ["policycoreutils", "selinux-policy-targeted"],
             install["ansible.builtin.package"]["name"],
         )
-        self.assertEqual("ansible_os_family == 'RedHat'", install["when"])
+        self.assertEqual("ansible_facts['os_family'] == 'RedHat'", install["when"])
 
 
 if __name__ == "__main__":

--- a/tests/ansible/test_source_contracts.py
+++ b/tests/ansible/test_source_contracts.py
@@ -96,18 +96,18 @@ READ_ONLY_ARGV_TEMPLATES = {
     "{{ ['/usr/bin/firewall-cmd', item] }}",
     "{{ ['/usr/bin/firewall-offline-cmd', '--direct', item] }}",
     "{{ ['/usr/bin/firewall-cmd', '--direct', item] }}",
-    "{{ ['/usr/bin/systemctl', 'is-enabled',\n    {{ 'apt-daily-upgrade.timer' if ansible_os_family == 'Debian'\n       else 'dnf-automatic.timer' }}] }}",
-    "{{ ['/usr/bin/systemd-analyze', 'cat-config',\n    {{ 'systemd/system/apt-daily-upgrade.timer'\n       if ansible_os_family == 'Debian'\n       else 'systemd/system/dnf-automatic.timer' }}] }}",
+    "{{ ['/usr/bin/systemctl', 'is-enabled',\n    {{ 'apt-daily-upgrade.timer' if ansible_facts['os_family'] == 'Debian'\n       else 'dnf-automatic.timer' }}] }}",
+    "{{ ['/usr/bin/systemd-analyze', 'cat-config',\n    {{ 'systemd/system/apt-daily-upgrade.timer'\n       if ansible_facts['os_family'] == 'Debian'\n       else 'systemd/system/dnf-automatic.timer' }}] }}",
 }
 
 READ_ONLY_ARGV_DYNAMIC_LISTS = {
     (
         "/usr/bin/systemctl", "is-enabled",
-        "{{ 'apt-daily-upgrade.timer' if ansible_os_family == 'Debian'\n   else 'dnf-automatic.timer' }}",
+        "{{ 'apt-daily-upgrade.timer' if ansible_facts['os_family'] == 'Debian'\n   else 'dnf-automatic.timer' }}",
     ),
     (
         "/usr/bin/systemd-analyze", "cat-config",
-        "{{ 'systemd/system/apt-daily-upgrade.timer'\n   if ansible_os_family == 'Debian'\n   else 'systemd/system/dnf-automatic.timer' }}",
+        "{{ 'systemd/system/apt-daily-upgrade.timer'\n   if ansible_facts['os_family'] == 'Debian'\n   else 'systemd/system/dnf-automatic.timer' }}",
     ),
 }
 
@@ -592,7 +592,8 @@ class SourceContractTests(unittest.TestCase):
             "ansible.builtin.import_role",
             {"name": "security_baseline", "tasks_from": "mac.yml"},
         )
-        for index in (reset, setup, post_boot):
+        self.assertNotIn("when", provisioning_pre[reset])
+        for index in (setup, post_boot):
             self.assertEqual("os_reboot_performed | bool", provisioning_pre[index]["when"])
         assert_strictly_ordered(
             identity,
@@ -648,8 +649,8 @@ class SourceContractTests(unittest.TestCase):
             "ansible.builtin.assert"
         ]["that"]
         self.assertEqual(1, len(maintenance_platform_contract))
-        self.assertIn("ansible_distribution == 'Debian'", maintenance_platform_contract[0])
-        self.assertIn("ansible_distribution == 'Rocky'", maintenance_platform_contract[0])
+        self.assertIn("ansible_facts['distribution'] == 'Debian'", maintenance_platform_contract[0])
+        self.assertIn("ansible_facts['distribution'] == 'Rocky'", maintenance_platform_contract[0])
         self.assertEqual(
             "os maintenance supports Debian 13 and Rocky Linux 9 only",
             normalize_expression(
@@ -742,10 +743,10 @@ class SourceContractTests(unittest.TestCase):
             if task["name"]
             == "Gather facts after an Ansible-controlled reboot"
         )
-        for index in (maintenance_reset, maintenance_setup):
-            self.assertEqual(
-                "os_reboot_performed | bool", maintenance_pre[index]["when"]
-            )
+        self.assertNotIn("when", maintenance_pre[maintenance_reset])
+        self.assertEqual(
+            "os_reboot_performed | bool", maintenance_pre[maintenance_setup]["when"]
+        )
         assert_strictly_ordered(
             maintenance_connection_preflight,
             maintenance_initial_setup,
@@ -872,8 +873,8 @@ class SourceContractTests(unittest.TestCase):
     def test_os_maintenance_rejects_unsupported_distribution_releases(self) -> None:
         """Full maintenance must stop before updating unsupported family members."""
         unsupported = (
-            {"ansible_os_family": "Debian", "ansible_distribution": "Debian", "ansible_distribution_major_version": "12"},
-            {"ansible_os_family": "RedHat", "ansible_distribution": "RedHat", "ansible_distribution_major_version": "9"},
+            {"os_family": "Debian", "distribution": "Debian", "distribution_major_version": "12"},
+            {"os_family": "RedHat", "distribution": "RedHat", "distribution_major_version": "9"},
         )
         for facts in unsupported:
             with self.subTest(facts=facts):
@@ -891,7 +892,7 @@ class SourceContractTests(unittest.TestCase):
                         "--start-at-task",
                         "Validate full-maintenance platform support",
                         "--extra-vars",
-                        str({"ansible_become": False, **facts}),
+                        str({"ansible_become": False, "ansible_facts": facts}),
                     ],
                     cwd=REPOSITORY_ROOT,
                     check=False,
@@ -935,7 +936,7 @@ class SourceContractTests(unittest.TestCase):
             [task["name"] for task in tasks],
         )
         self.assertEqual(
-            {"cmd": "validate_repository_trust.py \"{{ ansible_os_family }}\"", "executable": "/usr/bin/python3"},
+            {"cmd": "validate_repository_trust.py \"{{ ansible_facts['os_family'] }}\"", "executable": "/usr/bin/python3"},
             tasks[0]["ansible.builtin.script"],
         )
         self.assertIs(tasks[0]["changed_when"], False)
@@ -1165,13 +1166,16 @@ class SourceContractTests(unittest.TestCase):
             for task in access_tasks
             if task["name"] == "Verify authoritative ansible access records"
         )
+        access_conditions = access_assert["ansible.builtin.assert"]["that"]
+        self.assertIn("'ansible' in ansible_facts['getent_passwd']", access_conditions)
+        self.assertIn("'ansible' in ansible_facts['getent_shadow']", access_conditions)
         self.assertIn(
             "os_baseline_verify_authorized_key_lines "
             "== (os_baseline_verify_expected_authorized_keys "
             "| map('trim') | list | sort)",
             [
                 normalize_expression(assertion)
-                for assertion in access_assert["ansible.builtin.assert"]["that"]
+                for assertion in access_conditions
             ],
         )
 
@@ -1329,7 +1333,7 @@ class SourceContractTests(unittest.TestCase):
             if "ansible.builtin.import_role" in task
         ]
         self.assertEqual(
-            ["ansible_os_family in ['Debian', 'RedHat']"],
+            ["ansible_facts['os_family'] in ['Debian', 'RedHat']"],
             platform_preflight["ansible.builtin.assert"]["that"],
         )
         self.assertTrue(imported_role_indices)
@@ -1353,7 +1357,7 @@ class SourceContractTests(unittest.TestCase):
                 "--start-at-task",
                 "Validate complete provisioning platform support",
                 "--extra-vars",
-                '{"ansible_become": false, "ansible_os_family": "Archlinux"}',
+                '{"ansible_become": false, "ansible_facts": {"os_family": "Archlinux"}}',
             ],
             cwd=REPOSITORY_ROOT,
             check=False,
@@ -1428,11 +1432,11 @@ class SourceContractTests(unittest.TestCase):
             first_task["ansible.builtin.assert"],
             {
                 "that": [
-                    "ansible_os_family in ['Debian', 'RedHat']"
+                    "ansible_facts['os_family'] in ['Debian', 'RedHat']"
                 ],
                 "fail_msg": (
                     "system-maintenance does not support operating-system family "
-                    "received {{ ansible_os_family }}"
+                    "received {{ ansible_facts['os_family'] }}"
                 ),
             },
         )
@@ -1457,7 +1461,7 @@ class SourceContractTests(unittest.TestCase):
         self.assertEqual(
             [
                 "system_maintenance_configure_automatic_updates | bool",
-                "ansible_os_family in ['Debian', 'RedHat']",
+                "ansible_facts['os_family'] in ['Debian', 'RedHat']",
             ],
             automatic_updates["when"],
         )
@@ -1465,7 +1469,7 @@ class SourceContractTests(unittest.TestCase):
             "roles/system_maintenance/tasks/reboot-state.yml"
         )[0]
         self.assertEqual(
-            "ansible_os_family in ['Debian', 'RedHat']",
+            "ansible_facts['os_family'] in ['Debian', 'RedHat']",
             reboot_state["when"],
         )
 
@@ -1476,11 +1480,11 @@ class SourceContractTests(unittest.TestCase):
         supported_families = ("Debian",)
 
         self.assertEqual(
-            "setup-{{ ansible_os_family }}.yml",
+            "setup-{{ ansible_facts['os_family'] }}.yml",
             dispatch_task["ansible.builtin.include_tasks"],
         )
         self.assertEqual(
-            "ansible_os_family in ['Debian']",
+            "ansible_facts['os_family'] in ['Debian']",
             dispatch_task["when"],
         )
         for os_family in supported_families:
@@ -1780,8 +1784,8 @@ class SourceContractTests(unittest.TestCase):
         )
         self.assertEqual("targeted", selinux["ansible.posix.selinux"]["policy"])
         self.assertEqual("enforcing", selinux["ansible.posix.selinux"]["state"])
-        self.assertIn("ansible_os_family == 'RedHat'", selinux["when"])
-        self.assertIn("ansible_os_family == 'Debian'", apparmor["when"])
+        self.assertIn("ansible_facts['os_family'] == 'RedHat'", selinux["when"])
+        self.assertIn("ansible_facts['os_family'] == 'Debian'", apparmor["when"])
 
     def test_logging_uses_persistent_bounded_journal(self) -> None:
         template = (
@@ -1825,16 +1829,16 @@ class SourceContractTests(unittest.TestCase):
             {"name": ["ca-certificates", "systemd-timesyncd"], "state": "present", "fail_on_autoremove": True, "lock_timeout": 300},
             debian["ansible.builtin.apt"],
         )
-        self.assertEqual("ansible_os_family == 'Debian'", debian["when"])
+        self.assertEqual("ansible_facts['os_family'] == 'Debian'", debian["when"])
         self.assertNotIn("security_baseline_apply_time_runtime", str(debian))
         self.assertEqual(
             {"name": ["ca-certificates", "chrony"], "state": "present", "lock_timeout": 300},
             rocky["ansible.builtin.dnf"],
         )
-        self.assertEqual("ansible_os_family == 'RedHat'", rocky["when"])
+        self.assertEqual("ansible_facts['os_family'] == 'RedHat'", rocky["when"])
         self.assertNotIn("security_baseline_apply_time_runtime", str(rocky))
         self.assertEqual(
-            "{{ 'systemd-timesyncd' if ansible_os_family == 'Debian' else 'chronyd' }}",
+            "{{ 'systemd-timesyncd' if ansible_facts['os_family'] == 'Debian' else 'chronyd' }}",
             runtime["ansible.builtin.systemd_service"]["name"],
         )
         self.assertEqual("security_baseline_apply_time_runtime | bool", runtime["when"])
@@ -1864,7 +1868,7 @@ class SourceContractTests(unittest.TestCase):
                 self.assertEqual(argv, task["ansible.builtin.command"]["argv"])
                 self.assertIs(False, task["changed_when"])
                 self.assertEqual(
-                    ["os_baseline_verify_runtime_controls | bool", "ansible_os_family == 'Debian'" if "Debian" in name else "ansible_os_family == 'RedHat'"],
+                    ["os_baseline_verify_runtime_controls | bool", "ansible_facts['os_family'] == 'Debian'" if "Debian" in name else "ansible_facts['os_family'] == 'RedHat'"],
                     task["when"],
                 )
 
@@ -2367,6 +2371,7 @@ class SourceContractTests(unittest.TestCase):
 
         self.assertEqual(config["defaults"]["roles_path"], "./.ansible/roles:./roles")
         self.assertEqual(config["defaults"]["collections_path"], "./.ansible/collections")
+        self.assertEqual(config["defaults"]["inject_facts_as_vars"], "false")
 
     def test_ansible_cfg_does_not_disable_host_key_checking(self) -> None:
         """Host-key verification must remain enabled unless Ansible's default is used."""

--- a/tests/ci/test_molecule_runner.py
+++ b/tests/ci/test_molecule_runner.py
@@ -863,6 +863,10 @@ class PlatformWorkerTests(unittest.TestCase):
             "system_maintenance/default",
             molecule_call[2].get("HOMELAB_MOLECULE_SCENARIO_SELECTOR"),
         )
+        self.assertEqual(
+            "False",
+            molecule_call[2].get("ANSIBLE_INJECT_FACT_VARS"),
+        )
 
     def test_worker_cleans_up_after_each_primary_stage_failure(self) -> None:
         cases = (


### PR DESCRIPTION
Closes #2

## Summary

- Accept Debian 13 installer archive keyrings while keeping repository trust validation fail-closed.
- Replace deprecated injected Ansible facts with `ansible_facts` and disable legacy fact injection in repository and Molecule runs.
- Remove unsupported `reset_connection` conditions and test the production-like Debian source configuration.

## Validation

- `mise run ci`
- `mise run ci:changed`

No production or staging playbook was run as part of validation.