### PR TITLE
Pin legacy Debian repository sources

### DIFF
--- a/docs/specs/003-os-maintenance-security-baseline.md
+++ b/docs/specs/003-os-maintenance-security-baseline.md
@@ -214,6 +214,14 @@ and DNF repository GPG checks. It does not import third-party signing keys or
 enable EPEL by default. Later roles must own and justify any additional
 repository.
 
+Debian sources select the package-owned Debian archive keyring explicitly.
+Before trust validation, provisioning adds that restriction to official Debian
+repositories in legacy one-line source files that omit `Signed-By`. It
+preserves their selected suites and components. The trust preflight then
+rejects an unpinned source, a third-party source, or an authentication bypass.
+This supports both Debian source formats without relying on APT's broader
+global trusted-key store.
+
 The baseline package set contains only packages required for:
 
 - the Python and sudo management path;

--- a/roles/security_baseline/tasks/pre-update.yml
+++ b/roles/security_baseline/tasks/pre-update.yml
@@ -12,6 +12,62 @@
     - localpkg_gpgcheck
   when: ansible_facts['os_family'] == 'RedHat'
 
+- name: Inspect the primary legacy Debian repository source
+  ansible.builtin.stat:
+    path: /etc/apt/sources.list
+    follow: false
+  register: security_baseline_debian_primary_legacy_source
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Find legacy Debian repository source fragments
+  ansible.builtin.find:
+    paths: /etc/apt/sources.list.d
+    patterns: '*.list'
+    file_type: file
+    recurse: false
+    follow: false
+  register: security_baseline_debian_legacy_source_fragments
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Record legacy Debian repository source files
+  ansible.builtin.set_fact:
+    security_baseline_debian_legacy_source_files: >-
+      {{
+        (['/etc/apt/sources.list']
+         if (security_baseline_debian_primary_legacy_source.stat.isreg
+             | default(false))
+         else [])
+        + (security_baseline_debian_legacy_source_fragments.files
+           | map(attribute='path') | list)
+      }}
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Pin unqualified legacy Debian repository sources
+  ansible.builtin.replace:
+    path: "{{ item }}"
+    regexp: >-
+      (?x)
+      ^(\s*deb(?:-src)?\s+)
+      (https?://(?:deb\.debian\.org/debian/?|security\.debian\.org/debian-security/?)\s+)
+    replace: >-
+      \g<1>[signed-by=/usr/share/keyrings/debian-archive-keyring.pgp] \g<2>
+  loop: "{{ security_baseline_debian_legacy_source_files }}"
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Pin optioned legacy Debian repository sources
+  ansible.builtin.replace:
+    path: "{{ item }}"
+    regexp: >-
+      (?x)
+      ^(\s*deb(?:-src)?\s+\[)
+      (?![^\]]*(?i:signed-by)=)
+      ([^\]]*\]\s+)
+      (https?://(?:deb\.debian\.org/debian/?|security\.debian\.org/debian-security/?)\s+)
+    replace: >-
+      \g<1>signed-by=/usr/share/keyrings/debian-archive-keyring.pgp \g<2>\g<3>
+  loop: "{{ security_baseline_debian_legacy_source_files }}"
+  when: ansible_facts['os_family'] == 'Debian'
+
 - name: Validate effective distribution repository trust
   ansible.builtin.script:
     cmd: validate_repository_trust.py "{{ ansible_facts['os_family'] }}"

--- a/roles/system_maintenance/molecule/baseline/Containerfile.debian13
+++ b/roles/system_maintenance/molecule/baseline/Containerfile.debian13
@@ -15,6 +15,12 @@ RUN apt-get update \
     && install --directory --mode=0750 /etc/sudoers.d \
     && printf 'ansible ALL=(ALL:ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/90-installer-ansible \
     && chmod 0440 /etc/sudoers.d/90-installer-ansible \
+    && rm -f /etc/apt/sources.list.d/debian.sources \
+    && printf '%s\n' \
+        'deb http://deb.debian.org/debian/ trixie main non-free-firmware' \
+        'deb http://security.debian.org/debian-security trixie-security main non-free-firmware' \
+        'deb http://deb.debian.org/debian/ trixie-updates main non-free-firmware' \
+        > /etc/apt/sources.list \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/ansible/test_source_contracts.py
+++ b/tests/ansible/test_source_contracts.py
@@ -950,6 +950,71 @@ class SourceContractTests(unittest.TestCase):
             self.assertIs(task["changed_when"], False)
             self.assertNotIn("failed_when", task)
 
+    def test_provisioning_pins_legacy_debian_sources_before_trust_validation(
+        self,
+    ) -> None:
+        tasks = load_tasks("roles/security_baseline/tasks/pre-update.yml")
+        names = [task["name"] for task in tasks]
+        self.assertIn("Pin unqualified legacy Debian repository sources", names)
+        self.assertIn("Pin optioned legacy Debian repository sources", names)
+        plain = tasks[names.index("Pin unqualified legacy Debian repository sources")]
+        options = tasks[names.index("Pin optioned legacy Debian repository sources")]
+        validation = names.index("Validate effective distribution repository trust")
+
+        self.assertLess(tasks.index(plain), validation)
+        self.assertLess(tasks.index(options), validation)
+        self.assertEqual(
+            "ansible_facts['os_family'] == 'Debian'",
+            plain["when"],
+        )
+        self.assertEqual(
+            "ansible_facts['os_family'] == 'Debian'",
+            options["when"],
+        )
+
+        plain_replace = plain["ansible.builtin.replace"]
+        option_replace = options["ansible.builtin.replace"]
+        plain_source = "deb http://deb.debian.org/debian/ trixie main\n"
+        option_source = (
+            "deb [arch=amd64] http://security.debian.org/debian-security "
+            "trixie-security main\n"
+        )
+        already_pinned = (
+            "deb [signed-by=/usr/share/keyrings/debian-archive-keyring.pgp] "
+            "http://deb.debian.org/debian/ trixie main\n"
+        )
+        third_party = "deb https://packages.example.test/debian trixie main\n"
+        expected_key = "signed-by=/usr/share/keyrings/debian-archive-keyring.pgp"
+
+        normalized_plain = re.sub(
+            plain_replace["regexp"],
+            plain_replace["replace"],
+            plain_source,
+            flags=re.MULTILINE,
+        )
+        normalized_option = re.sub(
+            option_replace["regexp"],
+            option_replace["replace"],
+            option_source,
+            flags=re.MULTILINE,
+        )
+        normalized_pinned = re.sub(
+            option_replace["regexp"],
+            option_replace["replace"],
+            already_pinned,
+            flags=re.MULTILINE,
+        )
+        normalized_third_party = re.sub(
+            plain_replace["regexp"],
+            plain_replace["replace"],
+            third_party,
+            flags=re.MULTILINE,
+        )
+        self.assertIn(expected_key, normalized_plain)
+        self.assertIn(expected_key, normalized_option)
+        self.assertEqual(already_pinned, normalized_pinned)
+        self.assertEqual(third_party, normalized_third_party)
+
     def test_os_baseline_verifier_is_observational(self) -> None:
         task_paths = sorted(
             (REPOSITORY_ROOT / "roles/os_baseline_verify/tasks").glob("*.yml")


### PR DESCRIPTION
Closes #2

## Summary

- normalize official Debian legacy one-line sources to use the distribution archive keyring explicitly
- keep the strict repository trust validator instead of relying on the global APT trusted-key store
- exercise Debian 13 legacy sources through complete provisioning and idempotence

## Validation

- `mise run validate:fast`
- `mise run validate:ansible`
- `mise run test:molecule -- system_maintenance/baseline`
- `mise run ci:changed`

No production or staging playbook was run as part of validation.