### PR TITLE
Handle unbound management firewall interfaces

### DIFF
--- a/roles/security_baseline/tasks/firewall.yml
+++ b/roles/security_baseline/tasks/firewall.yml
@@ -269,13 +269,15 @@
   no_log: true
   when: security_baseline_apply_firewall_runtime | bool
 
-- name: Read runtime management interface zone
+- name: Query runtime homelab management interface binding
   ansible.builtin.command:
     argv:
       - /usr/bin/firewall-cmd
-      - "--get-zone-of-interface={{ security_baseline_firewall_management.interface }}"
-  register: security_baseline_firewall_management_runtime_zone
+      - --zone=homelab
+      - "--query-interface={{ security_baseline_firewall_management.interface }}"
+  register: security_baseline_firewall_management_runtime_binding
   changed_when: false
+  failed_when: security_baseline_firewall_management_runtime_binding.rc not in [0, 1]
   when: security_baseline_apply_firewall_runtime | bool
 
 - name: Bind runtime management interface to homelab
@@ -287,16 +289,18 @@
   changed_when: true
   when:
     - security_baseline_apply_firewall_runtime | bool
-    - security_baseline_firewall_management_runtime_zone.stdout | trim != 'homelab'
+    - security_baseline_firewall_management_runtime_binding.rc == 1
 
-- name: Read permanent management interface zone
+- name: Query permanent homelab management interface binding
   ansible.builtin.command:
     argv:
       - /usr/bin/firewall-cmd
       - --permanent
-      - "--get-zone-of-interface={{ security_baseline_firewall_management.interface }}"
-  register: security_baseline_firewall_management_permanent_zone
+      - --zone=homelab
+      - "--query-interface={{ security_baseline_firewall_management.interface }}"
+  register: security_baseline_firewall_management_permanent_binding
   changed_when: false
+  failed_when: security_baseline_firewall_management_permanent_binding.rc not in [0, 1]
   when: security_baseline_apply_firewall_runtime | bool
 
 - name: Persist management interface binding to homelab
@@ -309,7 +313,7 @@
   changed_when: true
   when:
     - security_baseline_apply_firewall_runtime | bool
-    - security_baseline_firewall_management_permanent_zone.stdout | trim != 'homelab'
+    - security_baseline_firewall_management_permanent_binding.rc == 1
 
 - name: Read back runtime management interface binding
   ansible.builtin.command:

--- a/tests/ansible/test_platform_control_contracts.py
+++ b/tests/ansible/test_platform_control_contracts.py
@@ -938,6 +938,50 @@ homelab (active)
             if runtime_only_target:
                 self.assertIn("--permanent", argv)
 
+    def test_unbound_management_interface_reaches_binding(self) -> None:
+        tasks = load_tasks("roles/security_baseline/tasks/firewall.yml")
+        names = [task["name"] for task in tasks]
+        expected_queries = {
+            "Query runtime homelab management interface binding": [
+                "/usr/bin/firewall-cmd",
+                "--zone=homelab",
+                "--query-interface={{ security_baseline_firewall_management.interface }}",
+            ],
+            "Query permanent homelab management interface binding": [
+                "/usr/bin/firewall-cmd",
+                "--permanent",
+                "--zone=homelab",
+                "--query-interface={{ security_baseline_firewall_management.interface }}",
+            ],
+        }
+
+        for name, expected_argv in expected_queries.items():
+            with self.subTest(task=name):
+                task = tasks[names.index(name)]
+                self.assertEqual(
+                    expected_argv,
+                    task["ansible.builtin.command"]["argv"],
+                )
+                register = task["register"]
+                self.assertEqual(
+                    f"{register}.rc not in [0, 1]",
+                    task["failed_when"],
+                )
+
+        bind_tasks = (
+            "Bind runtime management interface to homelab",
+            "Persist management interface binding to homelab",
+        )
+        for name in bind_tasks:
+            with self.subTest(task=name):
+                task = tasks[names.index(name)]
+                query_result = (
+                    "security_baseline_firewall_management_runtime_binding"
+                    if name.startswith("Bind runtime")
+                    else "security_baseline_firewall_management_permanent_binding"
+                )
+                self.assertIn(f"{query_result}.rc == 1", task["when"])
+
     def test_exact_policy_comparison_ignores_firewalld_output_order(self) -> None:
         rules = [
             (


### PR DESCRIPTION
Relates to #2

## Summary

- query whether the management interface belongs to the `homelab` zone using firewalld membership semantics
- treat return code 1 as the expected unbound state and continue to runtime and permanent binding
- keep every unexpected firewalld return code fatal
- add regression coverage for unbound and already-bound decisions

## Validation

- `mise run validate:fast`
- `mise run validate:ansible`
- `mise run ci:changed`
- independent read-only code review: no findings

No production or staging playbook was run as part of validation. Issue #2 remains open pending successful live provisioning.