### PR TITLE
Integrate host TLS publication with Caddy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
     needs: classify
     if: needs.classify.outputs.run_molecule == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/docs/guides/device-proxy.md
+++ b/docs/guides/device-proxy.md
@@ -4,8 +4,9 @@ The selected [hybrid TLS design](../specs/007-off-cluster-tls-trust.md) includes
 private HTTPS browser access to device management interfaces through the shared
 Caddy proxy on NUC #4. The host issuer and certificate publication capability
 are implemented with automatic renewal disabled by default; see the
-[TLS playbook README](../../playbooks/tls/README.md). The Caddy adapter and live
-device routes remain undeployed. Use this guide for their configuration and
+[TLS playbook README](../../playbooks/tls/README.md). The TLS role installs the
+Caddy adapter; live device routes require operator configuration and deployment.
+Use this guide for their configuration and
 acceptance procedure; it does not claim operational routes.
 
 Use one explicit route per device. Caddy presents the separately managed public
@@ -78,6 +79,32 @@ back to HTTP for a device that is expected to support authenticated HTTPS. After
 a device replacement or firmware change that replaces its certificate, repeat
 trust establishment before updating the route's trust material.
 
+Declare the route and its trust bundle in protected host variables. The following
+values are synthetic; replace the address, certificate name, and PEM placeholder
+with independently verified device inputs before deployment:
+
+```yaml
+reverse_proxy_deferred_certificates: [infra]
+reverse_proxy_routes:
+  - hostname: modem.infra.example.com
+    certificate_name: infra
+    backend:
+      transport: https
+      address: 10.20.30.50
+      port: 443
+      server_name: modem.example.test
+      trust_name: modem_v1
+reverse_proxy_trust_certificates:
+  modem_v1: |
+    <verified PEM trust bundle>
+```
+
+`server_name` must match the device certificate. The role installs `modem_v1`
+as `/etc/caddy/trust/modem_v1.pem`; only root can write it and Caddy can read it.
+An existing trust name cannot receive different contents. For a replacement
+certificate, add a new name such as `modem_v2` and update the route to use it.
+Keeping the old bundle lets a configuration rollback retain its previous trust.
+
 ### HTTP-only devices
 
 For the Room Alert 3E example, configure Caddy to use the explicit
@@ -94,6 +121,23 @@ between Caddy and the device. Do not describe this route as end-to-end encrypted
 Do not add a TLS trust pool, TLS server name, or disabled-verification option to
 an HTTP route. If a future firmware or replacement device provides HTTPS,
 evaluate and test authenticated HTTPS before changing the backend transport.
+
+Add the HTTP route to the same authoritative `reverse_proxy_routes` list:
+
+```yaml
+  - hostname: room-alert.infra.example.com
+    certificate_name: infra
+    backend:
+      transport: http
+      address: 10.20.30.60
+      port: 80
+```
+
+The address is synthetic. Both examples require private listener addresses and
+client networks as described in the
+[proxy README](../../playbooks/reverse-proxy/README.md). With `infra` explicitly
+deferred, provisioning saves these routes before the first certificate exists.
+Successful certificate publication activates them together.
 
 The proxy does not need stored administrator passwords for either transport; it
 forwards the browser session. Keep device certificate material and protected

--- a/docs/reference/repository-command-lifecycle.md
+++ b/docs/reference/repository-command-lifecycle.md
@@ -140,6 +140,22 @@ The [OS playbook README](../../playbooks/os/README.md) describes the subsystem.
 The [managed host onboarding guide](../guides/managed-host-onboarding.md)
 documents the exact operator interface and safeguards.
 
+### Host TLS and proxy operations
+
+The host Caddy helpers are internal operations, not alternate operator gateways.
+`homelab-reverse-proxy apply-desired` reconciles the declared configuration and
+its verified ingress binding; `reload` reopens selected certificates; `recover`
+restores interrupted disk state before service startup. These are mutating
+operations under an authorized provisioning, renewal, or service lifecycle.
+`verify` observes state. The fixed TLS adapter's `validate` prepares and checks
+a candidate without activating it; `reload` and `deactivate` mutate the managed
+routes and verify the result. The issuer cannot choose these operations or their
+paths. Operators continue to use `mise run playbook` with the applicable target
+authorization; invoking an internal helper does not supply new authority.
+`homelab-reverse-proxy install-trust` creates immutable device trust bundles from
+the fixed root-owned candidate under the deployment lock. It checks an existing
+name for exact contents and metadata and never replaces it.
+
 ### Dependency bootstrap
 
 ```text

--- a/docs/specs/003-os-maintenance-security-baseline.md
+++ b/docs/specs/003-os-maintenance-security-baseline.md
@@ -215,6 +215,15 @@ and DNF repository GPG checks. It does not import third-party signing keys or
 enable EPEL by default. Later roles must own and justify any additional
 repository.
 
+The managed Caddy role is the approved Rocky exception. Maintenance accepts
+the standard `epel` and `epel-cisco-openh264` repositories only when the existing
+`/var/lib/homelab-reverse-proxy/managed` ownership marker is a regular `root:root`
+`0600` file with one link and the exact managed content. These repositories must
+use the local `RPM-GPG-KEY-EPEL-9` key; Rocky repositories must still use their
+Rocky 9 key. Global and per-repository signature checks remain mandatory.
+An absent or invalid ownership marker does not authorize EPEL, and enabled
+testing, debug, source, next, or other repository IDs are not accepted.
+
 Debian sources select the package-owned Debian archive keyring explicitly.
 Before trust validation, provisioning adds that restriction to official Debian
 repositories in legacy one-line source files that omit `Signed-By`. It

--- a/docs/specs/007-off-cluster-tls-trust.md
+++ b/docs/specs/007-off-cluster-tls-trust.md
@@ -4,8 +4,9 @@ Issue: [#5](https://github.com/supermorphic/homelab-playbook/issues/5)
 
 Status: hybrid topology and architecture approved with review refinements below.
 The guides describe operator procedures. Host automation is implemented by the
-`tls_automation` role and `tls` playbooks. Live deployment and the Caddy adapter
-remain dependent on issue #25; the private device routes are not yet deployed.
+`tls_automation` role and `tls` playbooks. Issue #25 supplied the host Caddy
+deployment. Issue #5 owns its TLS adapter and integration; the private device
+routes and live TLS renewal still require operator deployment and evidence.
 
 ## Decision and ownership
 
@@ -127,7 +128,9 @@ same root coordinator is used by the authorized Ansible renewal action. Its
 executable, units, configuration, and parent directories are root-owned and not
 writable by the issuer or proxy accounts.
 
-The coordinator performs this sequence under one root-owned exclusive lock:
+The coordinator serializes renewal with its root-owned TLS lock. Publication
+additionally takes the shared Caddy deployment lock, always after the TLS lock.
+It releases the Caddy lock during the ACME network request.
 
 1. Load the fixed root-owned `/etc/homelab-tls/config.json` and validate its
    schema, ownership, paths, and exact approved SAN set. Reject command fields,
@@ -146,15 +149,15 @@ The coordinator performs this sequence under one root-owned exclusive lock:
    perform rollback when required. All these steps run in the root coordinator.
    It generates publication identifiers and destinations itself beneath the
    approved root. Caddy validation and reload use fixed argument vectors in a
-   root-owned integration adapter installed for issue #25's selected runtime;
+   root-owned integration adapter for the host Caddy runtime;
    they are never shell strings or issuer-controlled arguments. The adapter is
    fixed at `/usr/local/libexec/homelab-tls-caddy`. Its only actions are
    `validate <root-owned-candidate-directory>`, `reload`, and `deactivate`.
    `reload` must force certificate file reopening. `deactivate` removes a failed
    first deployment's routes and proves them inactive when no previous
-   generation exists. Issue #25 implements these operations for its selected
-   runtime. Missing integration fails before issuance; no successful stub is
-   installed.
+   generation exists. Issue #5 implements these operations for the host Caddy
+   runtime supplied by issue #25. Missing integration fails before issuance;
+   no successful stub is installed.
 5. Record issuance and publication results separately. A failed issuance does
    not prevent validation and retry of an already-issued pending certificate,
    but remains visible in the overall result. No valid pending candidate means
@@ -180,22 +183,19 @@ one administrator-owned certificate root. Publish both as a generation, then
 atomically replace a relative `current` symlink to a complete generation beneath
 that same root. Keep the parent root directory itself stable; do not replace it
 during publication or rollback. The implementation must
-bind the root path and proxy read access to issue #25's actual runtime contract.
-Do not install guessed service names, UID allocations, or reload commands while
-that implementation is absent from this checkout.
+use `/etc/caddy/tls/infra` for the host Caddy deployment. The service runs as
+`caddy:caddy`; resolve its package-created group by name instead of allocating
+a new numeric proxy identity. Directories are `root:caddy` mode `0750`, files
+are `root:caddy` mode `0640`, and the relative `current` link is owned by
+`root:caddy`. Apply the required platform labels before candidate validation.
 
-If issue #25 selects containerized Caddy, bind-mount the stable parent certificate
-root read-only into the container. Do not mount `current`, its resolved generation
-directory, or individual certificate files. For example, mounting the host
-publication root at `/etc/caddy/certificates` lets Caddy read
-`/etc/caddy/certificates/current/fullchain.pem` and
-`/etc/caddy/certificates/current/privkey.pem`. Relative symlink targets must remain
-within that mounted root. Each switch and rollback is therefore visible on the
-next file open in the existing container; force reload to reopen the files
-without recreating the container. Ensure new generations have the required
-numeric ownership, read permissions, and SELinux labels before switching, not
-only when the mount is first created. The mount contains only published
-generations, never issuer state, credential sources, or candidate snapshots.
+Certificate preparation is a production operation, not an ACME staging test.
+Keep its snapshots, temporary generations, transaction journal, and retirement
+artifacts in the root-only `/etc/caddy/tls/.homelab-tls-private` directory.
+Preparation and publication must remain on the same filesystem so atomic moves
+cannot fail across a separate `/var` mount. Caddy cannot traverse this private
+directory. Coordinator status and its private lock remain under
+`/var/lib/homelab-tls`; issuer state remains separate.
 
 Before publication, copy bounded regular-file inputs into an administrator-owned
 snapshot without following untrusted symlinks. Validate only that immutable
@@ -327,11 +327,11 @@ metadata, and arguments. Verify that the issuer cannot write coordinator policy
 or published generations and that no such input changes the fixed privileged
 operation. Exercise pending publication retry after issuance failure.
 
-For containerized Caddy, a bounded registered container test mounts the stable
-parent once, publishes a replacement generation, forces reload, and checks the
-new served fingerprint without container recreation. Roll back and check the
-previous fingerprint in the same container. Assert the container identity is
-unchanged and include the supported platform's file-label and permission checks.
+For host Caddy, bounded registered disposable Debian and Rocky tests publish a
+replacement generation, force one reload, and check the new served fingerprint.
+Roll back and check the previous fingerprint. Include first publication,
+failed first publication with unrelated routes, interrupted recovery, concurrent
+configuration and certificate operations, and platform permission checks.
 Use independent cryptographic checks and effective system state as oracles.
 Bounded local TLS servers prove served-certificate checks; no Cloudflare token,
 production ACME request, or inventory host is available to CI.

--- a/docs/specs/008-shared-private-reverse-proxy.md
+++ b/docs/specs/008-shared-private-reverse-proxy.md
@@ -356,8 +356,14 @@ Register any required container scenario in local and GitHub CI dispatch togethe
 Do not weaken host restrictions to accommodate nested container limitations.
 
 The rootless proxy test containers add `SYS_PTRACE` so their administrator can
-observe Caddy-owned sockets with `ss -p`. This capability belongs to the test
-container; the managed Caddy service still receives only `CAP_NET_BIND_SERVICE`.
+observe Caddy-owned sockets with `ss -p`. They also add `SYS_ADMIN` so systemd
+can create the nested coordinator filesystem sandbox. Without it, Debian's
+service can fail before execution, and systemd can skip filesystem restrictions
+in containers. An early disposable service verifies that `/usr/local` is
+read-only while the declared `/var/lib` write exception remains writable.
+These capabilities belong to the rootless test container; the
+managed Caddy service still receives only `CAP_NET_BIND_SERVICE`, and the
+production coordinator restrictions remain unchanged.
 Container checks establish permanent firewall configuration, not host-kernel
 firewall enforcement or enforcing SELinux behavior.
 

--- a/docs/specs/008-shared-private-reverse-proxy.md
+++ b/docs/specs/008-shared-private-reverse-proxy.md
@@ -52,6 +52,10 @@ benefit for this service that outweighs the additional mechanisms.
 Install the unpinned `caddy` distribution package without DNS-provider plugins.
 Use Debian 13's native APT repository. Rocky Linux 9 uses its compatible EPEL
 package, with the signed EPEL repository explicitly established by the role.
+The OS maintenance trust check recognizes the standard `epel` and
+`epel-cisco-openh264` repositories only when the exact root-owned Caddy ownership
+marker is present, and requires their EPEL 9 signing key. This keeps repeat
+provisioning and maintenance compatible with the installed Caddy package source.
 The demonstrated need for EPEL is the Caddy package; no upstream Caddy repository
 or standalone binary installer is introduced. Installation uses `state: present`;
 existing OS maintenance owns package upgrades. Daily security updates retain

--- a/docs/specs/008-shared-private-reverse-proxy.md
+++ b/docs/specs/008-shared-private-reverse-proxy.md
@@ -106,16 +106,30 @@ Use an explicit `reverse_proxy_hosts` inventory group and these service inputs:
 - `reverse_proxy_client_sources`: non-empty explicit private client CIDRs.
 - `reverse_proxy_routes`: a complete list of route declarations, initially
   empty until the operator supplies certificates and approved services.
-- Each route contains `hostname`, `backend_port`, and `certificate_name`.
+- `reverse_proxy_deferred_certificates`: empty or exactly `[infra]`; only this
+  explicit dependency may be missing before first certificate publication.
+- `reverse_proxy_trust_certificates`: named immutable route-specific device
+  trust bundles supplied through protected inventory.
+- Each local application route contains `hostname`, `backend_port`, and `certificate_name`.
   A hostname is an exact DNS name, a backend port is an integer from 1024 through
   65535, and a certificate name is a restricted filesystem component.
 
 Reject duplicate hostnames, invalid types, wildcard hostnames, control
 characters, arbitrary Caddyfile fragments, URL credentials, path traversal,
-and unapproved upstream addresses. Templates always construct upstreams as
+and unapproved upstream addresses. Local application routes construct upstreams as
 `127.0.0.1:<backend_port>`. Each application owns its loopback port allocation
 and Podman port publication; the proxy owns no application account or data.
 Host loopback prevents remote access but is not a boundary between local users.
+
+Issue #5 extends routes with an explicit private-device form: `hostname`,
+`certificate_name`, and `backend`. The backend contains `transport` (`http` or
+`https`), an RFC1918 or ULA `address`, and `port` from 1 through 65535. HTTPS also
+requires `server_name` and `trust_name`, selecting
+`/etc/caddy/trust/<trust_name>.pem`. Caddy verifies the backend certificate using
+that route-specific trust and server name. HTTP accepts no TLS trust fields.
+Local and device backend forms cannot be combined. Trust names identify immutable
+content; use a new name when rotating trust so rollback can retain the old trust.
+The shared renderer supports the distribution packages' TLS transport syntax.
 
 The operator supplies live addresses, client networks, and sensitive deployment
 names through the existing protected inventory process. Public examples use
@@ -141,6 +155,17 @@ to delay WebSocket closure.
 An empty route list renders an admin-only configuration with no HTTPS listener
 and no required certificate pair. Removing the final route removes ingress
 allowances as well as listeners. It does not delete externally owned TLS files.
+
+Ansible supplies a root-only candidate desired manifest and ingress metadata
+after firewall verification. The fixed `apply-desired` helper validates their
+binding, renders effective routes, and commits configuration plus the desired
+manifest in one recoverable transaction. The committed `desired.json` contains
+the exact original manifest string and ingress metadata with its SHA256 revision.
+Only routes explicitly depending on the absent first `infra` certificate are
+deferred. Missing or malformed certificates for other routes fail activation.
+Private ingress policy follows declared routes so TLS can later activate them
+without becoming a second firewall controller. An empty effective route list
+still has no network listener. Removing all desired routes removes allowances.
 
 ## Firewall integration
 
@@ -194,6 +219,27 @@ The helper is `/usr/local/libexec/homelab-reverse-proxy`; the shared lock is
 inherited on file descriptor 9. The helper validates that inherited lock;
 the flag alone does not grant execution authority. Certificate automation must
 retain it through version selection, reload, and served-certificate verification.
+
+Issue #5 supplies the fixed `homelab-tls-caddy` adapter. TLS takes its coordinator
+lock before the Caddy lock and releases the Caddy lock during ACME network work.
+Its root-only publication journal binds certificate selection, prior and candidate
+boot configurations, and the committed desired revision. While that transaction
+is pending, ordinary configuration changes cannot replace its recovery authority.
+Startup recovery restores consistent certificate and configuration disk state
+without acquiring the TLS coordinator lock or requesting a certificate. Runtime
+recovery then verifies or retries the retained generation before new issuance.
+
+First publication activates only declared routes dependent on `infra`. Failed
+first publication restores their previous inactive state while preserving
+unrelated routes. Verify route absence in the active configuration and check
+remaining listeners and certificates; an unknown-SNI handshake alone does not
+establish route absence on a shared listener.
+
+Device trust installation uses the same deployment lock. The fixed
+`install-trust` action reads `/var/lib/homelab-reverse-proxy/trust.candidate.json`,
+validates its bounded PEM bundles, and publishes each new name without replacing
+an existing file. Existing names must have the exact declared contents and safe
+metadata. Concurrent declarations cannot change another route's trust bundle.
 
 The `reload` entry point validates the committed configuration as the service
 account and forces Caddy to reload it from the selected `current` certificate

--- a/docs/specs/008-shared-private-reverse-proxy.md
+++ b/docs/specs/008-shared-private-reverse-proxy.md
@@ -365,6 +365,12 @@ can create the nested coordinator filesystem sandbox. Without it, Debian's
 service can fail before execution, and systemd can skip filesystem restrictions
 in containers. An early disposable service verifies that `/usr/local` is
 read-only while the declared `/var/lib` write exception remains writable.
+The disposable services inherit the system manager's root identity rather than
+setting `User=root`: explicit user setup in nested Debian systemd prevents the
+adapter from switching to the Caddy user. The early probe verifies effective
+root identity and a successful unprivileged user switch, and the integrated
+driver independently checks its root identity. The remaining sandbox settings
+stay in place; production units retain their explicit service identities.
 These capabilities belong to the rootless test container; the
 managed Caddy service still receives only `CAP_NET_BIND_SERVICE`, and the
 production coordinator restrictions remain unchanged.

--- a/inventory/production/group_vars/tls_hosts/vars.yml
+++ b/inventory/production/group_vars/tls_hosts/vars.yml
@@ -1,0 +1,11 @@
+---
+# Capability installation only; initial renewal and timer enablement are separate
+# authorized actions. The role verifies the issuer allocation before creating it.
+tls_automation_timer_enabled: false
+tls_automation_issuer_uid: 2010
+tls_automation_issuer_gid: 2010
+reverse_proxy_deferred_certificates:
+  - infra
+# Supply namespace, ACME contact, listener/client networks, routes, and optional
+# Cloudflare credential through operator-managed secrets.sops.yml. The installed
+# Caddy group supplies certificate read access; do not allocate another proxy GID.

--- a/inventory/production/hosts.yml
+++ b/inventory/production/hosts.yml
@@ -10,3 +10,6 @@ all:
     reverse_proxy_hosts:
       hosts:
         nuc4:
+    tls_hosts:
+      hosts:
+        nuc4:

--- a/playbooks/os/README.md
+++ b/playbooks/os/README.md
@@ -23,6 +23,9 @@ Debian 13 and Rocky Linux 9 are the supported complete-baseline platforms.
 Complete-baseline operations reject unsupported platforms before mutation.
 The baseline preserves each distribution's official repository configuration
 and existing time sources.
+On Rocky hosts owned by the Caddy role, it also accepts that role's signed
+EPEL 9 package source. The exact Caddy ownership marker is required; the OS
+baseline does not enable EPEL on other hosts.
 
 ## Playbook surface
 

--- a/playbooks/reverse-proxy/README.md
+++ b/playbooks/reverse-proxy/README.md
@@ -37,8 +37,9 @@ permission-protected Unix admin socket; no HTTPS listener or allowance exists.
 Active routes require explicit private bind addresses and client CIDRs. HTTPS
 client sources are independent of the SSH management-source list. Supply live
 values through the existing protected inventory process. Activating routes also
-requires DNS pointing to the selected private host address and externally
-deployed trusted certificates.
+requires DNS pointing to the selected private host address and trusted
+certificates. The explicit `infra` dependency can remain pending until the
+issue #5 issuer publishes its first certificate.
 
 Synthetic configuration example:
 
@@ -53,11 +54,38 @@ reverse_proxy_routes:
     certificate_name: app
 ```
 
-Each route has an exact `hostname`, a `backend_port` from 1024 through 65535,
-and a safe `certificate_name`. Caddy always connects to
+Each local application route has an exact `hostname`, a `backend_port` from 1024
+through 65535, and a safe `certificate_name`. For these routes, Caddy connects to
 `127.0.0.1:<backend_port>`. Application roles own port allocation and loopback-only
 publication under their separate Podman accounts. No socket-based discovery or
 application account membership is required by Caddy.
+
+Private device routes replace `backend_port` with an explicit `backend` mapping.
+For example, an HTTP-only device uses:
+
+```yaml
+reverse_proxy_routes:
+  - hostname: room-alert.infra.example.com
+    certificate_name: infra
+    backend:
+      transport: http
+      address: 10.20.30.60
+      port: 80
+reverse_proxy_deferred_certificates: [infra]
+```
+
+HTTPS device backends additionally require `server_name` and `trust_name`.
+Supply the named PEM trust bundle through `reverse_proxy_trust_certificates`
+in protected inventory. Trust names are immutable; use a new name to rotate
+trust. See the [device guide](../../docs/guides/device-proxy.md) for examples
+and the modem identity prerequisite. No TLS-verification bypass is available.
+
+Provisioning commits a desired manifest together with Caddy's effective
+configuration. Only explicitly deferred `infra` routes can wait for the first
+certificate; other certificate failures stop activation. The TLS coordinator
+uses that committed manifest and its verified private ingress binding when it
+activates the first certificate. Declare live inputs in protected host variables
+so they override the public group's empty defaults.
 
 The complete desired route list is authoritative. Removing a route removes new
 requests to that backend; removing the final route removes HTTPS listeners and

--- a/playbooks/tls/README.md
+++ b/playbooks/tls/README.md
@@ -2,8 +2,9 @@
 
 These playbooks install and operate the NUC host issuer from
 [specification 007](../../docs/specs/007-off-cluster-tls-trust.md). They target
-only the `tls_hosts` inventory group through `mise run playbook`. That group has
-no active host until the operator supplies and authorizes one.
+only the `tls_hosts` inventory group through `mise run playbook`. Production
+registers `nuc4` in both `tls_hosts` and `reverse_proxy_hosts`, with renewal
+disabled. Inventory membership does not authorize a live playbook run.
 
 The TLS command family accepts only the `production` inventory. The gateway
 rejects staging and frozen inventory selections because this implementation has
@@ -25,19 +26,27 @@ skip preflight checks.
 
 ## Required inputs
 
-Declare these public values for the selected host:
+Public inventory declares stable issuer IDs and a disabled timer. Supply live
+namespace, contact, routes, listener addresses, and client networks in
+`inventory/production/host_vars/nuc4/secrets.sops.yml` through the existing
+[operator SOPS workflow](../../docs/guides/sops-secrets.md). Host variables
+override the empty group defaults without duplicating values between TLS and
+Caddy. This synthetic example shows the required shape:
 
 ```yaml
 tls_automation_namespace: infra.example.com
 tls_automation_email: acme@example.com
-tls_automation_reader_gid: 2001
-tls_automation_endpoints:
-  - hostname: modem.infra.example.com
-    address: 192.0.2.10
-    port: 443
+reverse_proxy_bind_addresses:
+  - 10.20.30.40
+reverse_proxy_client_sources:
+  - 10.20.0.0/16
+reverse_proxy_routes:
   - hostname: room-alert.infra.example.com
-    address: 192.0.2.10
-    port: 443
+    certificate_name: infra
+    backend:
+      transport: http
+      address: 10.20.30.60
+      port: 80
 tls_automation_issuer_uid: 2010
 tls_automation_issuer_gid: 2010
 tls_automation_timer_enabled: false
@@ -48,8 +57,20 @@ namespace beneath the registered domain. The role derives the sole certificate
 SAN as `*.<namespace>`. Each endpoint hostname must be directly beneath that
 namespace and each address must be a private unicast IP literal.
 
-The reader GID must already exist and must differ from both issuer IDs. Assign
-an unused, stable UID and GID for `svc-acme`. The role records the allocation in
+TLS derives verification targets from every `infra` route and every declared
+Caddy listener at TCP/443. Do not maintain a separate endpoint list. Each route
+must fit the exact wildcard namespace. The public `tls_hosts` defaults declare
+`reverse_proxy_deferred_certificates: [infra]`, allowing those routes to remain
+inactive until the first certificate exists.
+Provisioning rejects a declaration that differs from Caddy's committed manifest
+or its verified ingress binding. Renewal repeats this check under the deployment
+lock before certificate operations.
+
+Provision Caddy first. TLS resolves the existing `caddy` group by name; its
+numeric GID is not an operator allocation. A supplied legacy
+`tls_automation_reader_gid` must match that group. Issuer IDs must differ from
+the reader GID. The declared `2010:2010` issuer allocation is checked for
+collisions before mutation. The role records the allocation in
 `/etc/homelab-tls/.issuer-account.json`. It rejects identity collisions,
 partial account state, allocation changes, and an existing account without the
 matching root-owned record.
@@ -63,27 +84,32 @@ capability. The host does not need an age identity for routine renewal.
 
 ## Disabled installation and bootstrap
 
-The timer defaults to disabled. A disabled provisioning run does not require a
-credential or `/usr/local/libexec/homelab-tls-caddy`. It installs pinned lego
-5.4.1, the Python runtime, fixed launchers, state boundaries, and systemd units.
-It does not contact an ACME server, publish a certificate, or create a Caddy
-adapter.
+The timer defaults to disabled. A disabled TLS provisioning run requires the
+installed Caddy capability and declared route inputs, but no Cloudflare
+credential. It installs pinned lego 5.4.1, the Python runtime, the real fixed
+Caddy adapter, state boundaries, and systemd units. It does not contact an ACME
+server or publish a certificate.
 
-Issue #25 must install `/usr/local/libexec/homelab-tls-caddy`. The adapter has
+Issue #5 installs `/usr/local/libexec/homelab-tls-caddy`. The adapter has
 three fixed actions: `validate <root-owned-candidate-directory>`, `reload`, and
 `deactivate`. It must validate Caddy's real candidate access and configuration,
 force the service to reopen certificate files, and prove the route inactive
-after a failed first publication. The TLS role does not assume a Caddy service
-name, user, group, configuration model, or reload command. The root coordinator
-unit can write only `/var/lib/homelab-tls`; the adapter must work within that
-boundary and the Caddy deployment from issue #25.
+after a failed first publication. It integrates with the host `caddy.service`
+and package-owned `caddy:caddy` identity. The root coordinator can write only
+its managed state and transaction roots: `/var/lib/homelab-tls`, `/etc/caddy`,
+and `/var/lib/homelab-reverse-proxy`. The issuer still writes only its private
+ACME state and receives the Cloudflare credential through systemd.
 
 Use this sequence for the first certificate:
 
-1. Provision with `tls_automation_timer_enabled: false`. The credential can be
-   omitted for this capability-only step.
-2. Install the issue #25 adapter and provide the protected Cloudflare token.
-   Provision again with the timer still disabled to install the credential.
+1. Declare the intended routes and private ingress in protected inventory.
+   Run an authorized `reverse-proxy provision production --limit nuc4` through
+   `mise run playbook --`. Provisioning verifies the firewall and commits the
+   desired manifest. Routes using the pending `infra` certificate stay inactive;
+   unrelated routes retain their certificates and service.
+2. Run authorized `tls provision production --limit nuc4` with the timer false.
+   The credential can be omitted for capability installation. Add the scoped
+   Cloudflare token through SOPS and provision again before initial renewal.
 3. Explicitly authorize and run one renewal:
 
    ```bash
@@ -120,11 +146,14 @@ keeps recovery blocked; do not remove the journal to bypass it.
 `in_progress` attempt can indicate an interrupted operation; it is not evidence
 of successful completion. Observational verification does not change status.
 
-Keep encrypted backups of `/var/lib/homelab-tls-issuer` ACME account state and
-`/var/lib/homelab-tls` publication state. Preserve numeric ownership and private
-key confidentiality. On a replacement host, restore administrative access and
+Keep encrypted backups of `/var/lib/homelab-tls-issuer` ACME account state,
+`/etc/caddy` configuration, trust, certificate and recovery state,
+`/var/lib/homelab-tls` status,
+and `/var/lib/homelab-reverse-proxy` configuration recovery state. Preserve
+issuer ownership and private key confidentiality. On a replacement host, restore administrative access and
 the OS baseline first. Reconcile the role with the timer disabled, restore
-state when available, install the issue #25 adapter, run one authorized renewal
+state when available, reconcile certificate-reader ownership to the installed
+`caddy` group, run one authorized renewal
 if necessary, verify the active endpoints, and only then enable the timer.
 
 If ACME account state is unavailable, restore independent DNS, time, outbound
@@ -132,10 +161,17 @@ network, and SOPS credential access before an explicitly authorized renewal.
 Account for CA rate limits. Direct appliance access remains the recovery path
 when Caddy or local DNS is unavailable.
 
-The registered `system_maintenance/baseline` Molecule scenario installs the
-disabled capability on disposable Debian 13 and Rocky Linux 9 hosts. It checks
-packages, identity isolation, file metadata, parsed systemd units, the missing
-adapter failure, manual-start waiting for successful and failed synthetic jobs,
-and the installed runtime with distribution Python and
-cryptography. It makes no ACME request and does not prove live Caddy reload,
-endpoint behavior, boot persistence, or production renewal.
+Certificate preparation is part of production publication, not an ACME staging
+environment. Root-only temporary files and the publication journal live under
+`/etc/caddy/tls/.homelab-tls-private`; complete readable generations live under
+`/etc/caddy/tls/infra`. Keeping them on one filesystem permits atomic moves.
+The previous `/var/lib/homelab-tls/published` layout is not migrated silently:
+nonempty state or an old pending journal blocks provisioning for operator recovery.
+
+The registered `system_maintenance/baseline` Molecule scenario installs real
+admin-only Caddy and disabled TLS on disposable Debian 13 and Rocky Linux 9 hosts.
+It checks identity isolation, file metadata, parsed units, missing-credential
+rejection, manual-start waiting, and the runtime with distribution Python and
+cryptography. The `reverse_proxy/default` scenario covers integrated certificate
+activation and recovery. These tests make no ACME requests and do not establish
+production issuance, device browser compatibility, or physical boot evidence.

--- a/roles/reverse_proxy/defaults/main.yml
+++ b/roles/reverse_proxy/defaults/main.yml
@@ -2,3 +2,5 @@
 reverse_proxy_bind_addresses: []
 reverse_proxy_client_sources: []
 reverse_proxy_routes: []
+reverse_proxy_deferred_certificates: []
+reverse_proxy_trust_certificates: {}

--- a/roles/reverse_proxy/files/activate.py
+++ b/roles/reverse_proxy/files/activate.py
@@ -125,6 +125,13 @@ class Activator:
         from proxy_manifest import Manifest
         return Manifest(self)
 
+    def install_trust(self):
+        with self.locked():
+            self.require_no_tls()
+            self.manifest()  # Establish the fixed installed module search path.
+            from proxy_manifest import Trust
+            return Trust(self).install()
+
     def require_no_tls(self):
         if os.path.lexists(self.tls_journal):
             raise ActivationError("TLS publication recovery is pending")
@@ -649,8 +656,8 @@ class Activator:
 
 def main(arguments=None):
     args = list(sys.argv[1:] if arguments is None else arguments)
-    if args not in (["apply-desired"], ["apply"], ["recover"], ["reload"], ["reload", "--lock-held"], ["verify"], ["verify", "--lock-held"]):
-        print("usage: homelab-reverse-proxy {apply|recover|reload [--lock-held]|verify [--lock-held]}", file=sys.stderr)
+    if args not in (["install-trust"], ["apply-desired"], ["apply"], ["recover"], ["reload"], ["reload", "--lock-held"], ["verify"], ["verify", "--lock-held"]):
+        print("usage: homelab-reverse-proxy {apply|apply-desired|install-trust|recover|reload [--lock-held]|verify [--lock-held]}", file=sys.stderr)
         return 2
     try:
         if os.geteuid() != 0:
@@ -659,8 +666,13 @@ def main(arguments=None):
         if args[0] in ("reload", "verify"):
             getattr(activator, args[0])(inherited=len(args) == 2)
         else:
-            result = activator.apply(desired=True) if args[0] == "apply-desired" else getattr(activator, args[0])()
-            if args[0] in ("apply", "apply-desired"):
+            if args[0] == "apply-desired":
+                result = activator.apply(desired=True)
+            elif args[0] == "install-trust":
+                result = activator.install_trust()
+            else:
+                result = getattr(activator, args[0])()
+            if args[0] in ("apply", "apply-desired", "install-trust"):
                 print(result)
         return 0
     except ActivationError as error:

--- a/roles/reverse_proxy/files/activate.py
+++ b/roles/reverse_proxy/files/activate.py
@@ -118,6 +118,16 @@ class Activator:
         self.previous = self.state / "last-good"
         self.lock_path = self.path("/run/lock/homelab-reverse-proxy.lock")
         self.socket = self.path("/run/caddy/admin.sock")
+        self.tls_journal = self.config_dir / "tls/.homelab-tls-private/transaction.json"
+
+    def manifest(self):
+        sys.path.insert(0, "/usr/local/lib/homelab-reverse-proxy")
+        from proxy_manifest import Manifest
+        return Manifest(self)
+
+    def require_no_tls(self):
+        if os.path.lexists(self.tls_journal):
+            raise ActivationError("TLS publication recovery is pending")
 
     def path(self, value):
         return self.root / value.lstrip("/")
@@ -179,7 +189,7 @@ class Activator:
                 operation = fcntl.LOCK_EX | fcntl.LOCK_NB
             fcntl.flock(descriptor, operation)
             self.preflight()
-            yield
+            yield descriptor
         finally:
             if not inherited:
                 os.close(descriptor)
@@ -306,14 +316,14 @@ class Activator:
         if observed != self.expected_listeners(configuration):
             raise ActivationError("Caddy network listeners differ from the declared listeners")
 
-    def validate(self, config):
+    def validate(self, config, certificate_generation=None):
         self.metadata(config, stat.S_ISREG, self.ids[0], self.ids[3], 0o640)
         adapted = self.adapted(config)
-        self.certificates(adapted)
+        self.certificates(adapted, certificate_generation=certificate_generation)
         self.caddy("validate", config)
         return adapted
 
-    def certificates(self, configuration):
+    def certificates(self, configuration, certificate_generation=None):
         certificates = configuration.get("apps", {}).get("tls", {}).get("certificates", {}).get("load_files", [])
         def route_hosts(value):
             result = set()
@@ -358,29 +368,36 @@ class Activator:
         for pair in certificates:
             certificate = pair.get("certificate", "")
             key = pair.get("key", "")
-            match = re.fullmatch(r"/etc/caddy/tls/([A-Za-z0-9][A-Za-z0-9_-]{0,63})/current/fullchain\.pem", certificate)
+            match = re.fullmatch(r"/etc/caddy/tls/([A-Za-z0-9][A-Za-z0-9_-]{0,63})/(current|generation-[0-9a-f]{32})/fullchain\.pem", certificate)
             if match is None or key != certificate.removesuffix("fullchain.pem") + "privkey.pem":
                 raise ActivationError("external TLS paths do not meet the certificate contract")
             base = self.config_dir / "tls" / match.group(1)
-            self.metadata(base, stat.S_ISDIR, self.ids[0], self.ids[3], 0o750)
-            current = base / "current"
-            info = current.lstat()
-            if not stat.S_ISLNK(info.st_mode) or info.st_uid != self.ids[0] or info.st_gid != self.ids[3]:
-                raise ActivationError("certificate version selection is not an administrator-owned symlink")
-            target = current.resolve(strict=True)
-            if base not in target.parents:
-                raise ActivationError("certificate version escapes its managed root")
-            # Only the current pointer may introduce path indirection.
-            relative = Path(os.readlink(current))
-            raw = relative if relative.is_absolute() else base / relative
-            if ".." in raw.parts:
-                raise ActivationError("certificate version path contains traversal")
-            cursor = base
-            for component in target.relative_to(base).parts:
-                cursor /= component
-                self.metadata(cursor, stat.S_ISDIR, self.ids[0], self.ids[3], 0o750)
-            if raw != target:
-                raise ActivationError("certificate version has additional path indirection")
+            if match.group(2) != "current":
+                target = base / match.group(2)
+                if match.group(1) != "infra" or target != certificate_generation:
+                    raise ActivationError("candidate generation requires internal validation authority")
+                self.metadata(base, stat.S_ISDIR, self.ids[0], self.ids[3], 0o750)
+                self.metadata(target, stat.S_ISDIR, self.ids[0], self.ids[3], 0o750)
+            else:
+                self.metadata(base, stat.S_ISDIR, self.ids[0], self.ids[3], 0o750)
+                current = base / "current"
+                info = current.lstat()
+                if not stat.S_ISLNK(info.st_mode) or info.st_uid != self.ids[0] or info.st_gid != self.ids[3]:
+                    raise ActivationError("certificate version selection is not an administrator-owned symlink")
+                target = current.resolve(strict=True)
+                if base not in target.parents:
+                    raise ActivationError("certificate version escapes its managed root")
+                # Only the current pointer may introduce path indirection.
+                relative = Path(os.readlink(current))
+                raw = relative if relative.is_absolute() else base / relative
+                if ".." in raw.parts:
+                    raise ActivationError("certificate version path contains traversal")
+                cursor = base
+                for component in target.relative_to(base).parts:
+                    cursor /= component
+                    self.metadata(cursor, stat.S_ISDIR, self.ids[0], self.ids[3], 0o750)
+                if raw != target:
+                    raise ActivationError("certificate version has additional path indirection")
             for filename in ("fullchain.pem", "privkey.pem"):
                 self.metadata(target / filename, stat.S_ISREG, self.ids[0], self.ids[3], 0o640)
             public = str(target / "fullchain.pem")
@@ -446,6 +463,15 @@ class Activator:
                     # the active configuration. Reload cannot close those sockets.
                     raise RestartRequired(previous) from None
 
+    def restore_manifest(self, manifests, previous):
+        if previous is None:
+            if os.path.lexists(manifests.path):
+                manifests.path.unlink()
+                self.fsync_directory(self.state)
+        else:
+            manifests.validate(json.loads(previous))
+            self.durable_write(manifests.path, previous.encode(), 0o600, self.ids[1])
+
     def recover_pending(self, runtime=False):
         if not self.pending.exists():
             if self.pending.is_symlink():
@@ -458,22 +484,47 @@ class Activator:
         except ValueError:
             raise ActivationError("transaction record is unreadable; operator recovery is required") from None
         previous = self.previous.read_bytes()
-        if (not isinstance(record, dict) or set(record) != {"previous", "candidate"}
+        fields = {"previous", "candidate"}
+        manifest_fields = {"desired_previous", "desired_candidate"}
+        if (not isinstance(record, dict) or set(record) not in (fields, fields | manifest_fields)
                 or hashlib.sha256(previous).hexdigest() != record["previous"]
                 or hashlib.sha256(self.boot.read_bytes()).hexdigest() not in (record["previous"], record["candidate"])):
             raise ActivationError("transaction state is ambiguous; operator recovery is required")
+        if "desired_previous" in record:
+            manifests = self.manifest()
+            current = manifests.read(manifests.path).decode("utf-8") if os.path.lexists(manifests.path) else None
+            if current not in (record["desired_previous"], record["desired_candidate"]):
+                raise ActivationError("desired authority changed during recovery")
+            for value in (record["desired_previous"], record["desired_candidate"]):
+                if value is not None:
+                    manifests.validate(json.loads(value))
+            self.restore_manifest(manifests, record["desired_previous"])
         self.restore_previous(previous, runtime)
         self.clear_pending()
 
     def recover(self):
         with self.locked():
+            if os.path.lexists(self.tls_journal):
+                sys.path.insert(0, "/usr/local/lib/homelab-tls")
+                from tls_runtime.caddy import Integration
+                Integration(self).recover_disk()
             self.recover_pending()
 
-    def apply(self):
+    def apply(self, desired=False):
         try:
             with self.locked():
                 try:
-                    return self.apply_locked()
+                    self.require_no_tls()
+                    manifests = self.manifest() if desired else None
+                    if not desired and os.path.lexists(self.state / "desired.json"):
+                        raise ActivationError("managed desired routes require apply-desired")
+                    if manifests is not None:
+                        self.recover_pending(runtime=True)
+                        envelope, config = manifests.candidate()
+                        self.durable_write(self.candidate, manifests.render(config).encode(), 0o640, self.ids[3])
+                    else:
+                        envelope = None
+                    return self.apply_locked(manifests, envelope)
                 except RestartRequired as recovery:
                     # Keep rollback authority durable while releasing the lock.
                     # Usually the original transaction marker is still present.
@@ -502,7 +553,7 @@ class Activator:
             raise ActivationError("activation failed: " + recovery.reason
                                   + "; previous boot and runtime configuration restored after service restart") from None
 
-    def apply_locked(self):
+    def apply_locked(self, manifests=None, envelope=None):
         self.active()
         self.recover_pending(runtime=True)
         self.metadata(self.candidate, stat.S_ISREG, self.ids[0], self.ids[3], 0o640)
@@ -512,27 +563,44 @@ class Activator:
         if self.candidate.read_bytes() != candidate:
             raise ActivationError("candidate changed during validation; rerun provisioning")
         previous = self.boot.read_bytes()
+        previous_desired = None
+        candidate_desired = None
+        if manifests is not None:
+            manifests.unchanged(envelope)
+            previous_desired = manifests.read(manifests.path).decode() if os.path.lexists(manifests.path) else None
+            if previous_desired is not None:
+                manifests.validate(json.loads(previous_desired))
+            candidate_desired = json.dumps(envelope, sort_keys=True)
+        observed_unchanged = False
         if candidate == previous:
             try:
                 self.observed(desired)
                 self.served_tls(desired)
-                return "unchanged"
+                observed_unchanged = True
+                if candidate_desired == previous_desired:
+                    return "unchanged"
             except ActivationError:
                 pass
         self.active()
         self.socket_metadata()
         # The backup and marker are both durable before changing the boot file.
         self.durable_write(self.previous, previous, 0o600, self.ids[1])
-        record = json.dumps({"previous": hashlib.sha256(previous).hexdigest(),
-                             "candidate": hashlib.sha256(candidate).hexdigest()}).encode()
-        self.durable_write(self.pending, record, 0o600, self.ids[1])
+        record = {"previous": hashlib.sha256(previous).hexdigest(),
+                  "candidate": hashlib.sha256(candidate).hexdigest()}
+        if manifests is not None:
+            record.update(desired_previous=previous_desired, desired_candidate=candidate_desired)
+        self.durable_write(self.pending, json.dumps(record).encode(), 0o600, self.ids[1])
         try:
             self.durable_write(self.boot, candidate, 0o640, self.ids[3])
-            self.caddy("reload", self.boot)
-            self.observed(desired)
-            self.served_tls(desired)
+            if not observed_unchanged:
+                self.caddy("reload", self.boot)
+                self.observed(desired)
+                self.served_tls(desired)
+            if manifests is not None:
+                manifests.unchanged(envelope)
+                self.durable_write(manifests.path, candidate_desired.encode(), 0o600, self.ids[1])
             self.clear_pending()
-        except (ActivationError, OSError) as failure:
+        except (ActivationError, OSError, ValueError) as failure:
             reason = str(failure) if isinstance(failure, ActivationError) else "managed filesystem operation failed"
             try:
                 if self.pending.exists() or self.pending.is_symlink():
@@ -540,6 +608,8 @@ class Activator:
                 else:
                     # Cleanup may have removed the marker before a failed fsync.
                     # Retain the in-memory rollback authority until commit returns.
+                    if manifests is not None:
+                        self.restore_manifest(manifests, previous_desired)
                     self.restore_previous(previous, runtime=True)
                     self.fsync_directory(self.state)
             except RestartRequired as recovery:
@@ -552,6 +622,7 @@ class Activator:
 
     def reload(self, inherited=False):
         with self.locked(inherited=inherited):
+            self.require_no_tls()
             self.active()
             if self.pending.exists() or self.pending.is_symlink():
                 raise ActivationError("configuration recovery is required before certificate refresh")
@@ -562,6 +633,12 @@ class Activator:
 
     def verify(self, inherited=False):
         with self.locked(shared=True, inherited=inherited):
+            self.require_no_tls()
+            if os.path.lexists(self.state / "desired.json"):
+                manifests = self.manifest()
+                unused, config = manifests.committed()
+                if self.boot.read_bytes() != manifests.render(config).encode():
+                    raise ActivationError("boot configuration differs from desired effective routes")
             if self.pending.exists() or self.pending.is_symlink():
                 raise ActivationError("configuration recovery is pending")
             desired = self.adapted(self.boot)
@@ -572,7 +649,7 @@ class Activator:
 
 def main(arguments=None):
     args = list(sys.argv[1:] if arguments is None else arguments)
-    if args not in (["apply"], ["recover"], ["reload"], ["reload", "--lock-held"], ["verify"], ["verify", "--lock-held"]):
+    if args not in (["apply-desired"], ["apply"], ["recover"], ["reload"], ["reload", "--lock-held"], ["verify"], ["verify", "--lock-held"]):
         print("usage: homelab-reverse-proxy {apply|recover|reload [--lock-held]|verify [--lock-held]}", file=sys.stderr)
         return 2
     try:
@@ -582,8 +659,8 @@ def main(arguments=None):
         if args[0] in ("reload", "verify"):
             getattr(activator, args[0])(inherited=len(args) == 2)
         else:
-            result = getattr(activator, args[0])()
-            if args[0] == "apply":
+            result = activator.apply(desired=True) if args[0] == "apply-desired" else getattr(activator, args[0])()
+            if args[0] in ("apply", "apply-desired"):
                 print(result)
         return 0
     except ActivationError as error:

--- a/roles/reverse_proxy/files/manifest.py
+++ b/roles/reverse_proxy/files/manifest.py
@@ -1,0 +1,102 @@
+"""Private desired manifest snapshots, ingress binding, and effective selection."""
+import copy
+import hashlib
+import json
+import os
+import stat
+
+import proxy_config
+
+
+LIMIT = 1024 * 1024
+
+
+def unique(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError('duplicate manifest field')
+        result[key] = value
+    return result
+
+
+def decode(raw):
+    return json.loads(raw, object_pairs_hook=unique)
+
+
+class Manifest:
+    def __init__(self, activator):
+        self.a = activator
+        self.path = activator.state / 'desired.json'
+        self.source = activator.state / 'desired.candidate.json'
+        self.ingress = activator.state / 'ingress.candidate.json'
+
+    def read(self, path):
+        self.a.parents(path)
+        expected = self.a.metadata(path, stat.S_ISREG, self.a.ids[0], self.a.ids[1], 0o600)
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        try:
+            before = os.fstat(fd)
+            if (before.st_dev, before.st_ino) != (expected.st_dev, expected.st_ino):
+                raise ValueError('manifest changed before snapshot')
+            data = b''
+            while len(data) <= LIMIT:
+                chunk = os.read(fd, min(65536, LIMIT + 1 - len(data)))
+                if not chunk:
+                    break
+                data += chunk
+            after = os.fstat(fd)
+            if (len(data) > LIMIT or
+                    (before.st_size, before.st_mtime_ns, before.st_ctime_ns) !=
+                    (after.st_size, after.st_mtime_ns, after.st_ctime_ns)):
+                raise ValueError('manifest changed during snapshot or exceeds bound')
+            return data
+        finally:
+            os.close(fd)
+
+    def validate(self, envelope):
+        if (not isinstance(envelope, dict) or set(envelope) != {'version', 'manifest', 'ingress'}
+                or type(envelope['version']) is not int or envelope['version'] != 1
+                or not isinstance(envelope['manifest'], str)):
+            raise ValueError('invalid desired envelope')
+        raw = envelope['manifest'].encode('utf-8')
+        config = proxy_config.validate(decode(raw))
+        ingress = envelope['ingress']
+        if (not isinstance(ingress, dict) or
+                set(ingress) != {'version', 'manifest_sha256', 'listen_addresses', 'https_client_networks'}
+                or type(ingress['version']) is not int or ingress['version'] != 1
+                or ingress['manifest_sha256'] != hashlib.sha256(raw).hexdigest()
+                or ingress['listen_addresses'] != config['bind_addresses']
+                or ingress['https_client_networks'] != config['client_sources']):
+            raise ValueError('desired revision is not bound to verified ingress')
+        return config
+
+    def candidate(self):
+        envelope = {'version': 1, 'manifest': self.read(self.source).decode('utf-8'),
+                    'ingress': decode(self.read(self.ingress))}
+        return envelope, self.validate(envelope)
+
+    def committed(self):
+        envelope = decode(self.read(self.path))
+        return envelope, self.validate(envelope)
+
+    def unchanged(self, expected):
+        actual, unused = self.candidate()
+        if actual != expected:
+            raise ValueError('desired candidate changed during activation')
+
+    def effective(self, config, generation=None):
+        result = copy.deepcopy(config)
+        pointer = self.a.config_dir / 'tls/infra/current'
+        if generation is None and not os.path.lexists(pointer) and 'infra' in config.get('deferred_certificates', []):
+            result['routes'] = [route for route in result['routes'] if route['certificate_name'] != 'infra']
+        return result
+
+    def render(self, config, generation=None):
+        paths = None if generation is None else {'infra': str(generation)}
+        return proxy_config.render(self.effective(config, generation), certificate_paths=paths)
+
+    @staticmethod
+    def endpoints(config):
+        return {(route['hostname'], address, 443) for route in config['routes']
+                if route['certificate_name'] == 'infra' for address in config['bind_addresses']}

--- a/roles/reverse_proxy/files/manifest.py
+++ b/roles/reverse_proxy/files/manifest.py
@@ -1,8 +1,12 @@
 """Private desired manifest snapshots, ingress binding, and effective selection."""
 import copy
 import hashlib
+import errno
 import json
 import os
+import re
+import ssl
+import uuid
 import stat
 
 import proxy_config
@@ -31,9 +35,10 @@ class Manifest:
         self.source = activator.state / 'desired.candidate.json'
         self.ingress = activator.state / 'ingress.candidate.json'
 
-    def read(self, path):
+    def read(self, path, *, gid=None, mode=0o600):
         self.a.parents(path)
-        expected = self.a.metadata(path, stat.S_ISREG, self.a.ids[0], self.a.ids[1], 0o600)
+        gid = self.a.ids[1] if gid is None else gid
+        expected = self.a.metadata(path, stat.S_ISREG, self.a.ids[0], gid, mode)
         fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
         try:
             before = os.fstat(fd)
@@ -100,3 +105,123 @@ class Manifest:
     def endpoints(config):
         return {(route['hostname'], address, 443) for route in config['routes']
                 if route['certificate_name'] == 'infra' for address in config['bind_addresses']}
+
+
+class Trust:
+    """Create immutable named bundles; the caller holds the Caddy lock."""
+    _stage = re.compile(r'\.trust-stage-([A-Za-z0-9][A-Za-z0-9_-]{0,63})-[0-9a-f]{32}\Z')
+    _pem = re.compile(r'(?:-----BEGIN CERTIFICATE-----\r?\n[A-Za-z0-9+/=\r\n]+-----END CERTIFICATE-----[ \t\r\n]*)+\Z')
+
+    def __init__(self, activator):
+        self.a = activator
+        self.manifests = Manifest(activator)
+        self.root = activator.config_dir / 'trust'
+        self.source = activator.state / 'trust.candidate.json'
+
+    @staticmethod
+    def no_acl(path):
+        listxattr = getattr(os, 'listxattr', None)
+        if listxattr is None:
+            return
+        try:
+            attributes = listxattr(path, follow_symlinks=False)
+        except OSError as error:
+            if error.errno in (errno.ENOTSUP, errno.EOPNOTSUPP):
+                return
+            raise
+        if set(attributes) & {'system.posix_acl_access', 'system.posix_acl_default'}:
+            raise ValueError('trust paths must not have extended or default ACLs')
+
+    def verify(self, target, expected):
+        self.no_acl(target)
+        actual = self.manifests.read(target, gid=self.a.ids[3], mode=0o640)
+        if actual != expected:
+            raise ValueError('trust name already identifies a different immutable bundle')
+
+    def remove_stage(self, stage):
+        match = self._stage.fullmatch(stage.name)
+        if stage.parent != self.root or match is None:
+            raise ValueError('trust preparation artifact name is invalid')
+        info = stage.lstat()
+        if (not stat.S_ISREG(info.st_mode) or info.st_uid != self.a.ids[0]
+                or info.st_gid not in (self.a.ids[1], self.a.ids[3])
+                or stat.S_IMODE(info.st_mode) not in (0o600, 0o640)
+                or info.st_nlink not in (1, 2)):
+            raise ValueError('trust preparation artifact metadata is invalid')
+        self.no_acl(stage)
+        if info.st_nlink == 2:
+            target = self.root / (match.group(1) + '.pem')
+            final = target.lstat()
+            if (not stat.S_ISREG(final.st_mode)
+                    or (final.st_dev, final.st_ino) != (info.st_dev, info.st_ino)
+                    or info.st_gid != self.a.ids[3] or stat.S_IMODE(info.st_mode) != 0o640):
+                raise ValueError('trust preparation link has unexpected authority')
+        stage.unlink()
+        self.a.fsync_directory(self.root)
+
+    def unchanged(self, raw):
+        if self.manifests.read(self.source) != raw:
+            raise ValueError('trust candidate changed during installation')
+
+    def install(self):
+        self.a.parents(self.root)
+        self.a.metadata(self.root, stat.S_ISDIR, self.a.ids[0], self.a.ids[3], 0o750)
+        self.no_acl(self.root)
+        self.no_acl(self.source)
+        raw = self.manifests.read(self.source)
+        values = decode(raw)
+        if not isinstance(values, dict) or len(values) > 64:
+            raise ValueError('trust candidate must be a bounded name-to-PEM mapping')
+        bundles = {}
+        for name, pem in values.items():
+            proxy_config._component(name, 'proxy trust name')
+            if (not isinstance(pem, str) or not 1 <= len(pem) <= 262144
+                    or self._pem.fullmatch(pem) is None):
+                raise ValueError('trust bundle must contain only bounded PEM certificates')
+            try:
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                context.load_verify_locations(cadata=pem)
+            except (ValueError, ssl.SSLError):
+                raise ValueError('trust bundle contains invalid certificates') from None
+            bundles[name] = pem.encode('ascii')
+        for stage in self.root.iterdir():
+            if stage.name.startswith('.trust-stage-'):
+                self.remove_stage(stage)
+        for name, contents in bundles.items():
+            target = self.root / (name + '.pem')
+            if os.path.lexists(target):
+                self.verify(target, contents)
+        changed = False
+        for name, contents in bundles.items():
+            target = self.root / (name + '.pem')
+            self.unchanged(raw)
+            if os.path.lexists(target):
+                self.verify(target, contents)
+                continue
+            stage = self.root / ('.trust-stage-' + name + '-' + uuid.uuid4().hex)
+            descriptor = os.open(stage, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+            try:
+                with os.fdopen(descriptor, 'wb') as output:
+                    os.fchown(output.fileno(), self.a.ids[0], self.a.ids[3])
+                    os.fchmod(output.fileno(), 0o640)
+                    output.write(contents)
+                    output.flush()
+                    os.fsync(output.fileno())
+                self.unchanged(raw)
+                try:
+                    # link(2) publishes complete bytes only when target is absent;
+                    # unlike rename/replace it cannot overwrite a competing name.
+                    os.link(stage, target, follow_symlinks=False)
+                    changed = True
+                    self.a.fsync_directory(self.root)
+                except FileExistsError:
+                    self.verify(target, contents)
+            finally:
+                if os.path.lexists(stage):
+                    self.remove_stage(stage)
+            restorecon = self.a.path('/usr/sbin/restorecon')
+            if restorecon.exists():
+                self.a.commands.run([str(restorecon), '-F', str(target)])
+            self.verify(target, contents)
+        self.unchanged(raw)
+        return 'changed' if changed else 'unchanged'

--- a/roles/reverse_proxy/filter_plugins/proxy.py
+++ b/roles/reverse_proxy/filter_plugins/proxy.py
@@ -1,6 +1,7 @@
 """Strict, deterministic inputs for the repository-owned reverse proxy."""
 
 import ipaddress
+import os
 import re
 from collections.abc import Mapping
 
@@ -9,6 +10,7 @@ _PRIVATE = tuple(ipaddress.ip_network(value) for value in (
 ))
 _LABEL = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\Z")
 _CERTIFICATE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}\Z")
+_PATH_COMPONENT = re.compile(r"[A-Za-z0-9._-]+\Z")
 
 
 def _private(value, network):
@@ -25,47 +27,177 @@ def _private(value, network):
     return str(address)
 
 
+def _hostname(value, description):
+    if (not isinstance(value, str) or len(value) > 253 or "." not in value
+            or any(not _LABEL.fullmatch(label) for label in value.lower().split("."))):
+        raise ValueError(f"{description} must be an exact DNS hostname")
+    result = value.lower()
+    try:
+        ipaddress.ip_address(result)
+    except ValueError:
+        return result
+    raise ValueError(f"{description} must be a DNS name, not an IP literal")
+
+
+def _component(value, description):
+    if not isinstance(value, str) or not _CERTIFICATE.fullmatch(value):
+        raise ValueError(f"{description} must be a restricted filesystem component")
+    return value
+
+
+def _port(value, minimum, description):
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= 65535:
+        raise ValueError(f"{description} must be an integer from {minimum} through 65535")
+    return int(value)
+
+
+def _device_backend(value):
+    if not isinstance(value, Mapping):
+        raise ValueError("proxy device backend must be a mapping")
+    transport = value.get("transport")
+    fields = {"transport", "address", "port"}
+    if transport == "https":
+        fields |= {"server_name", "trust_name"}
+    elif transport != "http":
+        raise ValueError("proxy device transport must be http or https")
+    if set(value) != fields:
+        raise ValueError("proxy device backend fields do not match its transport")
+    result = {
+        "transport": transport,
+        "address": _private(value["address"], False),
+        "port": _port(value["port"], 1, "proxy device backend port"),
+    }
+    if transport == "https":
+        result.update({
+            "server_name": _hostname(value["server_name"], "proxy TLS server name"),
+            "trust_name": _component(value["trust_name"], "proxy trust name"),
+        })
+    return result
+
+
 def validate(value):
     """Return canonical fields without accepting arbitrary template fragments."""
     fields = {"bind_addresses", "client_sources", "routes"}
-    if not isinstance(value, Mapping) or set(value) != fields:
-        raise ValueError("proxy configuration requires only bind_addresses, client_sources and routes")
+    allowed_fields = (fields, fields | {"deferred_certificates"})
+    if not isinstance(value, Mapping) or set(value) not in allowed_fields:
+        raise ValueError(
+            "proxy configuration requires bind_addresses, client_sources and routes, "
+            "with optional deferred_certificates"
+        )
     if any(not isinstance(value[field], list) for field in fields):
         raise ValueError("proxy configuration fields must be lists")
     result = {"bind_addresses": sorted(set(_private(item, False) for item in value["bind_addresses"])),
               "client_sources": sorted(set(_private(item, True) for item in value["client_sources"])),
               "routes": []}
+    if "deferred_certificates" in value:
+        deferred = value["deferred_certificates"]
+        if not isinstance(deferred, list) or deferred not in ([], ["infra"]):
+            raise ValueError("deferred_certificates must be [] or ['infra']")
+        result["deferred_certificates"] = list(deferred)
     if value["routes"] and (not result["bind_addresses"] or not result["client_sources"]):
         raise ValueError("configured proxy routes require bind addresses and client sources")
     hostnames = set()
     for route in value["routes"]:
-        if not isinstance(route, Mapping) or set(route) != {"hostname", "backend_port", "certificate_name"}:
-            raise ValueError("proxy route requires only hostname, backend_port and certificate_name")
-        hostname = route["hostname"]
-        if (not isinstance(hostname, str) or len(hostname) > 253 or "." not in hostname
-                or any(not _LABEL.fullmatch(label) for label in hostname.lower().split("."))):
-            raise ValueError("proxy hostname must be an exact DNS hostname")
-        hostname = hostname.lower()
-        try:
-            ipaddress.ip_address(hostname)
-        except ValueError:
-            pass
+        if not isinstance(route, Mapping):
+            raise ValueError("proxy route must be a mapping")
+        local_fields = {"hostname", "backend_port", "certificate_name"}
+        device_fields = {"hostname", "backend", "certificate_name"}
+        if set(route) == local_fields:
+            backend = {"backend_port": _port(
+                route["backend_port"], 1024, "proxy backend port"
+            )}
+        elif set(route) == device_fields:
+            backend = {"backend": _device_backend(route["backend"])}
         else:
-            raise ValueError("proxy hostname must be a DNS name, not an IP literal")
+            raise ValueError("proxy route must use exactly one local or device backend")
+        hostname = _hostname(route["hostname"], "proxy hostname")
         if hostname in hostnames:
             raise ValueError("proxy hostname is declared more than once")
         hostnames.add(hostname)
-        port = route["backend_port"]
-        if isinstance(port, bool) or not isinstance(port, int) or not 1024 <= port <= 65535:
-            raise ValueError("proxy backend port must be an integer from 1024 through 65535")
-        certificate = route["certificate_name"]
-        if not isinstance(certificate, str) or not _CERTIFICATE.fullmatch(certificate):
-            raise ValueError("proxy certificate name must be a restricted filesystem component")
-        result["routes"].append({"hostname": hostname, "backend_port": port, "certificate_name": certificate})
+        certificate = _component(route["certificate_name"], "proxy certificate name")
+        result["routes"].append({
+            "hostname": hostname,
+            "certificate_name": certificate,
+            **backend,
+        })
     result["routes"].sort(key=lambda route: route["hostname"])
     return result
 
 
+def _generation_directory(value):
+    try:
+        path = os.fspath(value)
+    except TypeError:
+        raise ValueError("certificate generation directories must be paths") from None
+    if not isinstance(path, str) or not path.startswith("/") or path.endswith("/"):
+        raise ValueError("certificate generation directories must be absolute paths")
+    components = path.split("/")[1:]
+    if (not components or any(component in ("", ".", "..")
+                              or not _PATH_COMPONENT.fullmatch(component)
+                              for component in components)):
+        raise ValueError("certificate generation directory is unsafe")
+    return path
+
+
+def _upstream(address, port):
+    return f"[{address}]:{port}" if ":" in address else f"{address}:{port}"
+
+
+def render(value, certificate_paths=None):
+    """Render a validated effective configuration using fixed Caddy syntax."""
+    config = validate(value)
+    if certificate_paths is None:
+        certificate_paths = {}
+    if not isinstance(certificate_paths, Mapping):
+        raise ValueError("certificate_paths must be a mapping")
+    certificates = {route["certificate_name"] for route in config["routes"]}
+    if set(certificate_paths) - certificates:
+        raise ValueError("certificate_paths contains an unknown certificate name")
+    selected_paths = {}
+    for name, path in certificate_paths.items():
+        _component(name, "certificate override name")
+        selected_paths[name] = _generation_directory(path)
+
+    lines = [
+        "{",
+        "\tadmin unix//run/caddy/admin.sock",
+        "\tauto_https off",
+        "\tservers {",
+        "\t\tprotocols h1 h2",
+        "\t}",
+        "}",
+    ]
+    for route in config["routes"]:
+        directory = selected_paths.get(
+            route["certificate_name"],
+            f"/etc/caddy/tls/{route['certificate_name']}/current",
+        )
+        lines.extend([
+            "",
+            f"https://{route['hostname']}:443 {{",
+            f"\tbind {' '.join(config['bind_addresses'])}",
+            f"\ttls {directory}/fullchain.pem {directory}/privkey.pem",
+        ])
+        if "backend_port" in route:
+            lines.append(f"\treverse_proxy 127.0.0.1:{route['backend_port']}")
+        else:
+            backend = route["backend"]
+            upstream = _upstream(backend["address"], backend["port"])
+            if backend["transport"] == "http":
+                lines.append(f"\treverse_proxy http://{upstream}")
+            else:
+                lines.extend([
+                    f"\treverse_proxy https://{upstream} {{",
+                    "\t\ttransport http {",
+                    f"\t\t\ttls_trusted_ca_certs /etc/caddy/trust/{backend['trust_name']}.pem",
+                    f"\t\t\ttls_server_name {backend['server_name']}",
+                    "\t\t}",
+                    "\t}",
+                ])
+        lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
 class FilterModule:
     def filters(self):
-        return {"reverse_proxy_validate": validate}
+        return {"reverse_proxy_validate": validate, "reverse_proxy_render": render}

--- a/roles/reverse_proxy/molecule/default/converge.yml
+++ b/roles/reverse_proxy/molecule/default/converge.yml
@@ -192,6 +192,10 @@
         follow: false
         force: true
 
+    - name: Exercise the installed TLS and Caddy integration before repeat provisioning
+      ansible.builtin.include_tasks: tasks/tls-integration.yml
+      when: reverse_proxy_molecule_first_activation
+
     - name: Apply and diagnose the valid two-route configuration
       block:
         - name: Apply the two-route reverse proxy configuration  # noqa: var-naming[no-role-prefix]

--- a/roles/reverse_proxy/molecule/default/diagnose.py
+++ b/roles/reverse_proxy/molecule/default/diagnose.py
@@ -141,6 +141,13 @@ def main():
         helper = load_helper()
         activator = helper.Activator()
         activator.preflight()
+        if not activator.candidate.exists():
+            try:
+                activator.manifest().candidate()
+            except Exception as error:
+                print(json.dumps({"stage": "desired-manifest",
+                                  "error_type": type(error).__name__}, sort_keys=True))
+                return 1
         adapted = activator.adapted(activator.candidate)
         activator.certificates(adapted)
         activator.caddy("validate", activator.candidate)

--- a/roles/reverse_proxy/molecule/default/molecule.yml
+++ b/roles/reverse_proxy/molecule/default/molecule.yml
@@ -18,6 +18,7 @@ platforms:
     container_command: /usr/lib/systemd/systemd
     container_cap_add:
       - SYS_PTRACE
+      - SYS_ADMIN
     container_privileged: false
     container_systemd: always
     restart_policy: always
@@ -36,6 +37,7 @@ platforms:
     container_command: /usr/lib/systemd/systemd
     container_cap_add:
       - SYS_PTRACE
+      - SYS_ADMIN
     container_privileged: false
     container_systemd: always
     restart_policy: always

--- a/roles/reverse_proxy/molecule/default/prepare.yml
+++ b/roles/reverse_proxy/molecule/default/prepare.yml
@@ -6,6 +6,60 @@
   vars:
     reverse_proxy_molecule_fixture_root: /var/lib/reverse-proxy-molecule
   tasks:
+    - name: Check the disposable coordinator sandbox before provisioning
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/systemd-run
+          - --unit=reverse-proxy-molecule-sandbox-probe
+          - --wait
+          - --pipe
+          - --collect
+          - --property=User=root
+          - --property=Group=root
+          - --property=NoNewPrivileges=yes
+          - --property=ProtectSystem=strict
+          - --property=ProtectHome=yes
+          - --property=PrivateTmp=yes
+          - --property=PrivateDevices=yes
+          - --property=ReadWritePaths=/var/lib
+          - /usr/bin/python3
+          - -c
+          - |
+            import errno
+            import tempfile
+            try:
+                with tempfile.TemporaryFile(dir='/usr/local'):
+                    pass
+            except OSError as error:
+                if error.errno != errno.EROFS:
+                    raise
+            else:
+                raise SystemExit('ProtectSystem=strict did not make /usr/local read-only')
+            with tempfile.TemporaryFile(dir='/var/lib'):
+                pass
+      register: reverse_proxy_molecule_sandbox_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Read bounded sandbox startup diagnostics
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/journalctl
+          - --unit=reverse-proxy-molecule-sandbox-probe.service
+          - --lines=20
+          - --no-pager
+          - --output=cat
+      register: reverse_proxy_molecule_sandbox_diagnostic
+      changed_when: false
+      when: reverse_proxy_molecule_sandbox_probe.rc != 0
+
+    - name: Require the disposable coordinator sandbox to start
+      ansible.builtin.assert:
+        that: reverse_proxy_molecule_sandbox_probe.rc == 0
+        fail_msg: >-
+          Sandbox startup failed: {{ reverse_proxy_molecule_sandbox_probe.stderr }}.
+          {{ reverse_proxy_molecule_sandbox_diagnostic.stdout | default('') }}
+
     - name: Discover the rootless container private address
       ansible.builtin.command:
         argv:

--- a/roles/reverse_proxy/molecule/default/prepare.yml
+++ b/roles/reverse_proxy/molecule/default/prepare.yml
@@ -6,6 +6,8 @@
   vars:
     reverse_proxy_molecule_fixture_root: /var/lib/reverse-proxy-molecule
   tasks:
+    # Inherit the system manager's root identity. Explicit User=root in nested
+    # Debian systemd loses the capability needed for the adapter's runuser call.
     - name: Check the disposable coordinator sandbox before provisioning
       ansible.builtin.command:
         argv:
@@ -14,7 +16,6 @@
           - --wait
           - --pipe
           - --collect
-          - --property=User=root
           - --property=Group=root
           - --property=NoNewPrivileges=yes
           - --property=ProtectSystem=strict
@@ -26,7 +27,18 @@
           - -c
           - |
             import errno
+            import os
+            from pathlib import Path
+            import subprocess
             import tempfile
+            assert os.getuid() == os.geteuid() == os.getgid() == os.getegid() == 0
+            print(next(line for line in Path('/proc/self/status').read_text().splitlines()
+                       if line.startswith('CapEff:')), flush=True)
+            identity = subprocess.run(
+                ['/usr/sbin/runuser', '-u', 'nobody', '--', '/usr/bin/id', '-u'],
+                capture_output=True, text=True, check=False)
+            assert identity.returncode == 0, identity.stderr
+            assert identity.stdout.strip() == '65534'
             try:
                 with tempfile.TemporaryFile(dir='/usr/local'):
                     pass

--- a/roles/reverse_proxy/molecule/default/tasks/tls-integration.yml
+++ b/roles/reverse_proxy/molecule/default/tasks/tls-integration.yml
@@ -65,6 +65,7 @@
     argv: [/usr/bin/python3, /usr/local/libexec/reverse-proxy-molecule-tls-integration.py, prepare]
   changed_when: false
 
+# Use the manager's root identity as verified by the early sandbox probe.
 - name: Exercise real publication with the coordinator filesystem restrictions
   ansible.builtin.command:
     argv:
@@ -73,7 +74,6 @@
       - --wait
       - --pipe
       - --collect
-      - --property=User=root
       - --property=Group=root
       - --property=NoNewPrivileges=yes
       - --property=ProtectSystem=strict

--- a/roles/reverse_proxy/molecule/default/tasks/tls-integration.yml
+++ b/roles/reverse_proxy/molecule/default/tasks/tls-integration.yml
@@ -1,0 +1,99 @@
+---
+- name: Read the disposable device trust bundle
+  ansible.builtin.slurp:
+    src: /var/lib/reverse-proxy-molecule/ca.pem
+  register: reverse_proxy_molecule_device_trust
+
+- name: Declare synthetic integrated application and device routes
+  ansible.builtin.set_fact:
+    reverse_proxy_molecule_tls_routes:
+      - hostname: other.example.test
+        backend_port: 18080
+        certificate_name: fixture
+      - hostname: room-alert.infra.example.com
+        certificate_name: infra
+        backend:
+          transport: http
+          address: "{{ reverse_proxy_molecule_address }}"
+          port: 80
+      - hostname: modem.infra.example.com
+        certificate_name: infra
+        backend:
+          transport: https
+          address: "{{ reverse_proxy_molecule_address }}"
+          port: 18443
+          server_name: app.example.test
+          trust_name: device_fixture_v1
+
+- name: Provision declared routes with the first infra certificate pending  # noqa: var-naming[no-role-prefix]
+  ansible.builtin.include_role:
+    name: reverse_proxy
+  vars:
+    reverse_proxy_bind_addresses: ["{{ reverse_proxy_molecule_address }}"]
+    reverse_proxy_client_sources: ["{{ reverse_proxy_molecule_address }}/32"]
+    reverse_proxy_routes: "{{ reverse_proxy_molecule_tls_routes }}"
+    reverse_proxy_deferred_certificates: [infra]
+    reverse_proxy_trust_certificates:
+      device_fixture_v1: "{{ reverse_proxy_molecule_device_trust.content | b64decode }}"
+    security_baseline_apply_firewall_runtime: false
+    os_baseline_verify_runtime_controls: false
+
+- name: Install the real TLS capability without an ACME credential  # noqa: var-naming[no-role-prefix]
+  ansible.builtin.include_role:
+    name: tls_automation
+  vars:
+    tls_automation_namespace: infra.example.com
+    tls_automation_email: acme@example.com
+    tls_automation_issuer_uid: 2010
+    tls_automation_issuer_gid: 2010
+    tls_automation_timer_enabled: false
+    reverse_proxy_bind_addresses: ["{{ reverse_proxy_molecule_address }}"]
+    reverse_proxy_client_sources: ["{{ reverse_proxy_molecule_address }}/32"]
+    reverse_proxy_routes: "{{ reverse_proxy_molecule_tls_routes }}"
+    reverse_proxy_deferred_certificates: [infra]
+
+- name: Install the bounded integrated TLS evidence driver
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/tls_integration.py"
+    dest: /usr/local/libexec/reverse-proxy-molecule-tls-integration.py
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Create disposable issued material without contacting ACME
+  ansible.builtin.command:
+    argv: [/usr/bin/python3, /usr/local/libexec/reverse-proxy-molecule-tls-integration.py, prepare]
+  changed_when: false
+
+- name: Exercise real publication with the coordinator filesystem restrictions
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/systemd-run
+      - --unit=reverse-proxy-molecule-tls-evidence
+      - --wait
+      - --pipe
+      - --collect
+      - --property=User=root
+      - --property=Group=root
+      - --property=NoNewPrivileges=yes
+      - --property=ProtectSystem=strict
+      - --property=ProtectHome=yes
+      - --property=PrivateTmp=yes
+      - --property=PrivateDevices=yes
+      - --property=ReadWritePaths=/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy
+      - --property=TimeoutStartSec=10min
+      - /usr/bin/python3
+      - /usr/local/libexec/reverse-proxy-molecule-tls-integration.py
+  register: reverse_proxy_molecule_tls_evidence
+  changed_when: false
+
+- name: Report integrated TLS evidence
+  ansible.builtin.debug:
+    var: reverse_proxy_molecule_tls_evidence.stdout_lines
+
+- name: Require the production renewal timer to remain disabled in the fixture
+  ansible.builtin.command:
+    argv: [/usr/bin/systemctl, is-enabled, homelab-tls-renew.timer]
+  register: reverse_proxy_molecule_tls_timer
+  changed_when: false
+  failed_when: reverse_proxy_molecule_tls_timer.stdout | trim != 'disabled'

--- a/roles/reverse_proxy/molecule/default/tasks/unexpected_failure.yml
+++ b/roles/reverse_proxy/molecule/default/tasks/unexpected_failure.yml
@@ -19,7 +19,9 @@
   ansible.builtin.command:
     argv:
       - /usr/local/libexec/homelab-reverse-proxy
-      - "{{ reverse_proxy_molecule_diagnostic_action }}"
+      - >-
+        {{ 'apply-desired' if reverse_proxy_molecule_diagnostic_action == 'apply'
+           else reverse_proxy_molecule_diagnostic_action }}
   register: reverse_proxy_molecule_helper_diagnostic
   changed_when: false
   failed_when: false

--- a/roles/reverse_proxy/molecule/default/tls_integration.py
+++ b/roles/reverse_proxy/molecule/default/tls_integration.py
@@ -1,0 +1,294 @@
+#!/usr/bin/python3
+"""Exercise installed TLS publication against real disposable Caddy services."""
+
+from datetime import datetime, timedelta, timezone
+import hashlib
+import http.client
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+from unittest import mock
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+FIXTURE = Path("/var/lib/reverse-proxy-molecule")
+HELPER = "/usr/local/libexec/homelab-reverse-proxy"
+MANAGED = {"room-alert.infra.example.com", "modem.infra.example.com"}
+
+
+def command(arguments, expected=0):
+    result = subprocess.run(arguments, stdin=subprocess.DEVNULL, capture_output=True,
+                            text=True, timeout=90, check=False)
+    if result.returncode != expected:
+        raise AssertionError("fixture operation failed: " + " ".join(arguments)
+                             + "\n" + result.stderr[:1000])
+    return result
+
+
+def material(number):
+    return ((FIXTURE / ("issued-" + str(number) + ".pem")).read_bytes(),
+            (FIXTURE / ("issued-" + str(number) + ".key")).read_bytes())
+
+
+def create_material(number):
+    ca = x509.load_pem_x509_certificate((FIXTURE / "ca.pem").read_bytes())
+    ca_key = serialization.load_pem_private_key((FIXTURE / "ca.key").read_bytes(), None)
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    certificate = (x509.CertificateBuilder()
+                   .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "TLS integration fixture")]))
+                   .issuer_name(ca.subject).public_key(key.public_key())
+                   .serial_number(x509.random_serial_number())
+                   .not_valid_before(now - timedelta(minutes=5))
+                   .not_valid_after(now + timedelta(days=2))
+                   .add_extension(x509.SubjectAlternativeName([x509.DNSName("*.infra.example.com")]), False)
+                   .add_extension(x509.BasicConstraints(ca=False, path_length=None), True)
+                   .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]), False)
+                   .sign(ca_key, hashes.SHA256()))
+    public = certificate.public_bytes(serialization.Encoding.PEM) + ca.public_bytes(serialization.Encoding.PEM)
+    private = key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+                                serialization.NoEncryption())
+    for suffix, data in (("pem", public), ("key", private)):
+        path = FIXTURE / ("issued-" + str(number) + "." + suffix)
+        path.write_bytes(data)
+        path.chmod(0o600)
+
+
+def fingerprint(number):
+    return x509.load_pem_x509_certificate(material(number)[0]).fingerprint(hashes.SHA256()).hex()
+
+
+def served(address, hostname, request=False):
+    with socket.create_connection((address, 443), timeout=10) as connection:
+        with ssl.create_default_context().wrap_socket(connection, server_hostname=hostname) as tls:
+            digest = hashlib.sha256(tls.getpeercert(binary_form=True)).hexdigest()
+            if request:
+                tls.sendall(("GET /ready HTTP/1.1\r\nHost: " + hostname
+                             + "\r\nConnection: close\r\n\r\n").encode())
+                response = http.client.HTTPResponse(tls)
+                response.begin()
+                body = response.read()
+                if response.status != 200 or b"device-fixture" not in body:
+                    raise AssertionError("private device backend did not receive the proxy request")
+            return digest
+
+
+class AdminConnection(http.client.HTTPConnection):
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX)
+        self.sock.settimeout(10)
+        self.sock.connect("/run/caddy/admin.sock")
+
+
+def active_configuration():
+    connection = AdminConnection("localhost")
+    try:
+        connection.request("GET", "/config/", headers={"Host": ""})
+        response = connection.getresponse()
+        if response.status != 200:
+            raise AssertionError("could not observe active Caddy configuration")
+        return json.loads(response.read())
+    finally:
+        connection.close()
+
+
+def route_names(value):
+    names = set()
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in {"host", "sni"} and isinstance(item, list):
+                names.update(item)
+            else:
+                names.update(route_names(item))
+    elif isinstance(value, list):
+        for item in value:
+            names.update(route_names(item))
+    return names
+
+
+class DeviceHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_arguments):
+        pass
+
+    def do_GET(self):
+        body = b"device-fixture\n"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def start_devices(address):
+    servers = []
+    for port in (80, 18443):
+        server = ThreadingHTTPServer((address, port), DeviceHandler)
+        if port == 18443:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain("/etc/caddy/tls/fixture/v1/fullchain.pem",
+                                    "/etc/caddy/tls/fixture/v1/privkey.pem")
+            server.socket = context.wrap_socket(server.socket, server_side=True)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        servers.append(server)
+    return servers
+
+
+def publish(runtime, policy, number, reject_after_serving=False):
+    original = runtime.verify_endpoints
+    rejected = False
+
+    def verify(selected_policy, digest):
+        nonlocal rejected
+        original(selected_policy, digest)
+        if reject_after_serving and not rejected:
+            rejected = True
+            raise ValueError("disposable post-activation failure")
+
+    with mock.patch.object(runtime, "verify_endpoints", verify):
+        with runtime.publication_locked(policy) as deployment:
+            return runtime.publisher_for(policy, deployment).publish(*material(number))
+
+
+def crash_publication(runtime, policy, stage, number):
+    from tls_runtime.publication import Publisher
+    original = Publisher._write_journal
+
+    def interrupt(publisher, record):
+        original(publisher, record)
+        if record["status"] == stage:
+            os._exit(86)
+
+    with mock.patch.object(Publisher, "_write_journal", interrupt):
+        publish(runtime, policy, number)
+    raise AssertionError("interruption point was not reached")
+
+
+def run(runtime, policy):
+    from tls_runtime.publication import PublicationError
+    address = policy.endpoints[0]["address"]
+    original_unrelated = served(address, "other.example.test")
+    servers = start_devices(address)
+    try:
+        if runtime.PUBLISHED.joinpath("current").exists():
+            raise AssertionError("first-publication fixture already has a certificate")
+        if MANAGED & route_names(active_configuration()):
+            raise AssertionError("unissued routes were activated")
+        try:
+            publish(runtime, policy, 1, reject_after_serving=True)
+        except PublicationError as error:
+            if error.restoration_failed:
+                raise
+        else:
+            raise AssertionError("failed first publication unexpectedly succeeded")
+        if os.path.lexists(runtime.PUBLISHED / "current") or runtime.JOURNAL.exists():
+            raise AssertionError("failed first publication retained active or unfinished state")
+        if MANAGED & route_names(active_configuration()):
+            raise AssertionError("failed first publication retained affected routes")
+        if served(address, "other.example.test") != original_unrelated:
+            raise AssertionError("failed first publication changed unrelated TLS")
+        print("PASS failed first publication preserves unrelated service", flush=True)
+
+        if not publish(runtime, policy, 1):
+            raise AssertionError("first publication was not recorded")
+        for name in MANAGED:
+            if served(address, name, request=True) != fingerprint(1):
+                raise AssertionError("first served certificate differs from issued leaf")
+        if publish(runtime, policy, 1):
+            raise AssertionError("identical material unexpectedly created another generation")
+        print("PASS first publication, private HTTP/HTTPS devices, identical-material reload", flush=True)
+
+        publish(runtime, policy, 2)
+        for name in MANAGED:
+            if served(address, name) != fingerprint(2):
+                raise AssertionError("renewal did not replace served leaf")
+        try:
+            publish(runtime, policy, 3, reject_after_serving=True)
+        except PublicationError as error:
+            if error.restoration_failed:
+                raise
+        else:
+            raise AssertionError("forced renewal activation failure was ignored")
+        if runtime.JOURNAL.exists() or served(address, next(iter(MANAGED))) != fingerprint(2):
+            raise AssertionError("renewal rollback did not restore the old served leaf")
+        print("PASS renewal, served-leaf replacement and rollback", flush=True)
+
+        for stage, number in (("prepared", 3), ("switched", 4)):
+            command([sys.executable, __file__, "crash", stage, str(number)], expected=86)
+            if not runtime.JOURNAL.exists():
+                raise AssertionError("interruption lost the durable transaction")
+            envelope = Path("/var/lib/homelab-reverse-proxy/desired.json").read_bytes()
+            command([HELPER, "apply-desired"], expected=1)
+            if Path("/var/lib/homelab-reverse-proxy/desired.json").read_bytes() != envelope:
+                raise AssertionError("concurrent configuration replaced recovery authority")
+            command(["/usr/bin/systemctl", "restart", "caddy.service"])
+            with runtime.publication_locked(policy) as deployment:
+                runtime.publisher_for(policy, deployment).recover()
+            if runtime.JOURNAL.exists():
+                raise AssertionError("interrupted publication did not complete recovery")
+            for name in MANAGED:
+                if served(address, name) != fingerprint(number):
+                    raise AssertionError("recovery did not activate retained issued material")
+            print("PASS interrupted " + stage + " recovery and blocked configuration change", flush=True)
+
+        process = None
+        try:
+            with runtime.publication_locked(policy) as deployment:
+                process = subprocess.Popen([HELPER, "apply-desired"], stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE, text=True)
+                try:
+                    process.wait(timeout=0.3)
+                except subprocess.TimeoutExpired:
+                    pass
+                else:
+                    raise AssertionError("configuration operation did not wait for publication lock")
+                runtime.publisher_for(policy, deployment).publish(*material(1))
+            output, error = process.communicate(timeout=90)
+            if process.returncode:
+                raise AssertionError("serialized configuration failed: " + output + error)
+        finally:
+            if process is not None and process.poll() is None:
+                process.kill()
+                process.wait()
+        for name in MANAGED:
+            if served(address, name, request=True) != fingerprint(1):
+                raise AssertionError("concurrent operation changed selected certificate")
+        if served(address, "other.example.test") != original_unrelated:
+            raise AssertionError("publication changed unrelated certificate")
+        command([HELPER, "verify"])
+        print("PASS concurrent configuration/certificate serialization and final verification", flush=True)
+    finally:
+        for server in servers:
+            server.shutdown()
+            server.server_close()
+
+
+def main():
+    if not Path("/run/.containerenv").exists() or not (FIXTURE / "ca.key").is_file():
+        raise RuntimeError("TLS integration fixture requires its disposable Podman target")
+    sys.path.insert(0, "/usr/local/lib/homelab-tls")
+    from tls_runtime import runtime
+    policy = runtime.load_policy()
+    if policy.namespace != "infra.example.com" or {item["hostname"] for item in policy.endpoints} != MANAGED:
+        raise RuntimeError("TLS integration fixture refuses non-fixture policy")
+    if sys.argv[1:] == ["prepare"]:
+        for number in range(1, 5):
+            create_material(number)
+    elif len(sys.argv) == 4 and sys.argv[1] == "crash":
+        crash_publication(runtime, policy, sys.argv[2], int(sys.argv[3]))
+    elif len(sys.argv) == 1:
+        run(runtime, policy)
+    else:
+        raise ValueError("invalid disposable fixture arguments")
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/reverse_proxy/molecule/default/tls_integration.py
+++ b/roles/reverse_proxy/molecule/default/tls_integration.py
@@ -53,6 +53,7 @@ def create_material(number):
                    .not_valid_after(now + timedelta(days=2))
                    .add_extension(x509.SubjectAlternativeName([x509.DNSName("*.infra.example.com")]), False)
                    .add_extension(x509.BasicConstraints(ca=False, path_length=None), True)
+                   .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()), False)
                    .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]), False)
                    .sign(ca_key, hashes.SHA256()))
     public = certificate.public_bytes(serialization.Encoding.PEM) + ca.public_bytes(serialization.Encoding.PEM)
@@ -181,7 +182,12 @@ def publish(runtime, policy, number, reject_after_serving=False, partial_listene
 
     with mock.patch.object(runtime, "verify_endpoints", verify):
         with runtime.publication_locked(policy) as deployment:
-            return runtime.publisher_for(policy, deployment).publish(*material(number))
+            try:
+                return runtime.publisher_for(policy, deployment).publish(*material(number))
+            except Exception as error:
+                if reject_after_serving and not rejected:
+                    raise AssertionError("activation failed before the intended served-certificate fault") from error
+                raise
 
 
 def crash_publication(runtime, policy, stage, number):
@@ -315,6 +321,8 @@ def run(runtime, policy):
 
 
 def main():
+    if (os.getuid(), os.geteuid(), os.getgid(), os.getegid()) != (0, 0, 0, 0):
+        raise RuntimeError("TLS integration fixture requires the system manager's root identity")
     if not Path("/run/.containerenv").exists() or not (FIXTURE / "ca.key").is_file():
         raise RuntimeError("TLS integration fixture requires its disposable Podman target")
     sys.path.insert(0, "/usr/local/lib/homelab-tls")

--- a/roles/reverse_proxy/molecule/default/tls_integration.py
+++ b/roles/reverse_proxy/molecule/default/tls_integration.py
@@ -142,7 +142,31 @@ def start_devices(address):
     return servers
 
 
-def publish(runtime, policy, number, reject_after_serving=False):
+def fail_native_load(policy):
+    """Reproduce the existing partial-listener regression on the real service."""
+    address = policy.endpoints[0]["address"]
+    candidate = Path("/etc/caddy/Caddyfile.fixture-failed-load")
+    contents = Path("/etc/caddy/Caddyfile").read_text()
+    changed = contents.replace("bind " + address, "bind " + address + " 192.168.255.254")
+    if changed == contents:
+        raise AssertionError("fixture failed to construct the unavailable listener")
+    try:
+        candidate.write_text(changed)
+        os.chown(candidate, 0, policy.reader_gid)
+        candidate.chmod(0o640)
+        command(["/usr/sbin/runuser", "-u", "caddy", "--", "/usr/bin/caddy", "reload",
+                 "--config", str(candidate), "--adapter", "caddyfile",
+                 "--address", "unix//run/caddy/admin.sock", "--force"], expected=1)
+    finally:
+        candidate.unlink(missing_ok=True)
+
+
+def caddy_pid():
+    return command(["/usr/bin/systemctl", "show", "--property=MainPID", "--value",
+                    "caddy.service"]).stdout.strip()
+
+
+def publish(runtime, policy, number, reject_after_serving=False, partial_listener=False):
     original = runtime.verify_endpoints
     rejected = False
 
@@ -151,6 +175,8 @@ def publish(runtime, policy, number, reject_after_serving=False):
         original(selected_policy, digest)
         if reject_after_serving and not rejected:
             rejected = True
+            if partial_listener:
+                fail_native_load(selected_policy)
             raise ValueError("disposable post-activation failure")
 
     with mock.patch.object(runtime, "verify_endpoints", verify):
@@ -220,6 +246,23 @@ def run(runtime, policy):
         if runtime.JOURNAL.exists() or served(address, next(iter(MANAGED))) != fingerprint(2):
             raise AssertionError("renewal rollback did not restore the old served leaf")
         print("PASS renewal, served-leaf replacement and rollback", flush=True)
+
+        previous_pid = caddy_pid()
+        try:
+            publish(runtime, policy, 3, reject_after_serving=True, partial_listener=True)
+        except PublicationError as error:
+            if error.restoration_failed:
+                raise
+        else:
+            raise AssertionError("partial listener failure unexpectedly succeeded")
+        if caddy_pid() == previous_pid or runtime.JOURNAL.exists():
+            raise AssertionError("automatic restart did not finish coupled rollback recovery")
+        for name in MANAGED:
+            if served(address, name) != fingerprint(2):
+                raise AssertionError("automatic restart did not restore the previous certificate")
+        if served(address, "other.example.test") != original_unrelated:
+            raise AssertionError("automatic restart changed unrelated TLS")
+        print("PASS automatic rollback restart outside deployment lock", flush=True)
 
         for stage, number in (("prepared", 3), ("switched", 4)):
             command([sys.executable, __file__, "crash", stage, str(number)], expected=86)

--- a/roles/reverse_proxy/molecule/default/verify.yml
+++ b/roles/reverse_proxy/molecule/default/verify.yml
@@ -735,9 +735,6 @@
             reverse_proxy_molecule_external_certificates.results
             | map(attribute='stat.mode') | list | unique == ['0640']
 
-    - name: Exercise the installed TLS and Caddy integration
-      ansible.builtin.include_tasks: tasks/tls-integration.yml
-
     - name: Report rootless firewall runtime evidence boundary
       ansible.builtin.debug:
         msg: >-

--- a/roles/reverse_proxy/molecule/default/verify.yml
+++ b/roles/reverse_proxy/molecule/default/verify.yml
@@ -232,6 +232,11 @@
         checksum_algorithm: sha256
       register: reverse_proxy_molecule_healthy_boot
 
+    - name: Isolate legacy Caddyfile fault injection from managed manifest ownership
+      ansible.builtin.file:
+        path: /var/lib/homelab-reverse-proxy/desired.json
+        state: absent
+
     - name: Reject invalid certificate material without disturbing healthy state
       ansible.builtin.include_tasks: tasks/certificate_failure.yml
       loop:
@@ -247,11 +252,6 @@
       loop_control:
         loop_var: reverse_proxy_molecule_certificate_failure
         label: "{{ reverse_proxy_molecule_certificate_failure.name }}"
-
-    - name: Isolate legacy Caddyfile fault injection from managed manifest ownership
-      ansible.builtin.file:
-        path: /var/lib/homelab-reverse-proxy/desired.json
-        state: absent
 
     - name: Start a WebSocket session across failed validation
       ansible.builtin.command:

--- a/roles/reverse_proxy/molecule/default/verify.yml
+++ b/roles/reverse_proxy/molecule/default/verify.yml
@@ -248,6 +248,11 @@
         loop_var: reverse_proxy_molecule_certificate_failure
         label: "{{ reverse_proxy_molecule_certificate_failure.name }}"
 
+    - name: Isolate legacy Caddyfile fault injection from managed manifest ownership
+      ansible.builtin.file:
+        path: /var/lib/homelab-reverse-proxy/desired.json
+        state: absent
+
     - name: Start a WebSocket session across failed validation
       ansible.builtin.command:
         argv: >-
@@ -729,6 +734,9 @@
           - >-
             reverse_proxy_molecule_external_certificates.results
             | map(attribute='stat.mode') | list | unique == ['0640']
+
+    - name: Exercise the installed TLS and Caddy integration
+      ansible.builtin.include_tasks: tasks/tls-integration.yml
 
     - name: Report rootless firewall runtime evidence boundary
       ansible.builtin.debug:

--- a/roles/reverse_proxy/tasks/configure.yml
+++ b/roles/reverse_proxy/tasks/configure.yml
@@ -10,6 +10,7 @@
     - /etc/tmpfiles.d
     - /usr
     - /usr/local
+    - /usr/local/lib
     - /var
     - /var/lib
     - /run
@@ -42,6 +43,8 @@
   loop:
     - /etc/caddy
     - /etc/caddy/tls
+    - /etc/caddy/trust
+    - /usr/local/lib/homelab-reverse-proxy
     - /var/lib/caddy
     - /var/lib/homelab-reverse-proxy
     - /usr/local/libexec
@@ -81,6 +84,12 @@
     - /etc/caddy/Caddyfile.candidate
     - /var/lib/homelab-reverse-proxy/managed
     - /usr/local/libexec/homelab-reverse-proxy
+    - /usr/local/lib/homelab-reverse-proxy/proxy_config.py
+    - /usr/local/lib/homelab-reverse-proxy/proxy_manifest.py
+    - /var/lib/homelab-reverse-proxy/desired.candidate.json
+    - /var/lib/homelab-reverse-proxy/ingress.candidate.json
+    - /var/lib/homelab-reverse-proxy/trust.candidate.json
+    - /var/lib/homelab-reverse-proxy/desired.json
     - /etc/systemd/system/caddy.service.d/override.conf
     - /etc/tmpfiles.d/homelab-reverse-proxy.conf
     - /run/lock/homelab-reverse-proxy.lock
@@ -114,6 +123,8 @@
   loop:
     - {path: /etc/caddy, group: caddy, mode: '0750'}
     - {path: /etc/caddy/tls, group: caddy, mode: '0750'}
+    - {path: /etc/caddy/trust, group: caddy, mode: '0750'}
+    - {path: /usr/local/lib/homelab-reverse-proxy, group: root, mode: '0755'}
     - {path: /var/lib/homelab-reverse-proxy, group: root, mode: '0700'}
     - {path: /usr/local/libexec, group: root, mode: '0755'}
     - {path: /etc/systemd/system/caddy.service.d, group: root, mode: '0755'}
@@ -158,6 +169,22 @@
     group: root
     mode: '0755'
 
+- name: Install the shared strict proxy renderer
+  ansible.builtin.copy:
+    src: "{{ role_path }}/filter_plugins/proxy.py"
+    dest: /usr/local/lib/homelab-reverse-proxy/proxy_config.py
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Install the desired manifest runtime
+  ansible.builtin.copy:
+    src: manifest.py
+    dest: /usr/local/lib/homelab-reverse-proxy/proxy_manifest.py
+    owner: root
+    group: root
+    mode: '0644'
+
 - name: Install reverse proxy volatile path policy
   ansible.builtin.template:
     src: homelab-reverse-proxy.tmpfiles.j2
@@ -192,6 +219,49 @@
     mode: '0600'
     access_time: preserve
     modification_time: preserve
+
+- name: Prepare declared device trust for fixed installation
+  ansible.builtin.copy:
+    content: "{{ reverse_proxy_trust_certificates | to_json(sort_keys=true) }}"
+    dest: /var/lib/homelab-reverse-proxy/trust.candidate.json
+    owner: root
+    group: root
+    mode: '0600'
+  no_log: true
+  diff: false
+
+- name: Install immutable device trust under the deployment lock
+  ansible.builtin.command:
+    argv: [/usr/local/libexec/homelab-reverse-proxy, install-trust]
+  register: reverse_proxy_trust_installation
+  changed_when: reverse_proxy_trust_installation.stdout | trim == 'changed'
+  no_log: true
+
+- name: Observe each declared immutable device trust bundle
+  ansible.builtin.stat:
+    path: "/etc/caddy/trust/{{ item.key }}.pem"
+    follow: false
+    checksum_algorithm: sha256
+    get_mime: false
+    get_attributes: false
+  loop: "{{ reverse_proxy_trust_certificates | dict2items }}"
+  register: reverse_proxy_installed_trust
+  no_log: true
+
+- name: Require this deployment's exact immutable trust contents
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+      - item.stat.isreg | default(false)
+      - not item.stat.islnk | default(false)
+      - item.stat.uid | default(-1) == 0
+      - item.stat.gr_name | default('') == 'caddy'
+      - item.stat.nlink | default(0) == 1
+      - item.stat.mode | default('') == '0640'
+      - item.stat.checksum | default('') == (item.item.value | hash('sha256'))
+    fail_msg: The immutable trust name differs from this declaration; use a new name
+  loop: "{{ reverse_proxy_installed_trust.results }}"
+  no_log: true
 
 - name: Install hardened reverse proxy systemd override
   ansible.builtin.template:

--- a/roles/reverse_proxy/tasks/filesystem-preflight.yml
+++ b/roles/reverse_proxy/tasks/filesystem-preflight.yml
@@ -10,6 +10,7 @@
     - /etc/tmpfiles.d
     - /usr
     - /usr/local
+    - /usr/local/lib
     - /var
     - /var/lib
     - /run
@@ -42,6 +43,8 @@
   loop:
     - /etc/caddy
     - /etc/caddy/tls
+    - /etc/caddy/trust
+    - /usr/local/lib/homelab-reverse-proxy
     - /var/lib/caddy
     - /var/lib/homelab-reverse-proxy
     - /usr/local/libexec
@@ -81,6 +84,12 @@
     - /etc/caddy/Caddyfile.candidate
     - /var/lib/homelab-reverse-proxy/managed
     - /usr/local/libexec/homelab-reverse-proxy
+    - /usr/local/lib/homelab-reverse-proxy/proxy_config.py
+    - /usr/local/lib/homelab-reverse-proxy/proxy_manifest.py
+    - /var/lib/homelab-reverse-proxy/desired.candidate.json
+    - /var/lib/homelab-reverse-proxy/ingress.candidate.json
+    - /var/lib/homelab-reverse-proxy/trust.candidate.json
+    - /var/lib/homelab-reverse-proxy/desired.json
     - /etc/systemd/system/caddy.service.d/override.conf
     - /etc/tmpfiles.d/homelab-reverse-proxy.conf
     - /run/lock/homelab-reverse-proxy.lock

--- a/roles/reverse_proxy/tasks/main.yml
+++ b/roles/reverse_proxy/tasks/main.yml
@@ -34,18 +34,39 @@
     os_baseline_verify_expected_firewall_services: >-
       {{ reverse_proxy_expected_firewall_services }}
 
-- name: Render candidate reverse proxy configuration
-  ansible.builtin.template:
-    src: Caddyfile.j2
-    dest: /etc/caddy/Caddyfile.candidate
-    owner: root
-    group: caddy
-    mode: '0640'
+- name: Serialize the declared reverse proxy manifest
+  ansible.builtin.set_fact:
+    reverse_proxy_manifest_bytes: >-
+      {{ reverse_proxy_config | to_json(sort_keys=true) }}
   no_log: true
+
+- name: Install candidate desired reverse proxy manifest
+  ansible.builtin.copy:
+    content: "{{ reverse_proxy_manifest_bytes }}"
+    dest: /var/lib/homelab-reverse-proxy/desired.candidate.json
+    owner: root
+    group: root
+    mode: '0600'
+  no_log: true
+  diff: false
+
+- name: Bind the candidate to the verified ingress policy
+  ansible.builtin.copy:
+    content: >-
+      {{ {'version': 1,
+          'manifest_sha256': reverse_proxy_manifest_bytes | hash('sha256'),
+          'listen_addresses': reverse_proxy_config.bind_addresses,
+          'https_client_networks': reverse_proxy_config.client_sources} | to_nice_json }}
+    dest: /var/lib/homelab-reverse-proxy/ingress.candidate.json
+    owner: root
+    group: root
+    mode: '0600'
+  no_log: true
+  diff: false
 
 - name: Activate candidate reverse proxy configuration
   ansible.builtin.command:
-    argv: [/usr/local/libexec/homelab-reverse-proxy, apply]
+    argv: [/usr/local/libexec/homelab-reverse-proxy, apply-desired]
   register: reverse_proxy_activation
   changed_when: reverse_proxy_activation.stdout | trim == 'changed'
   no_log: true

--- a/roles/reverse_proxy/tasks/validate.yml
+++ b/roles/reverse_proxy/tasks/validate.yml
@@ -25,10 +25,23 @@
       {{ {
            'bind_addresses': reverse_proxy_bind_addresses,
            'client_sources': reverse_proxy_client_sources,
-           'routes': reverse_proxy_routes
+           'routes': reverse_proxy_routes,
+           'deferred_certificates': reverse_proxy_deferred_certificates
          } | reverse_proxy_validate }}
     reverse_proxy_expected_management_sources: >-
       {{ security_baseline_management_sources | default([]) }}
     reverse_proxy_expected_firewall_services: >-
       {{ security_baseline_firewall_services | default([]) }}
+  no_log: true
+
+- name: Require explicitly named device trust material
+  ansible.builtin.assert:
+    that:
+      - reverse_proxy_trust_certificates is mapping
+      - item.key is string
+      - item.key is match('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')
+      - item.value is string
+      - item.value | length > 0
+    fail_msg: Device trust inputs require safe names and explicit certificate content
+  loop: "{{ reverse_proxy_trust_certificates | dict2items }}"
   no_log: true

--- a/roles/reverse_proxy/tasks/verify.yml
+++ b/roles/reverse_proxy/tasks/verify.yml
@@ -77,7 +77,11 @@
     - {path: /etc/caddy, kind: directory, owner: root, group: caddy, mode: '0750'}
     - {path: /etc/caddy/tls, kind: directory, owner: root, group: caddy, mode: '0750'}
     - {path: /etc/caddy/Caddyfile, kind: file, owner: root, group: caddy, mode: '0640'}
-    - {path: /etc/caddy/Caddyfile.candidate, kind: file, owner: root, group: caddy, mode: '0640'}
+    - {path: /var/lib/homelab-reverse-proxy/desired.json, kind: file, owner: root, group: root, mode: '0600'}
+    - {path: /etc/caddy/trust, kind: directory, owner: root, group: caddy, mode: '0750'}
+    - {path: /usr/local/lib/homelab-reverse-proxy, kind: directory, owner: root, group: root, mode: '0755'}
+    - {path: /usr/local/lib/homelab-reverse-proxy/proxy_config.py, kind: file, owner: root, group: root, mode: '0644'}
+    - {path: /usr/local/lib/homelab-reverse-proxy/proxy_manifest.py, kind: file, owner: root, group: root, mode: '0644'}
     - {path: /var/lib/caddy, kind: directory, owner: caddy, group: caddy, mode: '0700'}
     - {path: /var/lib/homelab-reverse-proxy, kind: directory, owner: root, group: root, mode: '0700'}
     - {path: /var/lib/homelab-reverse-proxy/managed, kind: file, owner: root, group: root, mode: '0600'}
@@ -109,18 +113,30 @@
   loop_control:
     label: "{{ item.item.path }}"
 
-- name: Verify committed configuration matches declared routes
+- name: Read the protected committed desired manifest
+  ansible.builtin.slurp:
+    src: /var/lib/homelab-reverse-proxy/desired.json
+  register: reverse_proxy_verify_manifest
+  no_log: true
+
+- name: Verify committed desired configuration matches declared routes
+  vars:
+    reverse_proxy_verify_envelope: "{{ reverse_proxy_verify_manifest.content | b64decode | from_json }}"
   ansible.builtin.assert:
     that:
+      - reverse_proxy_verify_envelope.version == 1
+      - reverse_proxy_verify_envelope.ingress.version == 1
       - >-
-        reverse_proxy_verify_paths.results[2].stat.checksum
-        == (lookup(
-              'ansible.builtin.template',
-              'Caddyfile.j2'
-            ) | hash('sha256'))
+        (reverse_proxy_verify_envelope.manifest | from_json | reverse_proxy_validate)
+        == reverse_proxy_config
+      - >-
+        reverse_proxy_verify_envelope.ingress.manifest_sha256
+        == (reverse_proxy_verify_envelope.manifest | hash('sha256'))
+      - reverse_proxy_verify_envelope.ingress.listen_addresses == reverse_proxy_config.bind_addresses
+      - reverse_proxy_verify_envelope.ingress.https_client_networks == reverse_proxy_config.client_sources
     fail_msg: >-
-      The committed Caddy configuration does not match the declared reverse
-      proxy routes
+      The committed desired manifest does not match the declared reverse proxy
+      routes and verified ingress policy
   no_log: true
 
 - name: Read installed Caddy version

--- a/roles/reverse_proxy/templates/Caddyfile.j2
+++ b/roles/reverse_proxy/templates/Caddyfile.j2
@@ -1,15 +1,1 @@
-{
-	admin unix//run/caddy/admin.sock
-	auto_https off
-	servers {
-		protocols h1 h2
-	}
-}
-{% for route in reverse_proxy_config.routes %}
-
-https://{{ route.hostname }}:443 {
-	bind {{ reverse_proxy_config.bind_addresses | join(' ') }}
-	tls /etc/caddy/tls/{{ route.certificate_name }}/current/fullchain.pem /etc/caddy/tls/{{ route.certificate_name }}/current/privkey.pem
-	reverse_proxy 127.0.0.1:{{ route.backend_port }}
-}
-{% endfor %}
+{{ reverse_proxy_config | reverse_proxy_render -}}

--- a/roles/security_baseline/files/validate_repository_trust.py
+++ b/roles/security_baseline/files/validate_repository_trust.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 import shlex
+import stat
 import subprocess
 import sys
 import urllib.parse
@@ -29,8 +31,16 @@ DEBIAN_SOURCE_BYPASSES = {
     "allow-weak",
     "allow-downgrade-to-insecure",
 }
-ROCKY_ALLOWED_REPOSITORIES = {"baseos", "appstream", "extras", "crb"}
-ROCKY_KEY = re.compile(r"^/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9$")
+ROCKY_REPOSITORY_KEYS = {
+    repository_id: "/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9"
+    for repository_id in ("baseos", "appstream", "extras", "crb")
+}
+CADDY_EPEL_REPOSITORY_KEYS = {
+    repository_id: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9"
+    for repository_id in ("epel", "epel-cisco-openh264")
+}
+CADDY_MANAGED_MARKER = "/var/lib/homelab-reverse-proxy/managed"
+CADDY_MANAGED_MARKER_CONTENT = b"managed by homelab-playbook\n"
 TRUE_VALUES = {"1", "yes", "true", "on"}
 
 
@@ -212,6 +222,56 @@ def _path_is_in_reposdir(path: str, reposdirs: list[str], root: pathlib.Path) ->
     return any(candidate.is_relative_to(_rooted(root, directory).resolve()) for directory in reposdirs)
 
 
+def _is_exact_caddy_marker(metadata: os.stat_result) -> bool:
+    return (
+        stat.S_ISREG(metadata.st_mode)
+        and stat.S_IMODE(metadata.st_mode) == 0o600
+        and metadata.st_uid == 0
+        and metadata.st_gid == 0
+        and metadata.st_nlink == 1
+        and metadata.st_size == len(CADDY_MANAGED_MARKER_CONTENT)
+    )
+
+
+def _caddy_owns_epel(root: pathlib.Path) -> bool:
+    """Accept the fixed Caddy marker without following or blocking on unsafe files."""
+    marker = _rooted(root, CADDY_MANAGED_MARKER)
+    try:
+        descriptor = os.open(
+            marker,
+            os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+    except OSError:
+        return False
+
+    try:
+        before = os.fstat(descriptor)
+        if not _is_exact_caddy_marker(before):
+            return False
+        content = os.read(descriptor, len(CADDY_MANAGED_MARKER_CONTENT) + 1)
+        after = os.fstat(descriptor)
+        stable_fields = (
+            "st_dev",
+            "st_ino",
+            "st_mode",
+            "st_nlink",
+            "st_uid",
+            "st_gid",
+            "st_size",
+            "st_mtime_ns",
+            "st_ctime_ns",
+        )
+        return (
+            _is_exact_caddy_marker(after)
+            and all(getattr(before, field) == getattr(after, field) for field in stable_fields)
+            and content == CADDY_MANAGED_MARKER_CONTENT
+        )
+    except OSError:
+        return False
+    finally:
+        os.close(descriptor)
+
+
 def validate_rocky_configuration(
     effective: Mapping[str, object],
     root: pathlib.Path = pathlib.Path("/"),
@@ -235,10 +295,14 @@ def validate_rocky_configuration(
     ]
     if not repositories:
         raise ValueError("DNF has no enabled distribution repository")
+    caddy_owns_epel = _caddy_owns_epel(root)
     for repository in repositories:
-        repository_id = str(repository.get("id", "")).lower()
-        if repository_id not in ROCKY_ALLOWED_REPOSITORIES:
-            raise ValueError("enabled DNF repository is not a Rocky distribution repository")
+        repository_id = str(repository.get("id", ""))
+        expected_key = ROCKY_REPOSITORY_KEYS.get(repository_id.lower())
+        if expected_key is None and caddy_owns_epel:
+            expected_key = CADDY_EPEL_REPOSITORY_KEYS.get(repository_id)
+        if expected_key is None:
+            raise ValueError("enabled DNF repository is not an approved repository")
         if repository.get("gpgcheck") is not True:
             raise ValueError("effective DNF repository package signature checking is disabled")
         repofile = str(repository.get("repofile", ""))
@@ -246,13 +310,13 @@ def validate_rocky_configuration(
             raise ValueError("enabled DNF repository is outside effective reposdir")
         keys = [str(value) for value in repository.get("gpgkey", [])]
         if not keys:
-            raise ValueError("enabled DNF repository has no Rocky distribution key")
+            raise ValueError("enabled DNF repository has no approved repository key")
         for key in keys:
             parsed = urllib.parse.urlparse(key)
-            if parsed.scheme != "file" or parsed.netloc or not ROCKY_KEY.fullmatch(parsed.path):
-                raise ValueError("enabled DNF repository uses a non-Rocky key")
+            if parsed.scheme != "file" or parsed.netloc or parsed.path != expected_key:
+                raise ValueError("enabled DNF repository does not use its approved key")
             if not _rooted(root, parsed.path).is_file():
-                raise ValueError("configured Rocky distribution key is absent")
+                raise ValueError("configured approved repository key is absent")
 
 
 def _collect_rocky_configuration() -> dict[str, object]:

--- a/roles/system_maintenance/molecule/baseline/converge.yml
+++ b/roles/system_maintenance/molecule/baseline/converge.yml
@@ -124,6 +124,8 @@
       ansible.builtin.include_role:
         name: reverse_proxy
       vars:
+        security_baseline_management_sources:
+          - 10.0.0.0/8
         security_baseline_apply_firewall_runtime: false
         os_baseline_verify_runtime_controls: false
 

--- a/roles/system_maintenance/molecule/baseline/converge.yml
+++ b/roles/system_maintenance/molecule/baseline/converge.yml
@@ -43,6 +43,14 @@
              | b64decode | trim }}
       no_log: true
 
+- name: Load synthetic proxy intent for the complete provisioning lifecycle
+  hosts: os_managed
+  gather_facts: false
+  tasks:
+    - name: Load shared disposable TLS and proxy declarations
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/vars/tls.yml"
+
 - name: Converge the production complete provisioning lifecycle
   ansible.builtin.import_playbook: ../../../../playbooks/os/provision.yml
   vars:
@@ -109,6 +117,16 @@
   vars_files:
     - vars/tls.yml
   tasks:
+    - name: Discover the disposable TLS address after OS Python bootstrap
+      ansible.builtin.include_tasks: tasks/tls-address.yml
+
+    - name: Install real Caddy with deferred routes before the disabled TLS capability  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.include_role:
+        name: reverse_proxy
+      vars:
+        security_baseline_apply_firewall_runtime: false
+        os_baseline_verify_runtime_controls: false
+
     - name: Install the off-cluster TLS capability
       ansible.builtin.import_role:
         name: tls_automation

--- a/roles/system_maintenance/molecule/baseline/filter_plugins/baseline_controls.py
+++ b/roles/system_maintenance/molecule/baseline/filter_plugins/baseline_controls.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import ipaddress
 from collections.abc import Mapping
 
 
@@ -108,6 +109,7 @@ def system_maintenance_molecule_baseline_firewall_errors(
     binding_text: object,
     policy_text: object,
     os_family: object,
+    https_sources: object = (),
 ) -> list[str]:
     """Return exact permanent firewall policy differences."""
     if (
@@ -149,7 +151,14 @@ def system_maintenance_molecule_baseline_firewall_errors(
         for line in zone["--list-rich-rules"]["stdout_lines"]
         if line.strip()
     ]
-    if rich_rules != [EXPECTED_RICH_RULE]:
+    expected_rules = [EXPECTED_RICH_RULE]
+    for source in https_sources:
+        network = ipaddress.ip_network(source, strict=True)
+        expected_rules.append(
+            f'rule family="ipv{network.version}" source address="{network}" '
+            'port port="443" protocol="tcp" accept'
+        )
+    if sorted(rich_rules) != sorted(expected_rules):
         errors.append("rich-rules")
     if any(str(result["stdout"]).strip() for result in direct.values()):
         errors.append("direct-openings")

--- a/roles/system_maintenance/molecule/baseline/tasks/tls-address.yml
+++ b/roles/system_maintenance/molecule/baseline/tasks/tls-address.yml
@@ -1,0 +1,19 @@
+---
+- name: Discover the disposable TLS listener without optional network tools
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/python3
+      - -c
+      - >-
+        import ipaddress, socket;
+        values={entry[4][0] for entry in
+        socket.getaddrinfo(socket.gethostname(), 0, socket.AF_INET)};
+        print(next(value for value in sorted(values)
+        if ipaddress.ip_address(value).is_private
+        and not ipaddress.ip_address(value).is_loopback))
+  register: system_maintenance_molecule_tls_address_result
+  changed_when: false
+
+- name: Record the disposable TLS listener
+  ansible.builtin.set_fact:
+    system_maintenance_molecule_tls_address: "{{ system_maintenance_molecule_tls_address_result.stdout | trim }}"

--- a/roles/system_maintenance/molecule/baseline/vars/tls.yml
+++ b/roles/system_maintenance/molecule/baseline/vars/tls.yml
@@ -1,11 +1,15 @@
 ---
 tls_automation_namespace: infra.example.com  # noqa var-naming[no-role-prefix] - Public input to the TLS role under test.
 tls_automation_email: acme@example.com  # noqa var-naming[no-role-prefix] - Public input to the TLS role under test.
-tls_automation_reader_gid: 2001  # noqa var-naming[no-role-prefix] - Public input to the TLS role under test.
-tls_automation_endpoints:  # noqa var-naming[no-role-prefix] - Public input to the TLS role under test.
+reverse_proxy_bind_addresses:  # noqa var-naming[no-role-prefix] - Synthetic TLS policy listener.
+  - "{{ system_maintenance_molecule_tls_address }}"
+reverse_proxy_client_sources:  # noqa var-naming[no-role-prefix] - Synthetic TLS policy client.
+  - 10.0.0.0/8
+reverse_proxy_deferred_certificates: [infra]  # noqa var-naming[no-role-prefix] - Synthetic certificate dependency.
+reverse_proxy_routes:  # noqa var-naming[no-role-prefix] - Synthetic TLS policy route.
   - hostname: modem.infra.example.com
-    address: 192.0.2.10
-    port: 443
+    backend_port: 18080
+    certificate_name: infra
 tls_automation_issuer_uid: 2010  # noqa var-naming[no-role-prefix] - Public input to the TLS role under test.
 tls_automation_issuer_gid: 2010  # noqa var-naming[no-role-prefix] - Public input to the TLS role under test.
 tls_automation_timer_enabled: false  # noqa var-naming[no-role-prefix] - Public input to the TLS role under test.

--- a/roles/system_maintenance/molecule/baseline/verify.yml
+++ b/roles/system_maintenance/molecule/baseline/verify.yml
@@ -1101,6 +1101,7 @@
             mode: '0755'
           loop:
             - tests/tls
+            - tests/ansible
             - roles/tls_automation/files
             - roles/reverse_proxy/files
             - roles/reverse_proxy/filter_plugins
@@ -1129,6 +1130,15 @@
               destination: roles/reverse_proxy/files/manifest.py
             - source: /usr/local/lib/homelab-reverse-proxy/proxy_config.py
               destination: roles/reverse_proxy/filter_plugins/proxy.py
+
+        - name: Copy the bounded proxy fixtures used by TLS integration tests
+          ansible.builtin.copy:
+            src: "{{ playbook_dir }}/../../../../tests/ansible/{{ item }}"
+            dest: "{{ system_maintenance_molecule_tls_test_root.path }}/tests/ansible/{{ item }}"
+            mode: '0644'
+          loop:
+            - test_reverse_proxy_activation.py
+            - test_proxy_manifest_runtime.py
 
         - name: Run TLS tests with distribution Python and cryptography
           ansible.builtin.command:

--- a/roles/system_maintenance/molecule/baseline/verify.yml
+++ b/roles/system_maintenance/molecule/baseline/verify.yml
@@ -359,11 +359,12 @@
         that:
           - system_maintenance_molecule_baseline_updater_problems | length == 0
 
-    - name: Verify the minimum package set and excluded ownership
+    - name: Verify baseline packages and the Caddy package source
       ansible.builtin.assert:
         that:
           - system_maintenance_molecule_baseline_minimum_packages[ansible_facts['os_family']] | difference(ansible_facts.packages.keys()) | length == 0
-          - "'epel-release' not in ansible_facts.packages"
+          - "'caddy' in ansible_facts.packages"
+          - "('epel-release' in ansible_facts.packages) == (ansible_facts['os_family'] == 'RedHat')"
           - "'fail2ban' not in ansible_facts.packages"
 
     - name: Inspect recurring full update timer and cron artifacts

--- a/roles/system_maintenance/molecule/baseline/verify.yml
+++ b/roles/system_maintenance/molecule/baseline/verify.yml
@@ -3,6 +3,8 @@
   hosts: os_managed
   gather_facts: true
   become: true
+  vars_files:
+    - vars/tls.yml
   vars:
     system_maintenance_molecule_baseline_expected_authorized_key: >-
       {{ lookup(
@@ -250,7 +252,7 @@
                  system_maintenance_molecule_baseline_direct_firewall.results,
                  system_maintenance_molecule_baseline_firewall_bindings.stdout,
                  system_maintenance_molecule_baseline_firewall_policies.stdout,
-                 ansible_facts['os_family']) }}
+                 ansible_facts['os_family'], reverse_proxy_client_sources) }}
       ansible.builtin.assert:
         that:
           - system_maintenance_molecule_baseline_firewall_problems | length == 0
@@ -520,6 +522,19 @@
   vars_files:
     - vars/tls.yml
   tasks:
+    - name: Discover the independently observed disposable TLS address
+      ansible.builtin.include_tasks: tasks/tls-address.yml
+
+    - name: Read the installed Caddy certificate reader group
+      ansible.builtin.command:
+        argv: [/usr/bin/getent, group, caddy]
+      register: system_maintenance_molecule_caddy_group
+      changed_when: false
+
+    - name: Record the installed Caddy certificate reader ID
+      ansible.builtin.set_fact:
+        system_maintenance_molecule_caddy_gid: "{{ system_maintenance_molecule_caddy_group.stdout.split(':')[2] | int }}"
+
     - name: Gather installed package evidence
       ansible.builtin.package_facts:
         manager: auto
@@ -576,10 +591,11 @@
         - {path: /etc/homelab-tls, mode: '0750', uid: 0, gid: 2010, type: directory}
         - {path: /etc/homelab-tls/config.json, mode: '0640', uid: 0, gid: 2010, type: file}
         - {path: /etc/homelab-tls/.issuer-account.json, mode: '0644', uid: 0, gid: 0, type: file}
-        - {path: /var/lib/homelab-tls, mode: '0750', uid: 0, gid: 2001, type: directory}
+        - {path: /var/lib/homelab-tls, mode: '0750', uid: 0, gid: "{{ system_maintenance_molecule_caddy_gid }}", type: directory}
         - {path: /var/lib/homelab-tls/private, mode: '0700', uid: 0, gid: 0, type: directory}
         - {path: /var/lib/homelab-tls/private/coordinator.lock, mode: '0600', uid: 0, gid: 0, type: file}
-        - {path: /var/lib/homelab-tls/published, mode: '0750', uid: 0, gid: 2001, type: directory}
+        - {path: /etc/caddy/tls/infra, mode: '0750', uid: 0, gid: "{{ system_maintenance_molecule_caddy_gid }}", type: directory}
+        - {path: /etc/caddy/tls/.homelab-tls-private, mode: '0700', uid: 0, gid: 0, type: directory}
         - {path: /var/lib/homelab-tls-issuer, mode: '0700', uid: 2010, gid: 2010, type: directory}
         - {path: /usr/local/lib/homelab-tls, mode: '0755', uid: 0, gid: 0, type: directory}
         - {path: /usr/local/lib/homelab-tls/tls_runtime, mode: '0755', uid: 0, gid: 0, type: directory}
@@ -589,9 +605,11 @@
         - {path: /usr/local/lib/homelab-tls/tls_runtime/publication.py, mode: '0644', uid: 0, gid: 0, type: file}
         - {path: /usr/local/lib/homelab-tls/tls_runtime/unit_contract.py, mode: '0644', uid: 0, gid: 0, type: file}
         - {path: /usr/local/lib/homelab-tls/tls_runtime/runtime.py, mode: '0644', uid: 0, gid: 0, type: file}
+        - {path: /usr/local/lib/homelab-tls/tls_runtime/caddy.py, mode: '0644', uid: 0, gid: 0, type: file}
         - {path: /usr/local/libexec/homelab-tls-issue, mode: '0755', uid: 0, gid: 0, type: file}
         - {path: /usr/local/libexec/homelab-tls-reconcile, mode: '0755', uid: 0, gid: 0, type: file}
         - {path: /usr/local/libexec/homelab-tls-verify, mode: '0755', uid: 0, gid: 0, type: file}
+        - {path: /usr/local/libexec/homelab-tls-caddy, mode: '0755', uid: 0, gid: 0, type: file}
         - {path: /usr/local/libexec/lego-5.4.1, mode: '0755', uid: 0, gid: 0, type: file}
         - {path: /etc/systemd/system/homelab-tls-issuer.service, mode: '0644', uid: 0, gid: 0, type: file}
         - {path: /etc/systemd/system/homelab-tls-renew.service, mode: '0644', uid: 0, gid: 0, type: file}
@@ -613,7 +631,7 @@
       loop_control:
         label: "{{ item.item.path }}"
 
-    - name: Inspect omitted credential and unavailable adapter
+    - name: Inspect omitted credential
       ansible.builtin.stat:
         path: "{{ item }}"
         follow: false
@@ -622,7 +640,6 @@
         get_attributes: false
       loop:
         - /etc/homelab-tls/cloudflare-token
-        - /usr/local/libexec/homelab-tls-caddy
       register: system_maintenance_molecule_tls_absent_inputs
 
     - name: Verify omitted private input remains absent
@@ -645,8 +662,10 @@
         that:
           - >-
             system_maintenance_molecule_tls_policy.content | b64decode | from_json ==
-            {'namespace': 'infra.example.com', 'email': 'acme@example.com', 'reader_gid': 2001,
-             'endpoints': [{'hostname': 'modem.infra.example.com', 'address': '192.0.2.10', 'port': 443}]}
+            {'namespace': 'infra.example.com', 'email': 'acme@example.com',
+             'reader_gid': system_maintenance_molecule_caddy_gid,
+             'endpoints': [{'hostname': 'modem.infra.example.com',
+                            'address': system_maintenance_molecule_tls_address, 'port': 443}]}
           - >-
             system_maintenance_molecule_tls_marker.content | b64decode | from_json ==
             {'name': 'svc-acme', 'uid': 2010, 'gid': 2010}
@@ -775,7 +794,9 @@
           - "'NoNewPrivileges=yes' in system_maintenance_molecule_tls_services.results[1].stdout_lines"
           - "'ProtectSystem=strict' in system_maintenance_molecule_tls_services.results[1].stdout_lines"
           - "'PrivateTmp=yes' in system_maintenance_molecule_tls_services.results[1].stdout_lines"
-          - "'ReadWritePaths=/var/lib/homelab-tls' in system_maintenance_molecule_tls_services.results[1].stdout_lines"
+          - >-
+            'ReadWritePaths=/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy'
+            in system_maintenance_molecule_tls_services.results[1].stdout_lines
           - "'FragmentPath=/etc/systemd/system/homelab-tls-renew.service' in system_maintenance_molecule_tls_services.results[1].stdout_lines"
           - "'DropInPaths=' in system_maintenance_molecule_tls_services.results[1].stdout_lines"
 
@@ -1029,20 +1050,20 @@
       changed_when: false
       failed_when: false
 
-    - name: Read issuer state before unavailable-adapter preflight
+    - name: Read issuer state before missing-credential preflight
       ansible.builtin.command:
         argv: [/usr/bin/systemctl, show, homelab-tls-issuer.service, --property=ActiveState, --value]
       register: system_maintenance_molecule_tls_issuer_before
       changed_when: false
 
-    - name: Exercise runtime preflight without an adapter or credential
+    - name: Exercise runtime preflight without a credential
       ansible.builtin.command:
         argv: [/usr/local/libexec/homelab-tls-reconcile]
       register: system_maintenance_molecule_tls_preflight
       changed_when: false
       failed_when: false
 
-    - name: Read issuer state after unavailable-adapter preflight
+    - name: Read issuer state after missing-credential preflight
       ansible.builtin.command:
         argv: [/usr/bin/systemctl, show, homelab-tls-issuer.service, --property=ActiveState, --value]
       register: system_maintenance_molecule_tls_issuer_after
@@ -1081,6 +1102,8 @@
           loop:
             - tests/tls
             - roles/tls_automation/files
+            - roles/reverse_proxy/files
+            - roles/reverse_proxy/filter_plugins
 
         - name: Link the installed runtime into the disposable test tree
           ansible.builtin.file:
@@ -1093,6 +1116,19 @@
             src: "{{ playbook_dir }}/../../../../tests/tls/"
             dest: "{{ system_maintenance_molecule_tls_test_root.path }}/tests/tls/"
             mode: preserve
+
+        - name: Link installed proxy modules into the disposable test tree
+          ansible.builtin.file:
+            src: "{{ item.source }}"
+            dest: "{{ system_maintenance_molecule_tls_test_root.path }}/{{ item.destination }}"
+            state: link
+          loop:
+            - source: /usr/local/libexec/homelab-reverse-proxy
+              destination: roles/reverse_proxy/files/activate.py
+            - source: /usr/local/lib/homelab-reverse-proxy/proxy_manifest.py
+              destination: roles/reverse_proxy/files/manifest.py
+            - source: /usr/local/lib/homelab-reverse-proxy/proxy_config.py
+              destination: roles/reverse_proxy/filter_plugins/proxy.py
 
         - name: Run TLS tests with distribution Python and cryptography
           ansible.builtin.command:

--- a/roles/system_maintenance/molecule/baseline/verify.yml
+++ b/roles/system_maintenance/molecule/baseline/verify.yml
@@ -3,8 +3,10 @@
   hosts: os_managed
   gather_facts: true
   become: true
-  vars_files:
-    - vars/tls.yml
+  pre_tasks:
+    - name: Load proxy declarations for all standalone verification plays
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/vars/tls.yml"
   vars:
     system_maintenance_molecule_baseline_expected_authorized_key: >-
       {{ lookup(

--- a/roles/tls_automation/files/homelab-tls-caddy
+++ b/roles/tls_automation/files/homelab-tls-caddy
@@ -1,0 +1,11 @@
+#!/usr/bin/python3 -I
+"""Fixed certificate integration adapter; exclusive Caddy lock arrives on fd9."""
+import os
+import sys
+
+os.environ.clear()
+os.environ.update({"PATH": "/usr/sbin:/usr/bin:/sbin:/bin", "LANG": "C", "LC_ALL": "C", "HOME": "/"})
+sys.path.insert(0, "/usr/local/lib/homelab-tls")
+from tls_runtime.caddy import main
+
+sys.exit(main())

--- a/roles/tls_automation/files/tls_runtime/caddy.py
+++ b/roles/tls_automation/files/tls_runtime/caddy.py
@@ -1,0 +1,285 @@
+"""Fixed bridge between Publisher's journal and the existing Caddy Activator."""
+import contextlib
+import fcntl
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+from .publication import Publisher
+
+
+RESTART_EXIT = 75
+ADAPTER = '/usr/local/libexec/homelab-tls-caddy'
+
+
+def activation_module():
+    path = '/usr/local/libexec/homelab-reverse-proxy'
+    loader = importlib.machinery.SourceFileLoader('homelab_proxy_activation', path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class Integration:
+    def __init__(self, activator):
+        self.a = activator
+        self.root = self.a.config_dir / 'tls/infra'
+        # Disk recovery uses only Publisher's checked journal and pointer methods.
+        # No certificate/network callbacks are available in the startup process.
+        self.publisher = Publisher(self.root, self.a.tls_journal,
+                                   self.a.ids[0], self.a.ids[3], None, None, None)
+
+    def record(self):
+        self.a.metadata(self.a.tls_journal.parent, stat.S_ISDIR,
+                        self.a.ids[0], self.a.ids[1], 0o700)
+        self.publisher._assert_state()
+        return self.publisher._read_journal()
+
+    def check_revision(self, binding):
+        envelope, config = self.a.manifest().committed()
+        if envelope['ingress']['manifest_sha256'] != binding['desired_revision']:
+            raise ValueError('desired revision changed during TLS publication')
+        return config
+
+    def prepare(self, record):
+        manifests = self.a.manifest()
+        envelope, config = manifests.committed()
+        import proxy_config
+        return {'desired_revision': envelope['ingress']['manifest_sha256'],
+                'previous_boot': self.a.boot.read_bytes().decode('utf-8'),
+                'candidate_boot': proxy_config.render(config),
+                'disk_recovery': None, 'restart': False,
+                'activation_failed': False, 'restoration_failed': False}
+
+    def recover_disk(self):
+        record = self.record()
+        if 'caddy' not in record:
+            raise ValueError('TLS journal lacks Caddy rollback authority')
+        binding = record['caddy']
+        self.check_revision(binding)
+        current = self.publisher._assert_state()
+        if current not in (record['previous'], record['generation']):
+            raise ValueError('TLS pointer differs from disk recovery authority')
+        boot = self.a.boot.read_bytes().decode('utf-8')
+        if boot not in (binding['previous_boot'], binding['candidate_boot']):
+            raise ValueError('Caddy boot differs from disk recovery authority')
+        candidate = record['status'] == 'recovered' and not binding['restart']
+        selection = record['generation'] if candidate else record['previous']
+        contents = binding['candidate_boot'] if candidate else binding['previous_boot']
+        binding['disk_recovery'] = 'pending'
+        self.publisher._write_journal(record)
+        self.publisher._switch_current(selection)
+        self.a.durable_write(self.a.boot, contents.encode(), 0o640, self.a.ids[3])
+        binding['disk_recovery'] = 'restored'
+        self.publisher._write_journal(record)
+
+    def validate_candidate(self, path):
+        path = Path(path)
+        if path.parent != self.root:
+            raise ValueError('candidate must be beneath fixed infra publication root')
+        self.publisher._assert_generation(path.name)
+        if os.path.lexists(self.a.pending):
+            raise ValueError('Caddy configuration recovery is pending')
+        manifests = self.a.manifest()
+        envelope, config = manifests.committed()
+        if os.path.lexists(self.a.tls_journal):
+            record = self.record()
+            self.check_revision(record['caddy'])
+            if record['generation'] != path.name:
+                raise ValueError('candidate differs from retained publication')
+        restorecon = self.a.path('/usr/sbin/restorecon')
+        if restorecon.exists():
+            self.a.commands.run([str(restorecon), '-RF', str(path)])
+        validation = self.a.config_dir / 'Caddyfile.tls-validation'
+        host_path = Path('/etc/caddy/tls/infra') / path.name
+        self.a.durable_write(validation, manifests.render(config, host_path).encode(), 0o640, self.a.ids[3])
+        try:
+            if restorecon.exists():
+                self.a.commands.run([str(restorecon), '-F', str(validation)])
+            self.a.validate(validation, certificate_generation=path)
+        finally:
+            validation.unlink()
+            self.a.fsync_directory(self.a.config_dir)
+
+    def activate(self, action):
+        if action not in ('reload', 'deactivate'):
+            raise ValueError('invalid fixed adapter action')
+        if os.path.lexists(self.a.pending):
+            raise ValueError('Caddy configuration recovery is pending')
+        self.a.active()
+        record = self.record() if os.path.lexists(self.a.tls_journal) else None
+        if record is None:
+            if action != 'reload':
+                raise ValueError('deactivation requires publication rollback authority')
+            manifests = self.a.manifest()
+            unused, config = manifests.committed()
+            if self.a.boot.read_bytes() != manifests.render(config).encode():
+                raise ValueError('unjournaled configuration change is not permitted')
+            desired = self.a.validate(self.a.boot)
+            self.a.caddy('reload', self.a.boot)
+            self.a.observed(desired)
+            self.a.served_tls(desired)
+            return
+        binding = record['caddy']
+        self.check_revision(binding)
+        current = self.publisher._assert_state()
+        if current not in (record['previous'], record['generation']):
+            raise ValueError('selected generation differs from publication authority')
+        rollback = current == record['previous']
+        if action == 'deactivate' and (not rollback or current is not None):
+            raise ValueError('deactivation requires absent previous generation')
+        contents = binding['previous_boot'] if rollback else binding['candidate_boot']
+        if self.a.boot.read_bytes().decode() not in (binding['previous_boot'], binding['candidate_boot']):
+            raise ValueError('boot configuration differs from publication authority')
+        self.a.durable_write(self.a.boot, contents.encode(), 0o640, self.a.ids[3])
+        desired = self.a.validate(self.a.boot)
+        if rollback:
+            try:
+                # Active JSON and exact listener set prove failed-first absence,
+                # including when surviving routes share a default certificate.
+                self.a.observed(desired)
+                self.a.served_tls(desired)
+            except Exception:
+                try:
+                    self.a.caddy('reload', self.a.boot)
+                    self.a.observed(desired)
+                    self.a.served_tls(desired)
+                except Exception:
+                    binding['restart'] = True
+                    self.publisher._write_journal(record)
+                    raise RestartNeeded('Caddy rollback requires restart') from None
+            if binding['restart']:
+                binding['restart'] = False
+                self.publisher._write_journal(record)
+        else:
+            self.a.caddy('reload', self.a.boot)
+            self.a.observed(desired)
+            self.a.served_tls(desired)
+
+
+class RestartNeeded(RuntimeError):
+    """Return control to the parent, which owns the shared lock descriptor."""
+
+
+class Deployment:
+    """Parent-owned lock scope and bounded adapter/restart subprocesses."""
+    def __init__(self, activator, policy):
+        self._a = activator
+        self.policy = policy
+
+    @property
+    def a(self):
+        if self._a is None:
+            self._a = activation_module().Activator()
+        return self._a
+
+    @property
+    def integration(self):
+        return Integration(self.a)
+
+    def binding(self):
+        if self.policy.reader_gid != self.a.ids[3]:
+            raise ValueError('TLS reader differs from installed Caddy group')
+        envelope, config = self.a.manifest().committed()
+        actual = {(item['hostname'], item['address'], item['port']) for item in self.policy.endpoints}
+        if (not self.a.manifest().endpoints(config) or actual != self.a.manifest().endpoints(config)
+                or 'infra' not in config.get('deferred_certificates', [])):
+            raise ValueError('TLS verification policy differs from desired managed endpoints')
+        return envelope['ingress']['manifest_sha256']
+
+    @contextlib.contextmanager
+    def locked(self):
+        with self.a.locked() as descriptor:
+            saved = None
+            if descriptor != 9:
+                try:
+                    saved = os.dup(9)
+                except OSError:
+                    pass
+                os.dup2(descriptor, 9)
+            try:
+                self.binding()
+                yield self
+            finally:
+                if descriptor != 9:
+                    if saved is None:
+                        os.close(9)
+                    else:
+                        os.dup2(saved, 9)
+                        os.close(saved)
+
+    def prepare(self, record):
+        self.binding()
+        return self.integration.prepare(record)
+
+    def operation(self, action, path=None):
+        with self.a.locked(inherited=True):
+            revision = self.binding()
+            argv = [ADAPTER, action] + ([] if path is None else [str(path)])
+            result = subprocess.run(argv, pass_fds=(9,), stdin=subprocess.DEVNULL,
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                    cwd='/', timeout=900, check=False,
+                                    env={'PATH': '/usr/sbin:/usr/bin:/sbin:/bin', 'LANG': 'C', 'LC_ALL': 'C', 'HOME': '/'})
+            if result.returncode == RESTART_EXIT:
+                self.restart(revision)
+                # Startup restored disk authority. The same fixed action now
+                # verifies restoration; it cannot silently activate another revision.
+                result = subprocess.run(argv, pass_fds=(9,), stdin=subprocess.DEVNULL,
+                                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                        cwd='/', timeout=900, check=False,
+                                        env={'PATH': '/usr/sbin:/usr/bin:/sbin:/bin', 'LANG': 'C', 'LC_ALL': 'C', 'HOME': '/'})
+            if result.returncode:
+                raise RuntimeError('fixed Caddy integration operation failed')
+
+    def restart(self, revision):
+        publisher = self.integration.publisher
+        expected = self.integration.record()
+        if (not expected['caddy']['restart'] or expected['caddy']['desired_revision'] != revision
+                or publisher._current_name() != expected['previous']):
+            raise ValueError('restart lacks matching rollback authority')
+        fcntl.flock(9, fcntl.LOCK_UN)
+        try:
+            self.a.commands.run(['/usr/bin/systemctl', 'restart', 'caddy.service'])
+        finally:
+            fcntl.flock(9, fcntl.LOCK_EX)
+        with self.a.locked(inherited=True):
+            actual = self.integration.record()
+            comparable = dict(actual, caddy=dict(actual['caddy'],
+                              disk_recovery=expected['caddy']['disk_recovery']))
+            if (self.binding() != revision or comparable != expected
+                    or publisher._current_name() != expected['previous']
+                    or self.a.boot.read_bytes().decode() != expected['caddy']['previous_boot']
+                    or actual['caddy']['disk_recovery'] != 'restored'):
+                raise ValueError('publication changed during Caddy restart')
+            configuration = self.a.validate(self.a.boot)
+            self.a.observed(configuration)
+            self.a.served_tls(configuration)
+
+
+def main(arguments=None):
+    args = list(sys.argv[1:] if arguments is None else arguments)
+    if not (args in (['reload'], ['deactivate']) or len(args) == 2 and args[0] == 'validate'):
+        print('usage: homelab-tls-caddy {validate PATH|reload|deactivate}', file=sys.stderr)
+        return 2
+    try:
+        if os.geteuid() != 0:
+            raise ValueError('TLS integration requires root')
+        activator = activation_module().Activator()
+        with activator.locked(inherited=True):
+            integration = Integration(activator)
+            if args[0] == 'validate':
+                integration.validate_candidate(Path(args[1]))
+            else:
+                integration.activate(args[0])
+        return 0
+    except RestartNeeded:
+        return RESTART_EXIT
+    except Exception:
+        print('TLS Caddy integration failed; inspect private transaction state', file=sys.stderr)
+        return 1

--- a/roles/tls_automation/files/tls_runtime/policy.py
+++ b/roles/tls_automation/files/tls_runtime/policy.py
@@ -59,18 +59,16 @@ def parse_policy(raw):
     if type(gid) is not int or not 1 <= gid < 2**31:
         raise ValueError("reader_gid must be an explicit positive numeric group")
     endpoints = obj["endpoints"]
-    if not isinstance(endpoints, list) or not 1 <= len(endpoints) <= 32:
-        raise ValueError("declare one to 32 TLS endpoints")
+    if not isinstance(endpoints, list) or not 1 <= len(endpoints) <= 128:
+        raise ValueError("declare one to 128 TLS endpoints")
     seen = set()
     for endpoint in endpoints:
         if not isinstance(endpoint, dict) or set(endpoint) != {"hostname", "address", "port"}:
             raise ValueError("invalid endpoint fields")
         hostname = endpoint["hostname"]
         if (not isinstance(hostname, str)
-                or not re.fullmatch(rf"{LABEL}\.{re.escape(namespace)}", hostname)
-                or hostname in seen):
-            raise ValueError("endpoint hostname must be unique and directly beneath namespace")
-        seen.add(hostname)
+                or not re.fullmatch(rf"{LABEL}\.{re.escape(namespace)}", hostname)):
+            raise ValueError("endpoint hostname must be directly beneath namespace")
         address = endpoint["address"]
         if not isinstance(address, str) or "%" in address:
             raise ValueError("endpoint address must be a private IP literal")
@@ -80,6 +78,11 @@ def parse_policy(raw):
             raise ValueError("endpoint address must be a private unicast listener")
         if type(endpoint["port"]) is not int or not 1 <= endpoint["port"] <= 65535:
             raise ValueError("invalid endpoint port")
+        selection = (hostname, str(ip), endpoint["port"])
+        if selection in seen:
+            raise ValueError("endpoint selection must be unique")
+        seen.add(selection)
+        endpoint["address"] = str(ip)
     return Policy(namespace, email, gid, endpoints)
 
 

--- a/roles/tls_automation/files/tls_runtime/publication.py
+++ b/roles/tls_automation/files/tls_runtime/publication.py
@@ -697,6 +697,7 @@ class Publisher:
             self._assert_generation(str(previous))
 
         if (record["status"] in {"retry_pending", "recovered"}
+                or (record["status"] == "prepared" and "caddy" in record)
                 or record.get("caddy", {}).get("disk_recovery") is not None):
             try:
                 return self._retry_retained(record)

--- a/roles/tls_automation/files/tls_runtime/publication.py
+++ b/roles/tls_automation/files/tls_runtime/publication.py
@@ -690,6 +690,10 @@ class Publisher:
 
         if record["status"] == "restored":
             self._finish_restored_cleanup(record)
+            if "caddy" in record:
+                return {"publication": "failed",
+                        "activation_failed": record["caddy"]["activation_failed"],
+                        "restoration_failed": record["caddy"]["restoration_failed"]}
             return
 
         self._assert_generation(generation)
@@ -697,7 +701,7 @@ class Publisher:
             self._assert_generation(str(previous))
 
         if (record["status"] in {"retry_pending", "recovered"}
-                or (record["status"] == "prepared" and "caddy" in record)
+                or ("caddy" in record and (record["status"] == "prepared" or current == generation))
                 or record.get("caddy", {}).get("disk_recovery") is not None):
             try:
                 return self._retry_retained(record)

--- a/roles/tls_automation/files/tls_runtime/publication.py
+++ b/roles/tls_automation/files/tls_runtime/publication.py
@@ -66,6 +66,7 @@ class Publisher:
         validate: Callable[[Path], str],
         reload_and_verify: Callable[[str], None],
         preflight: Callable[[Path], None],
+        prepare=None,
     ) -> None:
         self.root = Path(root)
         self.journal = Path(journal)
@@ -74,6 +75,7 @@ class Publisher:
         self.validate = validate
         self.reload_and_verify = reload_and_verify
         self.preflight = preflight
+        self.prepare = prepare
         if not self.root.is_absolute() or not self.journal.is_absolute():
             raise ValueError("publication paths must be absolute")
         if self.journal == self.root or self.root in self.journal.parents:
@@ -425,6 +427,7 @@ class Publisher:
         self._assert_generation(generation)
         temporary = self.journal.parent / (_CURRENT_PREFIX + uuid.uuid4().hex)
         os.symlink(generation, temporary)
+        os.lchown(temporary, self.owner_uid, self.reader_gid)
         try:
             os.replace(temporary, current)
             self._fsync_directory(self.root)
@@ -476,13 +479,24 @@ class Publisher:
         self._remove_journal()
         self._remove_retired(destination)
 
+    def _refresh_binding(self, record):
+        if "caddy" in record and self._lstat(self.journal) is not None:
+            latest = self._read_journal()
+            if latest["generation"] != record["generation"]:
+                raise ValueError("publication identity changed during callback")
+            for key in ("restart", "disk_recovery"):
+                record["caddy"][key] = latest["caddy"][key]
+
     def _rollback(
         self,
         record: Dict[str, object],
         activation_error: Exception,
     ) -> None:
+        self._refresh_binding(record)
         previous = record["previous"]
         previous_fingerprint = record["previous_fingerprint"]
+        if "caddy" in record:
+            record["caddy"]["activation_failed"] = True
         try:
             self._switch_current(previous if isinstance(previous, str) else None)
             record["status"] = "rollback_pending"
@@ -491,9 +505,13 @@ class Publisher:
                 previous_fingerprint if isinstance(previous_fingerprint, str) else ""
             )
         except Exception as rollback_error:
+            self._refresh_binding(record)
             record["status"] = "rollback_failed"
+            if "caddy" in record:
+                record["caddy"]["restoration_failed"] = True
             self._write_journal(record)
             raise PublicationError(activation_error, rollback_error) from rollback_error
+        self._refresh_binding(record)
         self._finish_restored_cleanup(record)
         raise PublicationError(activation_error)
 
@@ -550,6 +568,13 @@ class Publisher:
                 generation,
                 fingerprint,
             )
+            if self.prepare is not None:
+                try:
+                    record["caddy"] = self.prepare(record)
+                    self._validate_binding(record["caddy"])
+                except Exception:
+                    self._retire_unjournaled_generation(generation)
+                    raise
             self._write_journal(record)
             try:
                 self._switch_current(generation)
@@ -574,7 +599,7 @@ class Publisher:
             record = json.loads(self.journal.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, json.JSONDecodeError) as error:
             raise ValueError("transaction journal is malformed") from error
-        if not isinstance(record, dict) or set(record) != _JOURNAL_FIELDS:
+        if not isinstance(record, dict) or set(record) not in (_JOURNAL_FIELDS, _JOURNAL_FIELDS | {"caddy"}):
             raise ValueError("transaction journal schema is invalid")
         if record.get("version") != 1 or record.get("status") not in _JOURNAL_STATUSES:
             raise ValueError("transaction journal state is invalid")
@@ -599,7 +624,23 @@ class Publisher:
             raise ValueError("transaction retired generation is invalid")
         if (record["status"] == "restored") != (retired is not None):
             raise ValueError("transaction terminal state is invalid")
+        if "caddy" in record:
+            self._validate_binding(record["caddy"])
         return record
+
+    @staticmethod
+    def _validate_binding(binding):
+        fields = {"desired_revision", "previous_boot", "candidate_boot", "disk_recovery",
+                  "restart", "activation_failed", "restoration_failed"}
+        if (not isinstance(binding, dict) or set(binding) != fields
+                or not isinstance(binding["desired_revision"], str)
+                or not _FINGERPRINT.fullmatch(binding["desired_revision"])
+                or binding["disk_recovery"] not in (None, "pending", "restored")
+                or any(type(binding[name]) is not bool for name in
+                       ("restart", "activation_failed", "restoration_failed"))
+                or any(not isinstance(binding[name], str) or len(binding[name].encode()) > 1048576
+                       for name in ("previous_boot", "candidate_boot"))):
+            raise ValueError("invalid Caddy publication binding")
 
     def _retry_retained(self, record: Dict[str, object]) -> Dict[str, object]:
         """Retry retained bytes after failed restoration, without new issuance.
@@ -628,11 +669,13 @@ class Publisher:
             self.reload_and_verify(actual)
         except Exception as activation_error:
             self._rollback(record, activation_error)
+        self._refresh_binding(record)
         record["status"] = "recovered"
         self._write_journal(record)
         self._remove_journal()
-        return {"publication": "changed", "activation_failed": True,
-                "restoration_failed": True}
+        binding = record.get("caddy", {})
+        return {"publication": "changed", "activation_failed": binding.get("activation_failed", True),
+                "restoration_failed": binding.get("restoration_failed", True)}
 
     def recover(self) -> Optional[Dict[str, object]]:
         """Finish or roll back the one journaled publication transaction."""
@@ -653,7 +696,8 @@ class Publisher:
         if previous is not None:
             self._assert_generation(str(previous))
 
-        if record["status"] in {"retry_pending", "recovered"}:
+        if (record["status"] in {"retry_pending", "recovered"}
+                or record.get("caddy", {}).get("disk_recovery") is not None):
             try:
                 return self._retry_retained(record)
             except Exception as error:
@@ -692,7 +736,10 @@ class Publisher:
                 expected_fingerprint if isinstance(expected_fingerprint, str) else ""
             )
         except Exception as rollback_error:
+            self._refresh_binding(record)
             record["status"] = "rollback_failed"
+            if "caddy" in record:
+                record["caddy"]["restoration_failed"] = True
             self._write_journal(record)
             try:
                 return self._retry_retained(record)

--- a/roles/tls_automation/files/tls_runtime/runtime.py
+++ b/roles/tls_automation/files/tls_runtime/runtime.py
@@ -1,5 +1,5 @@
 """No-argument host entrypoints. Paths and privileged operations are code-owned."""
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 import fcntl
 import grp
 import hashlib
@@ -38,9 +38,10 @@ from .unit_contract import (SERVICE_ARRAY_PROPERTIES, exec_start_matches,
 CONFIG = Path("/etc/homelab-tls/config.json")
 STATE = Path("/var/lib/homelab-tls")
 PRIVATE = STATE / "private"
-PUBLISHED = STATE / "published"
+PUBLISHED = Path("/etc/caddy/tls/infra")
+PUBLICATION_PRIVATE = Path("/etc/caddy/tls/.homelab-tls-private")
 ISSUER_STATE = Path("/var/lib/homelab-tls-issuer")
-JOURNAL = PRIVATE / "transaction.json"
+JOURNAL = PUBLICATION_PRIVATE / "transaction.json"
 LOCK = PRIVATE / "coordinator.lock"
 STATUS = PRIVATE / "status.json"
 ADAPTER = Path("/usr/local/libexec/homelab-tls-caddy")
@@ -78,7 +79,7 @@ UNIT_CONTRACTS = {
         "NoNewPrivileges": "yes",
         "ProtectSystem": "strict",
         "PrivateTmp": "yes",
-        "ReadWritePaths": str(STATE),
+        "ReadWritePaths": str(STATE) + " /etc/caddy /var/lib/homelab-reverse-proxy",
         "LoadCredential": "",
         "FragmentPath": "/etc/systemd/system/" + RENEW_UNIT,
         "DropInPaths": "",
@@ -241,7 +242,7 @@ def _directory_without_extra_acl(path):
         os.close(descriptor)
 
 
-def validate_publication_acl_roots(private=PRIVATE, published=PUBLISHED):
+def validate_publication_acl_roots(private=PUBLICATION_PRIVATE, published=PUBLISHED):
     """Reject ACLs that could leak new private or published material."""
     _directory_without_extra_acl(private)
     _directory_without_extra_acl(published)
@@ -281,13 +282,16 @@ def inspect_host(policy):
         raise ValueError("issuer identity overlaps privileged/read boundary")
     if set(os.getgrouplist("svc-acme", account.pw_gid)) != {account.pw_gid}:
         raise ValueError("issuer must not have supplementary groups")
-    grp.getgrgid(policy.reader_gid)
+    if grp.getgrnam("caddy").gr_gid != policy.reader_gid:
+        raise ValueError("TLS reader must match installed Caddy group")
     for path, mode, gid in [(STATE, 0o750, policy.reader_gid), (PRIVATE, 0o700, 0),
+                            (PUBLICATION_PRIVATE, 0o700, 0),
                             (PUBLISHED, 0o750, policy.reader_gid)]:
         info = secure_path(path, directory=True)
         if stat.S_IMODE(info.st_mode) != mode or info.st_gid != gid:
             raise ValueError("incorrect coordinator directory permissions")
     validate_publication_acl_roots()
+    _directory_without_extra_acl(PRIVATE)
     info = secure_path(ISSUER_STATE, account.pw_uid, directory=True)
     if stat.S_IMODE(info.st_mode) != 0o700 or info.st_gid != account.pw_gid:
         raise ValueError("incorrect issuer state permissions")
@@ -409,7 +413,17 @@ def active_fingerprint(policy):
     return validate_certificate(fullchain, private_key, policy.sans, 0)
 
 
-def publisher_for(policy):
+@contextmanager
+def publication_locked(policy):
+    from .caddy import Deployment
+    deployment = Deployment(None, policy)
+    with deployment.locked():
+        yield deployment
+
+
+def publisher_for(policy, deployment=None):
+    from .caddy import Deployment
+    deployment = deployment or Deployment(None, policy)
     def validate(path):
         # Only immutable generations beneath the fixed published root may use
         # historical validity. Candidate snapshots remain current-valid.
@@ -428,21 +442,24 @@ def publisher_for(policy):
         secure_path(ADAPTER)
         fullchain, private_key = read_published_directory(path, 0, policy.reader_gid)
         validate_certificate(fullchain, private_key, policy.sans, 3600)
-        run_fixed([str(ADAPTER), "validate", str(path)])
+        deployment.operation("validate", path)
 
     def reload_and_verify(fingerprint):
         secure_path(ADAPTER)
         if not fingerprint:
             # Fixed adapter must remove the new route and prove it is inactive.
-            run_fixed([str(ADAPTER), "deactivate"])
+            deployment.operation("deactivate")
         else:
-            run_fixed([str(ADAPTER), "reload"])
+            deployment.operation("reload")
             verify_endpoints(policy, fingerprint)
 
-    return Publisher(PUBLISHED, JOURNAL, 0, policy.reader_gid, validate, reload_and_verify, preflight)
+    publisher = Publisher(PUBLISHED, JOURNAL, 0, policy.reader_gid, validate, reload_and_verify,
+                          preflight, prepare=deployment.prepare)
+    publisher.publication_context = deployment.locked
+    return publisher
 
 
-def reconcile(publisher, issue_operation, snapshot_operation):
+def reconcile(publisher, issue_operation, snapshot_operation, publication_context=nullcontext):
     result = {
         "issuance": "not_run",
         "publication": "failed",
@@ -450,7 +467,8 @@ def reconcile(publisher, issue_operation, snapshot_operation):
         "restoration_failed": False,
     }
     try:
-        recovered = publisher.recover()
+        with publication_context():
+            recovered = publisher.recover()
         if isinstance(recovered, dict):
             result.update(recovered)
             return result
@@ -467,7 +485,8 @@ def reconcile(publisher, issue_operation, snapshot_operation):
         result["issuance"] = "failed"
     try:
         fullchain, private_key = snapshot_operation()
-        result["publication"] = "changed" if publisher.publish(fullchain, private_key) else "unchanged"
+        with publication_context():
+            result["publication"] = "changed" if publisher.publish(fullchain, private_key) else "unchanged"
     except PublicationError as error:
         result["activation_failed"] = error.activation_failed
         result["restoration_failed"] = error.restoration_failed
@@ -524,7 +543,8 @@ def renew_attempt():
         raise
     result["preflight"] = "ok"
     write_status(result)
-    result.update(reconcile(publisher_for(policy), start_issuer, snapshot))
+    publisher = publisher_for(policy)
+    result.update(reconcile(publisher, start_issuer, snapshot, publisher.publication_context))
     failed = result["issuance"] == "failed" or result["publication"] == "failed"
     result["attempt"] = "failed" if failed else "completed"
     # Only fixed phase outcomes are recorded; subprocess output is never stored.
@@ -535,9 +555,11 @@ def renew_attempt():
 
 def observe(policy):
     inspect_host(policy)
-    if os.path.lexists(JOURNAL):
-        raise RuntimeError("publication recovery is pending")
-    verify_endpoints(policy, active_fingerprint(policy))
+    with publication_locked(policy) as deployment:
+        if os.path.lexists(JOURNAL):
+            raise RuntimeError("publication recovery is pending")
+        deployment.a.verify(inherited=True)
+        verify_endpoints(policy, active_fingerprint(policy))
 
 
 def main(action, arguments=None):

--- a/roles/tls_automation/filter_plugins/validation.py
+++ b/roles/tls_automation/filter_plugins/validation.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import hashlib
+import importlib.util
 from pathlib import Path
 import sys
 
@@ -49,7 +51,7 @@ _UNITS = {
         "NoNewPrivileges": "yes",
         "ProtectSystem": "strict",
         "PrivateTmp": "yes",
-        "ReadWritePaths": "/var/lib/homelab-tls",
+        "ReadWritePaths": "/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy",
         "TimeoutStartUSec": "1h",
         "ExecStart": "/usr/local/libexec/homelab-tls-reconcile",
     },
@@ -84,6 +86,63 @@ def validate_policy(value: object) -> object:
     except (TypeError, ValueError) as error:
         raise ValueError("TLS public policy does not match the approved schema") from error
     return value
+
+
+def _proxy_configuration(value: object) -> dict:
+    source = ROLE_FILES.parents[1] / "reverse_proxy/filter_plugins/proxy.py"
+    specification = importlib.util.spec_from_file_location("tls_proxy_configuration", source)
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module.validate(value)
+
+
+def proxy_policy(value: object, namespace: str, email: str, reader_gid: int) -> dict:
+    """Derive TLS targets from the same strict declaration used by the proxy."""
+    configuration = _proxy_configuration(value)
+    policy = {
+        "namespace": namespace,
+        "email": email,
+        "reader_gid": reader_gid,
+        "endpoints": [
+            {"hostname": route["hostname"], "address": address, "port": 443}
+            for route in configuration["routes"]
+            if route["certificate_name"] == "infra"
+            for address in configuration["bind_addresses"]
+        ],
+    }
+    return validate_policy(policy)
+
+
+def committed_proxy_policy(raw: str, declared: object, namespace: str,
+                           email: str, reader_gid: int) -> dict:
+    """Require the committed, ingress-bound declaration before installing policy."""
+    def unique(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError("duplicate desired manifest field")
+            result[key] = value
+        return result
+
+    if not isinstance(raw, str) or len(raw.encode()) > 1024 * 1024:
+        raise ValueError("invalid committed desired manifest")
+    envelope = json.loads(raw, object_pairs_hook=unique)
+    if (not isinstance(envelope, dict) or set(envelope) != {"version", "manifest", "ingress"}
+            or type(envelope["version"]) is not int or envelope["version"] != 1
+            or not isinstance(envelope["manifest"], str)):
+        raise ValueError("invalid committed desired envelope")
+    config = _proxy_configuration(json.loads(envelope["manifest"], object_pairs_hook=unique))
+    expected_ingress = {
+        "version": 1, "manifest_sha256": hashlib.sha256(envelope["manifest"].encode()).hexdigest(),
+        "listen_addresses": config["bind_addresses"],
+        "https_client_networks": config["client_sources"],
+    }
+    ingress = envelope["ingress"]
+    if (not isinstance(ingress, dict) or type(ingress.get("version")) is not int
+            or ingress != expected_ingress or config != _proxy_configuration(declared)
+            or config.get("deferred_certificates") != ["infra"]):
+        raise ValueError("provision the declared Caddy routes and verified ingress before TLS")
+    return proxy_policy(config, namespace, email, reader_gid)
 
 
 def _keyed_records(value: object) -> dict[str, list[str] | None]:
@@ -257,6 +316,12 @@ def validate_units(value: object, allow_absent: object, array_value: object) -> 
             if key == "ExecStart":
                 if not exec_start_matches(properties.get(key), expected_value):
                     raise ValueError(f"{name} has an unexpected command")
+            elif (allow_absent and name == "homelab-tls-renew.service"
+                  and key == "ReadWritePaths"
+                  and properties.get(key) == "/var/lib/homelab-tls"):
+                # Preflight permits upgrading only the earlier canonical,
+                # narrower sandbox. Installed-unit verification stays strict.
+                continue
             elif properties.get(key) != expected_value:
                 raise ValueError(f"{name} has an unexpected {key} property")
         if name.endswith(".timer"):
@@ -272,6 +337,8 @@ class FilterModule:
     def filters(self):
         return {
             "tls_automation_validate_policy": validate_policy,
+            "tls_automation_proxy_policy": proxy_policy,
+            "tls_automation_committed_proxy_policy": committed_proxy_policy,
             "tls_automation_validate_identity": validate_identity,
             "tls_automation_validate_units": validate_units,
             "tls_automation_service_array_query": service_array_query,

--- a/roles/tls_automation/tasks/configure.yml
+++ b/roles/tls_automation/tasks/configure.yml
@@ -6,6 +6,8 @@
     owner: root
     group: svc-acme
     mode: '0640'
+  no_log: true
+  diff: false
 
 - name: Install optional Cloudflare credential source
   ansible.builtin.copy:

--- a/roles/tls_automation/tasks/install.yml
+++ b/roles/tls_automation/tasks/install.yml
@@ -25,6 +25,7 @@
     - policy.py
     - publication.py
     - runtime.py
+    - caddy.py
     - unit_contract.py
 
 - name: Install fixed TLS launchers
@@ -38,6 +39,7 @@
     - homelab-tls-issue
     - homelab-tls-reconcile
     - homelab-tls-verify
+    - homelab-tls-caddy
 
 - name: Create isolated lego extraction directory
   ansible.builtin.file:
@@ -97,9 +99,10 @@
     group: "{{ item.group }}"
     mode: "{{ item.mode }}"
   loop:
-    - {path: /var/lib/homelab-tls, owner: root, group: "{{ tls_automation_reader_gid }}", mode: '0750'}
+    - {path: /var/lib/homelab-tls, owner: root, group: "{{ tls_automation_caddy_gid }}", mode: '0750'}
     - {path: /var/lib/homelab-tls/private, owner: root, group: root, mode: '0700'}
-    - {path: /var/lib/homelab-tls/published, owner: root, group: "{{ tls_automation_reader_gid }}", mode: '0750'}
+    - {path: /etc/caddy/tls/infra, owner: root, group: caddy, mode: '0750'}
+    - {path: /etc/caddy/tls/.homelab-tls-private, owner: root, group: root, mode: '0700'}
     - {path: /var/lib/homelab-tls-issuer, owner: svc-acme, group: svc-acme, mode: '0700'}
 
 - name: Create the fixed coordinator lock

--- a/roles/tls_automation/tasks/preflight.yml
+++ b/roles/tls_automation/tasks/preflight.yml
@@ -15,41 +15,123 @@
       - ansible_become_pass is not defined
     fail_msg: TLS automation requires a supported systemd host and key-only ansible administration
 
+- name: Resolve the installed Caddy certificate reader group
+  ansible.builtin.command:
+    argv: [/usr/bin/getent, group, caddy]
+  register: tls_automation_reader_group
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: Require the package-owned Caddy group
+  ansible.builtin.assert:
+    that:
+      - tls_automation_reader_group.stdout.split(':') | length == 4
+      - tls_automation_reader_group.stdout.split(':')[0] == 'caddy'
+      - tls_automation_reader_group.stdout.split(':')[2] | int > 0
+      - >-
+        tls_automation_reader_gid is none or
+        tls_automation_reader_gid == tls_automation_reader_group.stdout.split(':')[2] | int
+    fail_msg: Provision the shared Caddy service before TLS; its named group owns certificate read access
+  no_log: true
+
+- name: Record the resolved certificate reader group
+  ansible.builtin.set_fact:
+    tls_automation_caddy_gid: "{{ tls_automation_reader_group.stdout.split(':')[2] | int }}"
+  no_log: true
+
 - name: Assemble fixed TLS policy and issuer declaration
   ansible.builtin.set_fact:
-    tls_automation_policy:
-      namespace: "{{ tls_automation_namespace }}"
-      email: "{{ tls_automation_email }}"
-      reader_gid: "{{ tls_automation_reader_gid }}"
-      endpoints: "{{ tls_automation_endpoints }}"
+    tls_automation_proxy_declaration:
+      bind_addresses: "{{ reverse_proxy_bind_addresses | default([]) }}"
+      client_sources: "{{ reverse_proxy_client_sources | default([]) }}"
+      routes: "{{ reverse_proxy_routes | default([]) }}"
+      deferred_certificates: "{{ reverse_proxy_deferred_certificates | default([]) }}"
+    tls_automation_policy: >-
+      {{ {'bind_addresses': reverse_proxy_bind_addresses | default([]),
+          'client_sources': reverse_proxy_client_sources | default([]),
+          'routes': reverse_proxy_routes | default([]),
+          'deferred_certificates': reverse_proxy_deferred_certificates | default([])}
+         | tls_automation_proxy_policy(tls_automation_namespace,
+                                       tls_automation_email,
+                                       tls_automation_caddy_gid) }}
     tls_automation_issuer_account:
       name: svc-acme
       uid: "{{ tls_automation_issuer_uid }}"
       gid: "{{ tls_automation_issuer_gid }}"
+  no_log: true
 
 - name: Validate strict TLS inputs
   ansible.builtin.assert:
     that:
       - >-
-        tls_automation_policy ==
-        {'namespace': tls_automation_namespace, 'email': tls_automation_email,
-         'reader_gid': tls_automation_reader_gid, 'endpoints': tls_automation_endpoints}
-      - >-
         tls_automation_issuer_account ==
         {'name': 'svc-acme', 'uid': tls_automation_issuer_uid, 'gid': tls_automation_issuer_gid}
       - tls_automation_policy | tls_automation_validate_policy == tls_automation_policy
+      - >-
+        tls_automation_endpoints | length == 0 or
+        tls_automation_endpoints == tls_automation_policy.endpoints
       - tls_automation_issuer_uid is integer
       - tls_automation_issuer_uid is not boolean
       - tls_automation_issuer_gid is integer
       - tls_automation_issuer_gid is not boolean
-      - tls_automation_issuer_uid != tls_automation_reader_gid
-      - tls_automation_issuer_gid != tls_automation_reader_gid
+      - tls_automation_issuer_uid != tls_automation_caddy_gid
+      - tls_automation_issuer_gid != tls_automation_caddy_gid
       - tls_automation_timer_enabled is boolean
       - >-
         tls_automation_cloudflare_token is not defined or
         (tls_automation_cloudflare_token is string and tls_automation_cloudflare_token | length > 0)
       - not tls_automation_timer_enabled or tls_automation_cloudflare_token is defined
     fail_msg: TLS policy, identity, timer, or credential input is invalid
+  no_log: true
+
+- name: Inspect required installed Caddy integration boundaries
+  ansible.builtin.stat:
+    path: "{{ item.path }}"
+    follow: false
+    get_checksum: false
+    get_mime: false
+    get_attributes: false
+  loop:
+    - {path: /usr/local/libexec/homelab-reverse-proxy, mode: '0755'}
+    - {path: /usr/local/lib/homelab-reverse-proxy/proxy_config.py, mode: '0644'}
+    - {path: /usr/local/lib/homelab-reverse-proxy/proxy_manifest.py, mode: '0644'}
+    - {path: /var/lib/homelab-reverse-proxy/desired.json, mode: '0600'}
+    - {path: /run/lock/homelab-reverse-proxy.lock, mode: '0600'}
+  register: tls_automation_proxy_boundaries
+
+- name: Require provisioned root-owned Caddy integration
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+      - item.stat.isreg | default(false)
+      - not item.stat.islnk | default(false)
+      - item.stat.uid | default(-1) == 0
+      - item.stat.gid | default(-1) == 0
+      - item.stat.nlink | default(0) == 1
+      - item.stat.mode | default('') == item.item.mode
+      - >-
+        item.item.path != '/var/lib/homelab-reverse-proxy/desired.json' or
+        0 < item.stat.size | default(0) <= 1048576
+    fail_msg: Provision the shared Caddy service and desired manifest before installing TLS
+  loop: "{{ tls_automation_proxy_boundaries.results }}"
+  loop_control:
+    label: "{{ item.item.path }}"
+
+- name: Read the committed Caddy declaration before TLS mutation
+  ansible.builtin.slurp:
+    src: /var/lib/homelab-reverse-proxy/desired.json
+  register: tls_automation_committed_proxy
+  no_log: true
+
+- name: Bind TLS policy to the committed Caddy routes and verified ingress
+  ansible.builtin.set_fact:
+    tls_automation_policy: >-
+      {{ tls_automation_committed_proxy.content | b64decode
+         | tls_automation_committed_proxy_policy(tls_automation_proxy_declaration,
+                                                 tls_automation_namespace,
+                                                 tls_automation_email,
+                                                 tls_automation_caddy_gid) }}
   no_log: true
 
 - name: Read effective host users before mutation
@@ -82,20 +164,6 @@
   check_mode: false
   no_log: true
 
-- name: Require the declared reader group
-  ansible.builtin.command:
-    argv: [/usr/bin/getent, group, "{{ tls_automation_reader_gid }}"]
-  register: tls_automation_reader_group
-  changed_when: false
-  check_mode: false
-
-- name: Verify the declared reader group ID
-  ansible.builtin.assert:
-    that:
-      - tls_automation_reader_group.stdout.split(':') | length == 4
-      - tls_automation_reader_group.stdout.split(':')[2] | int == tls_automation_reader_gid
-    fail_msg: The declared TLS reader GID must already exist
-
 - name: Inspect trusted TLS ancestor directories
   ansible.builtin.stat:
     path: "{{ item }}"
@@ -105,6 +173,8 @@
     get_attributes: false
   loop:
     - /etc
+    - /etc/caddy
+    - /etc/caddy/tls
     - /etc/systemd
     - /etc/systemd/system
     - /usr
@@ -148,11 +218,13 @@
     - {path: /usr/local/lib/homelab-tls/tls_runtime/policy.py, type: file, owner: 0}
     - {path: /usr/local/lib/homelab-tls/tls_runtime/publication.py, type: file, owner: 0}
     - {path: /usr/local/lib/homelab-tls/tls_runtime/runtime.py, type: file, owner: 0}
+    - {path: /usr/local/lib/homelab-tls/tls_runtime/caddy.py, type: file, owner: 0}
     - {path: /usr/local/libexec, type: directory, owner: 0}
     - {path: /usr/local/libexec/lego-5.4.1, type: file, owner: 0}
     - {path: /usr/local/libexec/homelab-tls-issue, type: file, owner: 0}
     - {path: /usr/local/libexec/homelab-tls-reconcile, type: file, owner: 0}
     - {path: /usr/local/libexec/homelab-tls-verify, type: file, owner: 0}
+    - {path: /usr/local/libexec/homelab-tls-caddy, type: file, owner: 0}
     - {path: /var/cache/homelab-tls, type: directory, owner: 0}
     - path: >-
         /var/cache/homelab-tls/lego_v5.4.1_linux_{{
@@ -172,7 +244,8 @@
     - {path: /var/lib/homelab-tls, type: directory, owner: 0}
     - {path: /var/lib/homelab-tls/private, type: directory, owner: 0}
     - {path: /var/lib/homelab-tls/private/coordinator.lock, type: file, owner: 0}
-    - {path: /var/lib/homelab-tls/published, type: directory, owner: 0}
+    - {path: /etc/caddy/tls/infra, type: directory, owner: 0}
+    - {path: /etc/caddy/tls/.homelab-tls-private, type: directory, owner: 0}
     - {path: /var/lib/homelab-tls-issuer, type: directory, owner: "{{ tls_automation_issuer_uid }}"}
     - {path: /etc/systemd/system/homelab-tls-issuer.service, type: file, owner: 0}
     - {path: /etc/systemd/system/homelab-tls-renew.service, type: file, owner: 0}
@@ -206,6 +279,51 @@
   loop: "{{ tls_automation_managed_paths.results }}"
   loop_control:
     label: "{{ item.item.path }}"
+
+- name: Inspect the previous publication directory
+  ansible.builtin.stat:
+    path: /var/lib/homelab-tls/published
+    follow: false
+    get_checksum: false
+    get_mime: false
+    get_attributes: false
+  register: tls_automation_old_root
+
+- name: Reject an unsafe previous publication directory
+  ansible.builtin.assert:
+    that:
+      - not tls_automation_old_root.stat.islnk | default(false)
+      - not tls_automation_old_root.stat.exists or tls_automation_old_root.stat.isdir
+      - not tls_automation_old_root.stat.exists or tls_automation_old_root.stat.uid == 0
+    fail_msg: The previous TLS publication path has unsafe metadata
+
+- name: Inspect the previous publication layout
+  ansible.builtin.find:
+    paths: /var/lib/homelab-tls/published
+    file_type: any
+    hidden: true
+    recurse: false
+  register: tls_automation_old_publication
+  when: tls_automation_old_root.stat.exists
+  no_log: true
+
+- name: Inspect the previous publication journal
+  ansible.builtin.stat:
+    path: /var/lib/homelab-tls/private/transaction.json
+    follow: false
+    get_checksum: false
+    get_mime: false
+    get_attributes: false
+  register: tls_automation_old_journal
+
+- name: Require explicit migration of previously published certificates
+  ansible.builtin.assert:
+    that:
+      - tls_automation_old_publication.matched | default(0) == 0
+      - not tls_automation_old_journal.stat.exists
+      - not tls_automation_old_journal.stat.islnk | default(false)
+    fail_msg: Existing TLS publication requires operator migration before installing the Caddy integration
+  no_log: true
 
 - name: Inspect the systemd typed property client before mutation
   ansible.builtin.stat:

--- a/roles/tls_automation/templates/config.json.j2
+++ b/roles/tls_automation/templates/config.json.j2
@@ -1,4 +1,1 @@
-{{ {'namespace': tls_automation_namespace,
-    'email': tls_automation_email,
-    'reader_gid': tls_automation_reader_gid,
-    'endpoints': tls_automation_endpoints} | to_nice_json }}
+{{ tls_automation_policy | to_nice_json }}

--- a/roles/tls_automation/templates/homelab-tls-renew.service.j2
+++ b/roles/tls_automation/templates/homelab-tls-renew.service.j2
@@ -20,6 +20,6 @@ ProtectControlGroups=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-ReadWritePaths=/var/lib/homelab-tls
+ReadWritePaths=/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy
 UMask=0077
 TimeoutStartSec=1h

--- a/tests/ansible/inventory-test.sh
+++ b/tests/ansible/inventory-test.sh
@@ -23,6 +23,7 @@ mkdir -p \
   "$inventory_test_root/production/group_vars/os_managed" \
   "$inventory_test_root/production/group_vars/podman_hosts" \
   "$inventory_test_root/production/group_vars/reverse_proxy_hosts" \
+  "$inventory_test_root/production/group_vars/tls_hosts" \
   "$inventory_test_root/production/host_vars/nuc4" \
   "$inventory_test_root/staging/group_vars/semaphore" \
   "$inventory_test_root/staging-semaphore/group_vars/semaphore" \
@@ -37,6 +38,8 @@ cp "$repository_root/inventory/production/group_vars/podman_hosts/vars.yml" \
   "$inventory_test_root/production/group_vars/podman_hosts/vars.yml"
 cp "$repository_root/inventory/production/group_vars/reverse_proxy_hosts/vars.yml" \
   "$inventory_test_root/production/group_vars/reverse_proxy_hosts/vars.yml"
+cp "$repository_root/inventory/production/group_vars/tls_hosts/vars.yml" \
+  "$inventory_test_root/production/group_vars/tls_hosts/vars.yml"
 cp "$repository_root/inventory/production/host_vars/nuc4/vars.yml" \
   "$inventory_test_root/production/host_vars/nuc4/vars.yml"
 
@@ -105,12 +108,17 @@ staging_semaphore = load_inventory(sys.argv[4])
 assert production["os_managed"].get("hosts", []) == ["nuc4"]
 assert production["podman_hosts"].get("hosts", []) == ["nuc4"]
 assert production["reverse_proxy_hosts"].get("hosts", []) == ["nuc4"]
+assert production["tls_hosts"].get("hosts", []) == ["nuc4"]
 for retired_group in ("servers", "pihole", "ansible"):
     assert retired_group not in production
 host_variables = production.get("_meta", {}).get("hostvars", {}).get("nuc4", {})
 assert host_variables.get("ansible_user") == "ansible"
 assert host_variables.get("host_identity_hostname") == "nuc4"
 assert host_variables.get("podman_foundation_accounts") == []
+assert host_variables.get("tls_automation_timer_enabled") is False
+assert host_variables.get("tls_automation_issuer_uid") == 2010
+assert host_variables.get("tls_automation_issuer_gid") == 2010
+assert host_variables.get("reverse_proxy_deferred_certificates") == ["infra"]
 assert host_variables.get("reverse_proxy_bind_addresses") == []
 assert host_variables.get("reverse_proxy_client_sources") == []
 assert host_variables.get("reverse_proxy_routes") == []

--- a/tests/ansible/test_baseline_molecule_controls.py
+++ b/tests/ansible/test_baseline_molecule_controls.py
@@ -166,6 +166,21 @@ class FirewallOracleTests(unittest.TestCase):
         zone, direct = exact_firewall_results()
         self.assertEqual([], self.errors(zone, direct))
 
+    def test_deferred_proxy_requires_only_its_declared_https_source(self) -> None:
+        zone, direct = exact_firewall_results()
+        observed = next(item for item in zone if item["item"] == "--list-rich-rules")
+        check = lambda: self.controls.system_maintenance_molecule_baseline_firewall_errors(
+            "DefaultZone=homelab\n", zone, direct,
+            "homelab\n  interfaces:\n  sources:\n", DEBIAN_FIREWALL_POLICY,
+            "Debian", ["10.20.30.40/32"])
+        self.assertIn("rich-rules", check())
+        observed["stdout_lines"].append(
+            'rule family="ipv4" source address="10.20.30.40/32" '
+            'port port="443" protocol="tcp" accept')
+        self.assertEqual([], check())
+        observed["stdout_lines"].append(observed["stdout_lines"][-1])
+        self.assertIn("rich-rules", check())
+
     def test_wrong_or_duplicate_default_zone_is_rejected(self) -> None:
         zone, direct = exact_firewall_results()
         for configuration in (

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -566,6 +566,17 @@ class MoleculeScenarioContractTests(unittest.TestCase):
         )
         self.assertEqual("UTC", variables["host_identity_timezone"])
         self.assertEqual(["10.0.0.0/8"], variables["security_baseline_management_sources"])
+        proxy_task = next(
+            task
+            for play in documents[0]
+            for task in play.get("tasks", [])
+            if task.get("ansible.builtin.include_role", {}).get("name") == "reverse_proxy"
+        )
+        self.assertEqual(
+            variables["security_baseline_management_sources"],
+            proxy_task.get("vars", {}).get("security_baseline_management_sources"),
+            "OS and Caddy plays must reconcile the same synthetic management network",
+        )
         self.assertEqual(
             "/usr/bin/stat -c %y /proc/1",
             variables["os_reboot_boot_time_command"],

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -122,6 +122,7 @@ class MoleculeScenarioContractTests(unittest.TestCase):
             "diagnose.py",
             "probe.py",
             "rotation.py",
+            "tls_integration.py",
         }
         self.assertEqual(
             required,
@@ -132,7 +133,7 @@ class MoleculeScenarioContractTests(unittest.TestCase):
             },
         )
         self.assertEqual(
-            {"certificate_failure.yml", "unexpected_failure.yml"},
+            {"certificate_failure.yml", "unexpected_failure.yml", "tls-integration.yml"},
             {
                 path.name
                 for path in (REVERSE_PROXY_SCENARIO_DIRECTORY / "tasks").iterdir()
@@ -545,7 +546,8 @@ class MoleculeScenarioContractTests(unittest.TestCase):
         )
         self.assertEqual(1, len(documents))
         key_play = documents[0][0]
-        imported_playbook = documents[0][1]
+        imported_playbook = next(play for play in documents[0]
+                                 if "ansible.builtin.import_playbook" in play)
         key_source = str(key_play)
         self.assertIn("molecule_ephemeral_directory", key_source)
         self.assertIn("ssh-keygen", key_source)

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -594,6 +594,11 @@ class MoleculeScenarioContractTests(unittest.TestCase):
 
     def test_baseline_verify_is_independent_and_states_evidence_limits(self) -> None:
         verify = load_baseline_yaml("verify.yml")[0]
+        self.assertEqual(
+            {"file": "{{ playbook_dir }}/vars/tls.yml"},
+            verify.get("pre_tasks", [{}])[0].get("ansible.builtin.include_vars"),
+            "Proxy declarations must persist into the standalone OS verification play",
+        )
         self.assertEqual("os_managed", verify["hosts"])
         self.assertIs(verify["gather_facts"], True)
         self.assertIs(verify["become"], True)

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -176,7 +176,8 @@ class MoleculeScenarioContractTests(unittest.TestCase):
                 self.assertEqual(image, platform["image"])
                 self.assertEqual(container_name, platform["container_name"])
                 self.assertEqual(["reverse_proxy_hosts"], platform["groups"])
-                self.assertEqual(["SYS_PTRACE"], platform["container_cap_add"])
+                expected_capabilities = ["SYS_PTRACE", "SYS_ADMIN"]
+                self.assertEqual(expected_capabilities, platform["container_cap_add"])
                 self.assertIs(platform["container_privileged"], False)
                 self.assertEqual("always", platform["container_systemd"])
                 self.assertEqual("never", platform["pull"])

--- a/tests/ansible/test_platform_control_contracts.py
+++ b/tests/ansible/test_platform_control_contracts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -293,11 +294,130 @@ Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
             ],
         }
 
+    def add_epel_fixture(
+        self,
+        root: Path,
+        effective: dict[str, object],
+    ) -> Path:
+        marker = root / "var/lib/homelab-reverse-proxy/managed"
+        marker.parent.mkdir(parents=True)
+        marker.write_text("managed by homelab-playbook\n", encoding="utf-8")
+        marker.chmod(0o600)
+        key = root / "etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9"
+        key.touch()
+        repo_dir = root / "etc/dnf/authoritative.repos.d"
+        repositories = effective["repos"]
+        assert isinstance(repositories, list)
+        for repository_id, filename in (
+            ("epel", "epel.repo"),
+            ("epel-cisco-openh264", "epel-cisco-openh264.repo"),
+        ):
+            repo_file = repo_dir / filename
+            repo_file.touch()
+            repositories.append(
+                {
+                    "id": repository_id,
+                    "enabled": True,
+                    "gpgcheck": True,
+                    "gpgkey": ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9"],
+                    "repofile": f"/etc/dnf/authoritative.repos.d/{filename}",
+                }
+            )
+        return marker
+
+    def marker_identity(self, uid: int = 0, gid: int = 0):
+        real_fstat = os.fstat
+
+        def identified(descriptor: int):
+            observed = real_fstat(descriptor)
+            fields = list(observed)
+            fields[4] = uid
+            fields[5] = gid
+            return os.stat_result(fields)
+
+        return mock.patch.object(os, "fstat", side_effect=identified)
+
     def test_rocky_accepts_effective_distribution_repository_policy(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             effective = self.rocky_fixture(root)
             self.repository_trust.validate_rocky_configuration(effective, root)
+
+    def test_rocky_accepts_exact_role_owned_epel_repositories(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            effective = self.rocky_fixture(root)
+            self.add_epel_fixture(root, effective)
+            with self.marker_identity():
+                self.repository_trust.validate_rocky_configuration(effective, root)
+
+    def test_rocky_rejects_epel_without_exact_caddy_ownership_marker(self) -> None:
+        for mutation in (
+            "absent",
+            "wrong mode",
+            "wrong uid",
+            "wrong gid",
+            "wrong content",
+            "symlink",
+            "hardlink",
+            "fifo",
+        ):
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                effective = self.rocky_fixture(root)
+                marker = self.add_epel_fixture(root, effective)
+                uid = gid = 0
+                if mutation == "absent":
+                    marker.unlink()
+                elif mutation == "wrong mode":
+                    marker.chmod(0o640)
+                elif mutation == "wrong uid":
+                    uid = 1000
+                elif mutation == "wrong gid":
+                    gid = 1000
+                elif mutation == "wrong content":
+                    marker.write_text("managed by homelab-playbook!", encoding="utf-8")
+                elif mutation == "symlink":
+                    target = marker.with_name("managed-target")
+                    marker.rename(target)
+                    marker.symlink_to(target)
+                elif mutation == "hardlink":
+                    os.link(marker, marker.with_name("managed-link"))
+                else:
+                    marker.unlink()
+                    os.mkfifo(marker, 0o600)
+                with self.marker_identity(uid, gid), self.assertRaises(ValueError):
+                    self.repository_trust.validate_rocky_configuration(effective, root)
+
+    def test_rocky_rejects_epel_id_key_and_signature_drift(self) -> None:
+        mutations = {
+            "EPEL signed by Rocky": lambda value, _root: value["repos"][1].update(
+                gpgkey=["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9"]
+            ),
+            "Rocky signed by EPEL": lambda value, _root: value["repos"][0].update(
+                gpgkey=["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9"]
+            ),
+            "unknown EPEL ID": lambda value, _root: value["repos"][1].update(
+                id="epel-testing"
+            ),
+            "case-changed EPEL ID": lambda value, _root: value["repos"][1].update(
+                id="EPEL"
+            ),
+            "missing EPEL key": lambda _value, root: (
+                root / "etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9"
+            ).unlink(),
+            "EPEL signature bypass": lambda value, _root: value["repos"][1].update(
+                gpgcheck=False
+            ),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                effective = self.rocky_fixture(root)
+                self.add_epel_fixture(root, effective)
+                mutate(effective, root)
+                with self.marker_identity(), self.assertRaises(ValueError):
+                    self.repository_trust.validate_rocky_configuration(effective, root)
 
     def test_rocky_rejects_signature_bypasses_and_non_authoritative_files(
         self,

--- a/tests/ansible/test_proxy_manifest_role.py
+++ b/tests/ansible/test_proxy_manifest_role.py
@@ -1,0 +1,84 @@
+"""Ingress verification must precede authorization of desired route activation."""
+
+from pathlib import Path
+import hashlib
+import json
+import unittest
+
+from ansible.parsing.dataloader import DataLoader
+from ansible.template import Templar, trust_as_template
+import yaml
+
+
+ROLE = Path(__file__).resolve().parents[2] / "roles/reverse_proxy"
+
+
+class ManifestRoleTests(unittest.TestCase):
+    def test_trust_installation_checks_this_runs_own_bytes_before_activation(self):
+        tasks = yaml.safe_load((ROLE / "tasks/configure.yml").read_text())
+        install = next(i for i, task in enumerate(tasks)
+                       if task.get("ansible.builtin.command", {}).get("argv")
+                       == ["/usr/local/libexec/homelab-reverse-proxy", "install-trust"])
+        verify = next(i for i, task in enumerate(tasks)
+                      if task["name"] == "Require this deployment's exact immutable trust contents")
+        self.assertLess(install, verify)
+        declared = "synthetic certificate contents"
+        observed = {"exists": True, "isreg": True, "islnk": False, "uid": 0,
+                    "gr_name": "caddy", "nlink": 1, "mode": "0640",
+                    "checksum": hashlib.sha256(declared.encode()).hexdigest()}
+        def accepted():
+            templar = Templar(loader=DataLoader(), variables={
+                "item": {"stat": observed, "item": {"value": declared}}})
+            return all(templar.template(trust_as_template("{{ " + expression + " }}"))
+                       for expression in tasks[verify]["ansible.builtin.assert"]["that"])
+        self.assertTrue(accepted())
+        observed["checksum"] = hashlib.sha256(b"other concurrent declaration").hexdigest()
+        self.assertFalse(accepted())
+
+    def test_ansible_serialization_produces_json_with_matching_ingress_hash(self):
+        tasks = yaml.safe_load((ROLE / "tasks/main.yml").read_text())
+        config = {"bind_addresses": [], "client_sources": [], "routes": [],
+                  "deferred_certificates": []}
+        values = {"reverse_proxy_config": config}
+        outputs = {}
+        for task in tasks:
+            facts = task.get("ansible.builtin.set_fact", {})
+            if "reverse_proxy_manifest_bytes" in facts:
+                values["reverse_proxy_manifest_bytes"] = Templar(
+                    loader=DataLoader(), variables=values,
+                ).template(trust_as_template(facts["reverse_proxy_manifest_bytes"]))
+            copy = task.get("ansible.builtin.copy", {})
+            if "content" in copy:
+                outputs[Path(copy["dest"]).name] = Templar(
+                    loader=DataLoader(), variables=values,
+                ).template(trust_as_template(copy["content"]))
+        raw = outputs["desired.candidate.json"]
+        self.assertEqual(config, json.loads(raw))
+        self.assertEqual(hashlib.sha256(raw.encode()).hexdigest(),
+                         json.loads(outputs["ingress.candidate.json"])["manifest_sha256"])
+
+    def test_verified_ingress_precedes_manifest_activation(self):
+        tasks = yaml.safe_load((ROLE / "tasks/main.yml").read_text())
+        verification = next(i for i, task in enumerate(tasks)
+                            if task.get("ansible.builtin.include_role", {}).get("name") == "os_baseline_verify")
+        stamps = [i for i, task in enumerate(tasks)
+                  if task.get("ansible.builtin.copy", {}).get("dest")
+                  == "/var/lib/homelab-reverse-proxy/ingress.candidate.json"]
+        activations = [i for i, task in enumerate(tasks)
+                       if task.get("ansible.builtin.command", {}).get("argv")
+                       == ["/usr/local/libexec/homelab-reverse-proxy", "apply-desired"]]
+        self.assertEqual(1, len(stamps))
+        self.assertEqual(1, len(activations))
+        self.assertLess(verification, stamps[0])
+        self.assertLess(stamps[0], activations[0])
+
+    def test_role_does_not_overwrite_committed_manifest_authority(self):
+        for source in (ROLE / "tasks").glob("*.yml"):
+            tasks = yaml.safe_load(source.read_text())
+            for task in tasks:
+                for module in ("ansible.builtin.copy", "ansible.builtin.template"):
+                    self.assertNotEqual(
+                        "/var/lib/homelab-reverse-proxy/desired.json",
+                        task.get(module, {}).get("dest"),
+                        source.name,
+                    )

--- a/tests/ansible/test_proxy_manifest_runtime.py
+++ b/tests/ansible/test_proxy_manifest_runtime.py
@@ -1,0 +1,146 @@
+"""Desired declaration authority is separate from deferred effective routes."""
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import unittest
+
+from test_reverse_proxy_activation import ActivationFixture
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location('proxy_config', ROOT / 'roles/reverse_proxy/filter_plugins/proxy.py')
+renderer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(renderer)
+sys.modules['proxy_config'] = renderer
+
+
+def manifest_module():
+    spec = importlib.util.spec_from_file_location('proxy_manifest', ROOT / 'roles/reverse_proxy/files/manifest.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ManifestTests(ActivationFixture):
+    def setUp(self):
+        super().setUp()
+        self.manifests = manifest_module().Manifest(self.activation)
+        self.config = {'bind_addresses': ['10.20.30.40'], 'client_sources': ['10.20.0.0/16'],
+                       'deferred_certificates': ['infra'], 'routes': [
+                           {'hostname': 'app.infra.example.com', 'backend_port': 18080,
+                            'certificate_name': 'infra'}]}
+
+    def candidates(self):
+        raw = json.dumps(self.config) + '\n'
+        ingress = {'version': 1, 'manifest_sha256': hashlib.sha256(raw.encode()).hexdigest(),
+                   'listen_addresses': ['10.20.30.40'], 'https_client_networks': ['10.20.0.0/16']}
+        self.write(self.state / 'desired.candidate.json', raw, 0o600)
+        self.write(self.state / 'ingress.candidate.json', json.dumps(ingress), 0o600)
+        return raw
+
+    def test_preserves_hashed_original_manifest_and_defers_only_infra(self):
+        raw = self.candidates()
+        envelope, config = self.manifests.candidate()
+        self.assertEqual(raw, envelope['manifest'])
+        self.assertEqual([], self.manifests.effective(config)['routes'])
+        self.assertEqual(1, len(config['routes']))
+        self.assertNotIn('https://', self.manifests.render(config))
+
+    def test_hash_or_ingress_mismatch_cannot_become_authority(self):
+        self.candidates()
+        ingress_path = self.state / 'ingress.candidate.json'
+        for field, value in [('manifest_sha256', 'f' * 64), ('listen_addresses', ['10.20.30.41']),
+                             ('https_client_networks', ['10.0.0.0/8']), ('version', True)]:
+            self.candidates()
+            ingress = json.loads(ingress_path.read_text())
+            ingress[field] = value
+            self.write(ingress_path, json.dumps(ingress), 0o600)
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                self.manifests.candidate()
+
+    def test_missing_other_certificate_remains_in_effective_candidate(self):
+        self.config['routes'].append({'hostname': 'other.example.com', 'backend_port': 18081,
+                                      'certificate_name': 'other'})
+        self.assertEqual(['other'], [route['certificate_name']
+                                    for route in self.manifests.effective(self.config)['routes']])
+
+    def test_broken_infra_pointer_is_not_treated_as_first_publication(self):
+        base = self.root / 'etc/caddy/tls/infra'
+        base.mkdir(mode=0o750)
+        (base / 'current').symlink_to('missing')
+        self.assertEqual(1, len(self.manifests.effective(self.config)['routes']))
+
+    def test_candidate_replacement_is_detected_before_commit(self):
+        self.candidates()
+        envelope, unused = self.manifests.candidate()
+        self.config['routes'][0]['backend_port'] = 18082
+        self.candidates()
+        with self.assertRaises(ValueError):
+            self.manifests.unchanged(envelope)
+
+    def test_policy_binding_covers_every_infra_hostname_and_address(self):
+        self.config['bind_addresses'].append('fd00::40')
+        expected = {('app.infra.example.com', '10.20.30.40', 443),
+                    ('app.infra.example.com', 'fd00::40', 443)}
+        self.assertEqual(expected, self.manifests.endpoints(self.config))
+
+class DesiredActivationTests(ManifestTests):
+    def setUp(self):
+        super().setUp()
+        sys.modules['proxy_manifest'] = manifest_module()
+        run = self.commands.run
+        def commands(argv):
+            if argv[:6] == ['/usr/sbin/runuser', '-u', 'caddy', '--', '/usr/bin/caddy', 'adapt']:
+                return json.dumps(self.old).encode()
+            if argv[:6] == ['/usr/sbin/runuser', '-u', 'caddy', '--', '/usr/bin/caddy', 'reload']:
+                self.commands.reloads += 1
+                self.commands.loaded = self.old
+                return b''
+            return run(argv)
+        self.commands.run = commands
+        self.write(self.boot, self.manifests.render(self.config))
+
+    def test_deferred_manifest_commits_even_when_boot_is_unchanged(self):
+        raw = self.candidates()
+        self.assertEqual('changed', self.activation.apply(desired=True))
+        self.assertEqual(raw, json.loads((self.state / 'desired.json').read_bytes())['manifest'])
+        self.assertEqual(0, self.commands.reloads)
+        self.assertEqual('unchanged', self.activation.apply(desired=True))
+
+    def test_interruption_restores_previous_desired_authority_with_boot(self):
+        self.candidates()
+        previous = self.boot.read_bytes()
+        original = self.activation.durable_write
+        def interrupted(path, *args):
+            original(path, *args)
+            if path.name == 'desired.json':
+                raise KeyboardInterrupt()
+        self.activation.durable_write = interrupted
+        with self.assertRaises(KeyboardInterrupt):
+            self.activation.apply(desired=True)
+        self.activation.durable_write = original
+        self.activation.recover()
+        self.assertEqual(previous, self.boot.read_bytes())
+        self.assertFalse((self.state / 'desired.json').exists())
+
+    def test_pending_tls_blocks_desired_and_legacy_apply_before_reload(self):
+        self.candidates()
+        journal = self.root / 'etc/caddy/tls/.homelab-tls-private/transaction.json'
+        journal.parent.mkdir(mode=0o700)
+        journal.write_text('{}')
+        for desired in (True, False):
+            with self.assertRaises(self.module.ActivationError):
+                self.activation.apply(desired=desired)
+        self.assertEqual(0, self.commands.reloads)
+
+    def test_marker_cleanup_failure_restores_desired_from_memory(self):
+        self.candidates()
+        def cleanup_failure():
+            self.activation.pending.unlink()
+            raise OSError('injected marker durability failure')
+        self.activation.clear_pending = cleanup_failure
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.apply(desired=True)
+        self.assertFalse((self.state / 'desired.json').exists())

--- a/tests/ansible/test_proxy_trust_runtime.py
+++ b/tests/ansible/test_proxy_trust_runtime.py
@@ -1,0 +1,255 @@
+"""Trust names are immutable even across interrupted or concurrent installs."""
+import fcntl
+import json
+import multiprocessing
+import os
+from pathlib import Path
+import stat
+import sys
+import unittest
+from unittest import mock
+
+from test_reverse_proxy_activation import ActivationFixture
+from test_proxy_manifest_runtime import manifest_module
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'tls'))
+from cert_fixtures import EphemeralCA
+from cryptography.hazmat.primitives import serialization
+
+
+class TrustFixture(ActivationFixture):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pem_a = EphemeralCA('Trust fixture A').certificate.public_bytes(serialization.Encoding.PEM).decode()
+        cls.pem_b = EphemeralCA('Trust fixture B').certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def setUp(self):
+        super().setUp()
+        self.manifest_runtime = manifest_module()
+        sys.modules['proxy_manifest'] = self.manifest_runtime
+        self.trust_root = self.root / 'etc/caddy/trust'
+        self.trust_root.mkdir(mode=0o750)
+        self.source = self.state / 'trust.candidate.json'
+
+    def trust_candidate(self, value):
+        self.write(self.source, json.dumps(value), 0o600)
+
+
+class TrustInstallTests(TrustFixture):
+    def test_existing_name_rejects_replacement_and_preserves_original_inode(self):
+        self.trust_candidate({'device': self.pem_a})
+        self.assertEqual('changed', self.activation.install_trust())
+        target = self.trust_root / 'device.pem'
+        original = target.stat()
+        self.assertEqual(self.pem_a, target.read_text())
+        self.assertEqual(0o640, stat.S_IMODE(original.st_mode))
+        self.assertEqual(1, original.st_nlink)
+        self.assertEqual('unchanged', self.activation.install_trust())
+        self.trust_candidate({'device': self.pem_b})
+        with self.assertRaises((ValueError, self.module.ActivationError)):
+            self.activation.install_trust()
+        self.assertEqual(original.st_ino, target.stat().st_ino)
+        self.assertEqual(self.pem_a, target.read_text())
+
+    def test_all_inputs_are_validated_before_any_new_anchor(self):
+        for invalid in [{'../escape': self.pem_a}, {'device': 'not a PEM certificate'},
+                        {'device': 1}, {'device': '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n'},
+                        {'device': self.pem_a + 'unparsed suffix'}, [],
+                        {'device': self.pem_a * 1000}]:
+            with self.subTest(value_type=type(invalid).__name__):
+                self.trust_candidate(invalid)
+                with self.assertRaises((ValueError, self.module.ActivationError)):
+                    self.activation.install_trust()
+                self.assertEqual([], list(self.trust_root.iterdir()))
+
+    def test_empty_mapping_is_unchanged_and_never_deletes_anchors(self):
+        self.trust_candidate({'device': self.pem_a})
+        self.activation.install_trust()
+        self.trust_candidate({})
+        self.assertEqual('unchanged', self.activation.install_trust())
+        self.assertEqual(self.pem_a, (self.trust_root / 'device.pem').read_text())
+
+    def test_unsafe_candidate_root_and_existing_anchor_metadata_are_rejected(self):
+        self.trust_candidate({'device': self.pem_a})
+        self.source.chmod(0o644)
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.install_trust()
+        self.source.chmod(0o600)
+        self.trust_root.chmod(0o770)
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.install_trust()
+        self.trust_root.chmod(0o750)
+        target = self.trust_root / 'device.pem'
+        target.symlink_to(self.source)
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.install_trust()
+        target.unlink()
+        self.write(target, self.pem_a, 0o644)
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.install_trust()
+        target.chmod(0o640)
+        os.link(target, self.trust_root / 'unrelated-hardlink')
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.install_trust()
+
+    def test_extended_or_default_acl_is_rejected(self):
+        self.trust_candidate({'device': self.pem_a})
+        original = getattr(os, 'listxattr', lambda path, **kwargs: [])
+        for attribute in ('system.posix_acl_access', 'system.posix_acl_default'):
+            def attributes(path, **kwargs):
+                return [attribute] if Path(path) == self.trust_root else original(path, **kwargs)
+            with self.subTest(attribute=attribute), mock.patch('os.listxattr', side_effect=attributes, create=True):
+                with self.assertRaises((ValueError, self.module.ActivationError)):
+                    self.activation.install_trust()
+        self.assertEqual([], list(self.trust_root.iterdir()))
+
+    def test_duplicate_names_are_rejected_before_installation(self):
+        self.write(self.source, '{"device":' + json.dumps(self.pem_a) + ',"device":' + json.dumps(self.pem_b) + '}', 0o600)
+        with self.assertRaises(ValueError):
+            self.activation.install_trust()
+        self.assertEqual([], list(self.trust_root.iterdir()))
+
+    def test_atomic_no_replace_preserves_a_file_created_at_publication_boundary(self):
+        self.trust_candidate({'device': self.pem_a})
+        target = self.trust_root / 'device.pem'
+        original = os.link
+        def contention(source, destination, **kwargs):
+            self.write(target, self.pem_b)
+            return original(source, destination, **kwargs)
+        with mock.patch('os.link', side_effect=contention), self.assertRaises((ValueError, self.module.ActivationError)):
+            self.activation.install_trust()
+        self.assertEqual(self.pem_b, target.read_text())
+        self.assertEqual(1, target.stat().st_nlink)
+
+
+class TrustRecoveryTests(TrustFixture):
+    def test_retry_recovers_interruption_after_link_without_overwriting_winner(self):
+        self.trust_candidate({'device': self.pem_a})
+        original = os.link
+        def interrupted(source, destination, **kwargs):
+            original(source, destination, **kwargs)
+            raise KeyboardInterrupt()
+        with mock.patch('os.link', side_effect=interrupted), self.assertRaises(KeyboardInterrupt):
+            self.activation.install_trust()
+        self.assertEqual(self.pem_a, (self.trust_root / 'device.pem').read_text())
+        self.trust_candidate({'device': self.pem_b})
+        with self.assertRaises((ValueError, self.module.ActivationError)):
+            self.activation.install_trust()
+        self.assertEqual(['device.pem'], [path.name for path in self.trust_root.iterdir()])
+        self.assertEqual(1, (self.trust_root / 'device.pem').stat().st_nlink)
+        self.assertEqual(self.pem_a, (self.trust_root / 'device.pem').read_text())
+
+    def test_abandoned_partial_stage_is_cleaned_without_touching_other_files(self):
+        self.trust_candidate({'device': self.pem_a})
+        stage = self.trust_root / ('.trust-stage-device-' + 'a' * 32)
+        self.write(stage, 'partial bytes', 0o600)
+        unrelated = self.trust_root / '.unrelated'
+        self.write(unrelated, 'keep', 0o600)
+        self.assertEqual('changed', self.activation.install_trust())
+        self.assertFalse(stage.exists())
+        self.assertEqual('keep', unrelated.read_text())
+
+
+class TrustConcurrencyTests(TrustFixture):
+    def test_different_concurrent_bundles_have_one_winner_and_one_failure(self):
+        self.trust_candidate({'device': self.pem_a})
+        context = multiprocessing.get_context('fork')
+        first_parent, first_child = context.Pipe()
+        second_parent, second_child = context.Pipe()
+        self.addCleanup(first_parent.close)
+        self.addCleanup(second_parent.close)
+        def first():
+            original = self.manifest_runtime.Manifest.read
+            captured = []
+            def read(manifest, path, **kwargs):
+                result = original(manifest, path, **kwargs)
+                if path == self.source and not captured:
+                    captured.append(True)
+                    first_child.send('snapshot captured')
+                    first_child.recv()
+                return result
+            self.manifest_runtime.Manifest.read = read
+            try:
+                first_child.send(self.activation.install_trust())
+            except (ValueError, self.module.ActivationError):
+                first_child.send('rejected')
+        def second():
+            try:
+                second_child.send(self.activation.install_trust())
+            except (ValueError, self.module.ActivationError):
+                second_child.send('rejected')
+        one = context.Process(target=first)
+        two = context.Process(target=second)
+        def cleanup(process):
+            if process.is_alive():
+                process.terminate()
+            process.join(5)
+        one.start()
+        self.addCleanup(cleanup, one)
+        self.assertTrue(first_parent.poll(5))
+        self.assertEqual('snapshot captured', first_parent.recv())
+        with self.activation.lock_path.open('rb') as probe:
+            with self.assertRaises(BlockingIOError):
+                fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        self.trust_candidate({'device': self.pem_b})
+        two.start()
+        self.addCleanup(cleanup, two)
+        first_parent.send('continue')
+        self.assertTrue(first_parent.poll(5))
+        self.assertTrue(second_parent.poll(5))
+        outcomes = [first_parent.recv(), second_parent.recv()]
+        self.assertEqual(['changed', 'rejected'], sorted(outcomes))
+        self.assertEqual(self.pem_b, (self.trust_root / 'device.pem').read_text())
+        self.assertEqual(1, (self.trust_root / 'device.pem').stat().st_nlink)
+
+class TrustHardInterruptionTests(TrustFixture):
+    def test_leftover_two_link_stage_recovers_to_one_immutable_final_link(self):
+        stage = self.trust_root / ('.trust-stage-device-' + 'b' * 32)
+        target = self.trust_root / 'device.pem'
+        self.write(stage, self.pem_a)
+        os.link(stage, target)
+        self.assertEqual(2, target.stat().st_nlink)
+        self.trust_candidate({'device': self.pem_b})
+        with self.assertRaises(ValueError):
+            self.activation.install_trust()
+        self.assertFalse(stage.exists())
+        self.assertEqual(1, target.stat().st_nlink)
+        self.assertEqual(self.pem_a, target.read_text())
+
+    def test_unrelated_second_link_is_not_removed_as_abandoned_stage(self):
+        stage = self.trust_root / ('.trust-stage-device-' + 'c' * 32)
+        unrelated = self.trust_root / 'other.pem'
+        self.write(stage, self.pem_a)
+        os.link(stage, unrelated)
+        self.trust_candidate({'device': self.pem_a})
+        with self.assertRaises((ValueError, OSError)):
+            self.activation.install_trust()
+        self.assertEqual(2, unrelated.stat().st_nlink)
+        self.assertEqual(self.pem_a, unrelated.read_text())
+        self.assertFalse((self.trust_root / 'device.pem').exists())
+
+
+class TrustCommandTests(TrustFixture):
+    def test_fixed_action_reports_change_and_rejects_path_arguments(self):
+        import contextlib
+        import io
+        self.trust_candidate({'device': self.pem_a})
+        output = io.StringIO()
+        with mock.patch.object(self.module.os, 'geteuid', return_value=0), \
+                mock.patch.object(self.module, 'Activator', return_value=self.activation), \
+                contextlib.redirect_stdout(output):
+            self.assertEqual(0, self.module.main(['install-trust']))
+            self.assertEqual(0, self.module.main(['install-trust']))
+        self.assertEqual('changed\nunchanged\n', output.getvalue())
+        with mock.patch.object(self.module, 'Activator', side_effect=AssertionError('unexpected host access')), \
+                contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(2, self.module.main(['install-trust', '/alternate']))
+
+    def test_pending_tls_stops_trust_installation(self):
+        self.trust_candidate({'device': self.pem_a})
+        self.activation.tls_journal.parent.mkdir(mode=0o700)
+        self.write(self.activation.tls_journal, '{}', 0o600)
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.install_trust()
+        self.assertEqual([], list(self.trust_root.iterdir()))

--- a/tests/ansible/test_reverse_proxy.py
+++ b/tests/ansible/test_reverse_proxy.py
@@ -5,6 +5,8 @@ import importlib.util
 from pathlib import Path
 import unittest
 
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -20,6 +22,14 @@ class ReverseProxyInputTests(unittest.TestCase):
         return {"bind_addresses": ["10.0.0.2"], "client_sources": ["10.0.0.0/24"],
                 "routes": [{"hostname": "app.example.test", "backend_port": 8080,
                             "certificate_name": "app"}]}
+
+    def device_route(self, transport="https"):
+        backend = {"transport": transport, "address": "10.0.0.50",
+                   "port": 443 if transport == "https" else 80}
+        if transport == "https":
+            backend.update({"server_name": "DEVICE.Example.test", "trust_name": "device"})
+        return {"hostname": "device.example.test", "certificate_name": "infra",
+                "backend": backend}
 
     def test_empty_routes_need_no_ingress(self):
         self.assertEqual(self.module.validate({"bind_addresses": [], "client_sources": [], "routes": []}),
@@ -90,6 +100,200 @@ class ReverseProxyInputTests(unittest.TestCase):
         data["routes"][0]["upstream"] = "remote:8080"
         with self.assertRaises(ValueError):
             self.module.validate(data)
+
+    def test_device_routes_are_canonical_without_mutating_input(self):
+        data = self.fixture()
+        data["routes"] = [self.device_route(), self.device_route("http")]
+        data["routes"][1]["hostname"] = "sensor.example.test"
+        data["routes"][1]["backend"]["address"] = "fd00:0:0::60"
+        original = copy.deepcopy(data)
+
+        result = self.module.validate(data)
+
+        self.assertEqual(
+            result["routes"],
+            [
+                {
+                    "hostname": "device.example.test",
+                    "certificate_name": "infra",
+                    "backend": {
+                        "transport": "https",
+                        "address": "10.0.0.50",
+                        "port": 443,
+                        "server_name": "device.example.test",
+                        "trust_name": "device",
+                    },
+                },
+                {
+                    "hostname": "sensor.example.test",
+                    "certificate_name": "infra",
+                    "backend": {
+                        "transport": "http",
+                        "address": "fd00::60",
+                        "port": 80,
+                    },
+                },
+            ],
+        )
+        self.assertEqual(data, original)
+
+    def test_device_route_rejects_ambiguous_or_unsafe_fields(self):
+        changes = (
+            {"backend_port": 8080},
+            {"upstream": "https://10.0.0.50:443"},
+            {"tls_insecure_skip_verify": True},
+        )
+        for change in changes:
+            data = self.fixture()
+            data["routes"] = [dict(self.device_route(), **change)]
+            with self.subTest(change=change), self.assertRaises(ValueError):
+                self.module.validate(data)
+
+        for field, values in {
+            "transport": ["h2c", "HTTP", "", None],
+            "address": ["device.example.test", "127.0.0.1", "169.254.1.1",
+                        "192.0.2.50", "10.0.0.50/32", "fd00::1%eth0"],
+            "port": [True, 0, 65536, "443", 443.0, None],
+        }.items():
+            for value in values:
+                data = self.fixture()
+                route = self.device_route()
+                route["backend"][field] = value
+                data["routes"] = [route]
+                with self.subTest(field=field, value=value), self.assertRaises(ValueError):
+                    self.module.validate(data)
+
+    def test_http_device_rejects_tls_fields_and_https_requires_them(self):
+        for field, value in {
+            "server_name": "device.example.test",
+            "trust_name": "device",
+            "tls_insecure_skip_verify": True,
+            "trust_path": "/tmp/device.pem",
+        }.items():
+            data = self.fixture()
+            route = self.device_route("http")
+            route["backend"][field] = value
+            data["routes"] = [route]
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                self.module.validate(data)
+
+        for missing in ("server_name", "trust_name"):
+            data = self.fixture()
+            route = self.device_route()
+            del route["backend"][missing]
+            data["routes"] = [route]
+            with self.subTest(missing=missing), self.assertRaises(ValueError):
+                self.module.validate(data)
+
+    def test_https_device_rejects_unsafe_server_and_trust_names(self):
+        for field, values in {
+            "server_name": ["*.example.test", "10.0.0.50", "localhost", "a/b.test",
+                            "device.example.test\ntls_insecure_skip_verify"],
+            "trust_name": ["../device", ".", "a/b", "device root", "-device",
+                           "device\ntls_insecure_skip_verify"],
+        }.items():
+            for value in values:
+                data = self.fixture()
+                route = self.device_route()
+                route["backend"][field] = value
+                data["routes"] = [route]
+                with self.subTest(field=field, value=value), self.assertRaises(ValueError):
+                    self.module.validate(data)
+
+    def test_deferred_certificate_marker_is_narrow_and_optional(self):
+        self.assertNotIn("deferred_certificates", self.module.validate(self.fixture()))
+        for deferred in ([], ["infra"]):
+            data = dict(self.fixture(), deferred_certificates=deferred)
+            self.assertEqual(self.module.validate(data)["deferred_certificates"], deferred)
+        for deferred in (["app"], ["infra", "infra"], "infra", None, {}):
+            data = dict(self.fixture(), deferred_certificates=deferred)
+            with self.subTest(deferred=deferred), self.assertRaises(ValueError):
+                self.module.validate(data)
+
+    def test_render_is_deterministic_for_local_http_and_https_routes(self):
+        data = self.fixture()
+        data["bind_addresses"].append("fd00::2")
+        data["routes"] = [self.device_route("http"), self.fixture()["routes"][0],
+                          self.device_route()]
+        data["routes"][0]["hostname"] = "sensor.example.test"
+        data["routes"][0]["backend"]["address"] = "fd00::60"
+
+        rendered = self.module.render(self.module.validate(data))
+
+        self.assertEqual(rendered, """\
+{
+\tadmin unix//run/caddy/admin.sock
+\tauto_https off
+\tservers {
+\t\tprotocols h1 h2
+\t}
+}
+
+https://app.example.test:443 {
+\tbind 10.0.0.2 fd00::2
+\ttls /etc/caddy/tls/app/current/fullchain.pem /etc/caddy/tls/app/current/privkey.pem
+\treverse_proxy 127.0.0.1:8080
+}
+
+https://device.example.test:443 {
+\tbind 10.0.0.2 fd00::2
+\ttls /etc/caddy/tls/infra/current/fullchain.pem /etc/caddy/tls/infra/current/privkey.pem
+\treverse_proxy https://10.0.0.50:443 {
+\t\ttransport http {
+\t\t\ttls_trusted_ca_certs /etc/caddy/trust/device.pem
+\t\t\ttls_server_name device.example.test
+\t\t}
+\t}
+}
+
+https://sensor.example.test:443 {
+\tbind 10.0.0.2 fd00::2
+\ttls /etc/caddy/tls/infra/current/fullchain.pem /etc/caddy/tls/infra/current/privkey.pem
+\treverse_proxy http://[fd00::60]:80
+}
+""")
+        self.assertNotIn("tls_insecure_skip_verify", rendered)
+
+    def test_render_uses_only_safe_internal_certificate_overrides(self):
+        data = self.fixture()
+        self.assertIn(
+            "tls /etc/caddy/tls/.homelab-tls-private/staging/generation-1/fullchain.pem "
+            "/etc/caddy/tls/.homelab-tls-private/staging/generation-1/privkey.pem",
+            self.module.render(
+                self.module.validate(data),
+                {"app": "/etc/caddy/tls/.homelab-tls-private/staging/generation-1"},
+            ),
+        )
+        for overrides in (
+            {"other": "/etc/caddy/tls/other/current"},
+            {"app": "relative/generation"},
+            {"app": "/etc/caddy/tls/app/../other"},
+            {"app": "/etc/caddy/tls/app/current\ntls internal"},
+            [("app", "/etc/caddy/tls/app/current")],
+        ):
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                self.module.render(self.module.validate(data), overrides)
+
+        data["certificate_paths"] = {"app": "/tmp/generation"}
+        with self.assertRaises(ValueError):
+            self.module.validate(data)
+
+    def test_ansible_template_uses_the_shared_renderer(self):
+        environment = Environment(
+            loader=FileSystemLoader(ROOT / "roles/reverse_proxy/templates"),
+            undefined=StrictUndefined,
+            keep_trailing_newline=True,
+        )
+        filters = self.module.FilterModule().filters()
+        self.assertIs(filters["reverse_proxy_render"], self.module.render)
+        environment.filters.update(filters)
+        config = self.module.validate(self.fixture())
+
+        rendered = environment.get_template("Caddyfile.j2").render(
+            reverse_proxy_config=config
+        )
+
+        self.assertEqual(rendered, self.module.render(config))
 
 
 if __name__ == "__main__":

--- a/tests/ansible/test_reverse_proxy_activation.py
+++ b/tests/ansible/test_reverse_proxy_activation.py
@@ -865,3 +865,21 @@ class CommandBoundaryTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class CandidateGenerationTests(ActivationFixture):
+    configure_certificate = CertificateTests.configure_certificate
+
+    def test_generation_override_requires_explicit_internal_authority(self):
+        base, version = self.configure_certificate()
+        base.rename(base.with_name('infra'))
+        base = base.with_name('infra')
+        generation = base / ('generation-' + '1' * 32)
+        (base / version.name).rename(generation)
+        configuration = json.loads(self.candidate.read_bytes())
+        pair = configuration['apps']['tls']['certificates']['load_files'][0]
+        pair['certificate'] = '/etc/caddy/tls/infra/' + generation.name + '/fullchain.pem'
+        pair['key'] = '/etc/caddy/tls/infra/' + generation.name + '/privkey.pem'
+        with self.assertRaises(self.module.ActivationError):
+            self.activation.certificates(configuration)
+        fingerprints = self.activation.certificates(configuration, certificate_generation=generation)
+        self.assertEqual({'app.example.test': {hashlib.sha256(b'synthetic DER').hexdigest()}}, fingerprints)

--- a/tests/ansible/test_reverse_proxy_role.py
+++ b/tests/ansible/test_reverse_proxy_role.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import configparser
+import copy
+import hashlib
 import importlib.util
 import io
+import json
 import os
 import subprocess
 import tempfile
@@ -317,6 +320,7 @@ class ProvisioningFlowTests(unittest.TestCase):
                 "/etc/tmpfiles.d",
                 "/usr",
                 "/usr/local",
+                "/usr/local/lib",
                 "/var",
                 "/var/lib",
                 "/run",
@@ -633,7 +637,7 @@ class ProvisioningFlowTests(unittest.TestCase):
         )
         self.assertLess(
             names.index("Verify shared host firewall policy"),
-            names.index("Render candidate reverse proxy configuration"),
+            names.index("Install candidate desired reverse proxy manifest"),
         )
         self.assertLess(
             names.index("Start committed reverse proxy configuration"),
@@ -647,7 +651,7 @@ class ProvisioningFlowTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            {"argv": ["/usr/local/libexec/homelab-reverse-proxy", "apply"]},
+            {"argv": ["/usr/local/libexec/homelab-reverse-proxy", "apply-desired"]},
             task["ansible.builtin.command"],
         )
         self.assertEqual("reverse_proxy_activation.stdout | trim == 'changed'", task["changed_when"])
@@ -765,18 +769,46 @@ class ObservationalVerificationTests(unittest.TestCase):
         self.assertIn("^Gid:", process_conditions)
         self.assertIn("^Groups:", process_conditions)
 
-    def test_verify_compares_committed_config_to_declared_routes(self) -> None:
+    def test_verify_compares_committed_manifest_to_declared_routes_and_ingress(self) -> None:
+        from ansible.plugins.filter.core import FilterModule
+
         task = named_task(
             load_tasks("verify.yml"),
-            "Verify committed configuration matches declared routes",
+            "Verify committed desired configuration matches declared routes",
         )
         conditions = task["ansible.builtin.assert"]["that"]
+        environment = Environment(undefined=StrictUndefined)
+        environment.filters.update(FilterModule().filters())
+        spec = importlib.util.spec_from_file_location("manifest_filter", ROLE_ROOT / "filter_plugins/proxy.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        environment.filters.update(module.FilterModule().filters())
+        config = {"bind_addresses": ["10.20.30.40"], "client_sources": ["10.20.0.0/16"],
+                  "routes": [], "deferred_certificates": ["infra"]}
+        manifest = json.dumps(config) + "\n"
+        envelope = {"version": 1, "manifest": manifest, "ingress": {
+            "version": 1, "manifest_sha256": hashlib.sha256(manifest.encode()).hexdigest(),
+            "listen_addresses": config["bind_addresses"],
+            "https_client_networks": config["client_sources"],
+        }}
 
-        self.assertEqual(1, len(conditions))
-        self.assertIn("reverse_proxy_verify_paths.results[2].stat.checksum", conditions[0])
-        self.assertIn("lookup(", conditions[0])
-        self.assertIn("'ansible.builtin.template'", conditions[0])
-        self.assertIn("'Caddyfile.j2'", conditions[0])
+        def accepted(value):
+            return all(environment.compile_expression(condition)(
+                reverse_proxy_verify_envelope=value, reverse_proxy_config=config
+            ) for condition in conditions)
+
+        self.assertTrue(accepted(envelope))
+        for field, value in (("listen_addresses", ["10.20.30.41"]),
+                             ("https_client_networks", ["10.0.0.0/8"]),
+                             ("manifest_sha256", "0" * 64)):
+            changed = copy.deepcopy(envelope)
+            changed["ingress"][field] = value
+            self.assertFalse(accepted(changed), field)
+        changed = copy.deepcopy(envelope)
+        changed_config = dict(config, deferred_certificates=[])
+        changed["manifest"] = json.dumps(changed_config)
+        changed["ingress"]["manifest_sha256"] = hashlib.sha256(changed["manifest"].encode()).hexdigest()
+        self.assertFalse(accepted(changed))
 
 
 if __name__ == "__main__":

--- a/tests/ansible/test_reverse_proxy_role.py
+++ b/tests/ansible/test_reverse_proxy_role.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import configparser
+import importlib.util
 import io
 import os
 import subprocess
@@ -36,6 +37,13 @@ class CaddyfileRenderingTests(unittest.TestCase):
             keep_trailing_newline=True,
             trim_blocks=True,
         )
+        plugin_path = ROLE_ROOT / "filter_plugins" / "proxy.py"
+        spec = importlib.util.spec_from_file_location(
+            "reverse_proxy_template_filter", plugin_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        cls.environment.filters.update(module.FilterModule().filters())
 
     def render(self, config: dict[str, object]) -> str:
         return self.environment.get_template("Caddyfile.j2").render(

--- a/tests/ansible/test_source_contracts.py
+++ b/tests/ansible/test_source_contracts.py
@@ -1820,9 +1820,11 @@ class SourceContractTests(unittest.TestCase):
             self.assertIn("fields[2]", source)
             self.assertIn("fields[3]", source)
 
-        converge = load_yaml_documents(
+        converge_plays = load_yaml_documents(
             "roles/system_maintenance/molecule/baseline/converge.yml"
-        )[0][1]
+        )[0]
+        converge = next(play for play in converge_plays
+                        if "ansible.builtin.import_playbook" in play)
         self.assertEqual(
             {
                 "host": "127.0.0.1",

--- a/tests/ansible/test_tls_fixture_material.py
+++ b/tests/ansible/test_tls_fixture_material.py
@@ -1,0 +1,38 @@
+"""Disposable integration certificates must pass strict native verification."""
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from cryptography.hazmat.primitives import serialization
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tests/tls"))
+from cert_fixtures import EphemeralCA
+
+
+class TLSFixtureMaterialTests(unittest.TestCase):
+    def test_generated_integration_leaf_passes_strict_server_verification(self):
+        spec = importlib.util.spec_from_file_location(
+            "tls_integration_fixture",
+            ROOT / "roles/reverse_proxy/molecule/default/tls_integration.py")
+        fixture = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(fixture)
+        with tempfile.TemporaryDirectory() as directory:
+            fixture.FIXTURE = Path(directory)
+            authority = EphemeralCA()
+            authority.write_certificate(fixture.FIXTURE / "ca.pem")
+            (fixture.FIXTURE / "ca.key").write_bytes(authority.key.private_bytes(
+                serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()))
+            fixture.create_material(1)
+            result = subprocess.run(
+                ["openssl", "verify", "-x509_strict", "-purpose", "sslserver",
+                 "-verify_hostname", "room-alert.infra.example.com",
+                 "-CAfile", str(fixture.FIXTURE / "ca.pem"),
+                 str(fixture.FIXTURE / "issued-1.pem")],
+                capture_output=True, text=True, timeout=10, check=False)
+            self.assertEqual(0, result.returncode, result.stderr)

--- a/tests/ansible/test_tls_proxy_policy.py
+++ b/tests/ansible/test_tls_proxy_policy.py
@@ -1,0 +1,114 @@
+"""TLS verification targets must come from the declared proxy routes."""
+
+import importlib.util
+import hashlib
+import json
+from pathlib import Path
+import unittest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "tls_proxy_policy", ROOT / "roles/tls_automation/filter_plugins/validation.py"
+)
+validation = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validation)
+
+
+class ProxyPolicyTests(unittest.TestCase):
+    def envelope(self, config):
+        raw = json.dumps(config)
+        return {"version": 1, "manifest": raw, "ingress": {
+            "version": 1, "manifest_sha256": hashlib.sha256(raw.encode()).hexdigest(),
+            "listen_addresses": config["bind_addresses"],
+            "https_client_networks": config["client_sources"],
+        }}
+
+    def test_policy_requires_the_committed_manifest_and_verified_ingress(self):
+        config = self.config()
+        config["deferred_certificates"] = ["infra"]
+        envelope = self.envelope(config)
+        derive = lambda value: validation.committed_proxy_policy(
+            json.dumps(value), config, "infra.example.com", "acme@example.com", 2001)
+        self.assertEqual(validation.proxy_policy(config, "infra.example.com", "acme@example.com", 2001),
+                         derive(envelope))
+        for field, bad in (("manifest_sha256", "0" * 64),
+                           ("listen_addresses", []), ("https_client_networks", []),
+                           ("version", True)):
+            altered = self.envelope(config)
+            altered["ingress"][field] = bad
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                derive(altered)
+        stale = dict(config, routes=[])
+        with self.assertRaises(ValueError):
+            derive(self.envelope(stale))
+        with self.assertRaises(ValueError):
+            derive(dict(envelope, extra=True))
+        with self.assertRaises(ValueError):
+            validation.committed_proxy_policy(
+                json.dumps(envelope).replace('"version": 1', '"version": 1, "version": 1', 1),
+                config, "infra.example.com", "acme@example.com", 2001)
+
+    def test_coordinator_write_scope_includes_only_managed_transaction_roots(self):
+        self.assertEqual(
+            "/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy",
+            validation._UNITS["homelab-tls-renew.service"]["ReadWritePaths"],
+        )
+
+    def test_preflight_resolves_named_caddy_group_before_deriving_policy(self):
+        tasks = yaml.safe_load((ROOT / "roles/tls_automation/tasks/preflight.yml").read_text())
+        group_reads = [index for index, task in enumerate(tasks)
+                       if task.get("ansible.builtin.command", {}).get("argv")
+                       == ["/usr/bin/getent", "group", "caddy"]]
+        policy_tasks = [index for index, task in enumerate(tasks)
+                        if "tls_automation_proxy_policy" in str(task)]
+        self.assertEqual(1, len(group_reads))
+        self.assertEqual(1, len(policy_tasks))
+        self.assertLess(group_reads[0], policy_tasks[0])
+
+    def config(self):
+        return {
+            "bind_addresses": ["10.20.30.40"],
+            "client_sources": ["10.20.0.0/16"],
+            "routes": [
+                {"hostname": "app.infra.example.com", "backend_port": 18080,
+                 "certificate_name": "infra"},
+                {"hostname": "unrelated.example.com", "backend_port": 18081,
+                 "certificate_name": "separate"},
+            ],
+        }
+
+    def test_targets_use_proxy_listener_and_only_managed_certificate_routes(self):
+        result = validation.proxy_policy(self.config(), "infra.example.com", "acme@example.com", 2001)
+        self.assertEqual({
+            "namespace": "infra.example.com", "email": "acme@example.com", "reader_gid": 2001,
+            "endpoints": [{"hostname": "app.infra.example.com", "address": "10.20.30.40", "port": 443}],
+        }, result)
+
+    def test_wrong_namespace_is_rejected_instead_of_silently_omitted(self):
+        config = self.config()
+        config["routes"][0]["hostname"] = "udm.example.com"
+        with self.assertRaises(ValueError):
+            validation.proxy_policy(config, "infra.example.com", "acme@example.com", 2001)
+
+    def test_every_configured_listener_is_verified(self):
+        config = self.config()
+        config["bind_addresses"].append("fd00:20::40")
+        result = validation.proxy_policy(config, "infra.example.com", "acme@example.com", 2001)
+        self.assertEqual([
+            {"hostname": "app.infra.example.com", "address": "10.20.30.40", "port": 443},
+            {"hostname": "app.infra.example.com", "address": "fd00:20::40", "port": 443},
+        ], result["endpoints"])
+
+    def test_no_managed_route_cannot_authorize_issuance(self):
+        config = self.config()
+        config["routes"] = config["routes"][1:]
+        with self.assertRaises(ValueError):
+            validation.proxy_policy(config, "infra.example.com", "acme@example.com", 2001)
+
+    def test_shared_route_schema_rejects_arbitrary_fields(self):
+        config = self.config()
+        config["routes"][0]["command"] = "unapproved"
+        with self.assertRaises(ValueError):
+            validation.proxy_policy(config, "infra.example.com", "acme@example.com", 2001)

--- a/tests/ansible/test_tls_role.py
+++ b/tests/ansible/test_tls_role.py
@@ -20,7 +20,7 @@ def registered_units(absent=False, omit_arrays=False):
     records = []
     for unit, user, path, timeout in (
         ("issuer.service", "svc-acme", "/var/lib/homelab-tls-issuer", "15min"),
-        ("renew.service", "root", "/var/lib/homelab-tls", "1h"),
+        ("renew.service", "root", "/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy", "1h"),
         ("renew.timer", "", "", ""),
     ):
         name = "homelab-tls-" + unit
@@ -59,6 +59,21 @@ def registered_arrays(absent=False):
 
 
 class RoleUnitTests(unittest.TestCase):
+    def test_previous_canonical_write_scope_can_upgrade_only_in_preflight(self):
+        value = registered_units()
+        value["results"][1]["stdout"] = value["results"][1]["stdout"].replace(
+            "ReadWritePaths=/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy",
+            "ReadWritePaths=/var/lib/homelab-tls",
+        )
+        self.assertTrue(validation.validate_units(value["results"], True, registered_arrays()["results"]))
+        with self.assertRaises(ValueError):
+            validation.validate_units(value["results"], False, registered_arrays()["results"])
+        value["results"][1]["stdout"] = value["results"][1]["stdout"].replace(
+            "ReadWritePaths=/var/lib/homelab-tls", "ReadWritePaths=/etc"
+        )
+        with self.assertRaises(ValueError):
+            validation.validate_units(value["results"], True, registered_arrays()["results"])
+
     def test_actual_role_assertions_accept_registered_results(self):
         tasks = []
         for filename in ("preflight.yml", "configure.yml", "timer.yml"):

--- a/tests/ci/test_merge_gate.py
+++ b/tests/ci/test_merge_gate.py
@@ -498,7 +498,7 @@ class WorkflowContractTests(unittest.TestCase):
             direct_mapping_values(self.molecule, "if", 4),
         )
         self.assertIn("runs-on: ubuntu-24.04", self.molecule)
-        self.assertIn("timeout-minutes: 30", self.molecule)
+        self.assertIn("timeout-minutes: 60", self.molecule)
         expected_strategy = "\n".join(
             [
                 "    strategy:",

--- a/tests/tls/test_integration.py
+++ b/tests/tls/test_integration.py
@@ -1,0 +1,467 @@
+"""Joint publication recovery uses the real Publisher journal and filesystem."""
+import json
+from pathlib import Path
+import unittest
+
+import test_publication as publication_tests
+from tls_runtime.publication import Publisher
+
+
+class BoundPublicationTests(unittest.TestCase):
+    setUp = publication_tests.PublicationTests.setUp
+    fingerprint = staticmethod(publication_tests.PublicationTests.fingerprint)
+    reload_and_verify = publication_tests.PublicationTests.reload_and_verify
+    preflight = publication_tests.PublicationTests.preflight
+
+    def integrated(self, **kwargs):
+        return Publisher(self.root, self.journal, self.owner_uid, self.reader_gid,
+                         self.fingerprint, self.reload_and_verify, self.preflight,
+                         prepare=lambda record: {'desired_revision': 'a' * 64,
+                             'previous_boot': 'old\n', 'candidate_boot': 'new\n',
+                             'disk_recovery': None, 'restart': False,
+                             'activation_failed': False, 'restoration_failed': False}, **kwargs)
+
+    def test_binding_is_durable_before_pointer_switch(self):
+        publisher = self.integrated()
+        switch = publisher._switch_current
+        def check(generation):
+            record = json.loads(self.journal.read_bytes())
+            self.assertEqual('old\n', record['caddy']['previous_boot'])
+            self.assertEqual('prepared', record['status'])
+            switch(generation)
+        publisher._switch_current = check
+        self.assertTrue(publisher.publish(b'certificate-one', b'private-key-one'))
+
+    def test_disk_restoration_retries_prepared_first_candidate_without_issuance(self):
+        publisher = self.integrated()
+        original = publisher._switch_current
+        publisher._switch_current = lambda name: (_ for _ in ()).throw(KeyboardInterrupt())
+        with self.assertRaises(KeyboardInterrupt):
+            publisher.publish(b'certificate-one', b'private-key-one')
+        record = json.loads(self.journal.read_bytes())
+        record['caddy']['disk_recovery'] = 'restored'
+        publisher._write_journal(record)
+        publisher._switch_current = original
+        result = publisher.recover()
+        self.assertEqual('changed', result['publication'])
+        self.assertFalse(result['activation_failed'])
+        self.assertFalse(result['restoration_failed'])
+        self.assertEqual(b'certificate-one', (self.root / 'current/fullchain.pem').read_bytes())
+        self.assertFalse(self.journal.exists())
+
+import hashlib
+import importlib.util
+import os
+import re
+import sys
+from unittest import mock
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'ansible'))
+from test_reverse_proxy_activation import ActivationFixture
+import test_reverse_proxy_activation as proxy_tests
+
+
+class AdapterFixture(ActivationFixture):
+    configure_certificate = proxy_tests.CertificateTests.configure_certificate
+
+    def setUp(self):
+        super().setUp()
+        from test_proxy_manifest_runtime import manifest_module
+        sys.modules['proxy_manifest'] = manifest_module()
+        from tls_runtime.caddy import Integration
+        self.integration = Integration(self.activation)
+        (self.root / 'etc/caddy/tls/infra').mkdir(mode=0o750)
+        (self.root / 'etc/caddy/tls/.homelab-tls-private').mkdir(mode=0o700)
+        self.config = {'bind_addresses': ['10.20.30.40'], 'client_sources': ['10.20.0.0/16'],
+                       'deferred_certificates': ['infra'], 'routes': [
+                           {'hostname': 'app.infra.example.com', 'backend_port': 18080,
+                            'certificate_name': 'infra'}]}
+        raw = json.dumps(self.config)
+        self.envelope = {'version': 1, 'manifest': raw, 'ingress': {'version': 1,
+                         'manifest_sha256': hashlib.sha256(raw.encode()).hexdigest(),
+                         'listen_addresses': ['10.20.30.40'], 'https_client_networks': ['10.20.0.0/16']}}
+        self.write(self.state / 'desired.json', json.dumps(self.envelope), 0o600)
+        base, version = self.configure_certificate()
+        self.sans = b'X509v3 Subject Alternative Name:\n    DNS:*.infra.example.com\n'
+        self.commands.ss = None
+        original = self.commands.run
+        def host(argv):
+            if argv[:6] == ['/usr/sbin/runuser', '-u', 'caddy', '--', '/usr/bin/caddy', 'adapt']:
+                content = Path(argv[argv.index('--config') + 1]).read_text()
+                if content.startswith('{"'):
+                    return content.encode()
+                result = dict(self.old)
+                hosts = re.findall(r'https://([a-z0-9.-]+):443', content)
+                if hosts:
+                    files = re.findall(r'\ttls (\S+) (\S+)', content)
+                    server = {'listen': ['10.20.30.40:443'], 'protocols': ['h1', 'h2'],
+                              'automatic_https': {'disable': True}, 'routes': [],
+                              'tls_connection_policies': []}
+                    pairs = []
+                    for index, (hostname, pair) in enumerate(zip(hosts, files)):
+                        tag = 'cert' + str(index)
+                        server['routes'].append({'match': [{'host': [hostname]}]})
+                        server['tls_connection_policies'].append({'match': {'sni': [hostname]},
+                            'certificate_selection': {'any_tag': [tag]}})
+                        pairs.append({'certificate': pair[0], 'key': pair[1], 'tags': [tag]})
+                    result['apps'] = {'http': {'servers': {'srv0': server}},
+                                      'tls': {'certificates': {'load_files': pairs}}}
+                return json.dumps(result).encode()
+            if argv[:6] == ['/usr/sbin/runuser', '-u', 'caddy', '--', '/usr/bin/caddy', 'reload']:
+                self.commands.reloads += 1
+                if self.commands.fail_reload:
+                    self.commands.fail_reload = False
+                    raise self.module.ActivationError('injected reload failure')
+                adapt = list(argv)
+                adapt[5] = 'adapt'
+                self.commands.loaded = json.loads(host(adapt))
+                return b''
+            return original(argv)
+        self.commands.run = host
+        self.publisher = Publisher(self.integration.root, self.activation.tls_journal,
+                                   os.getuid(), os.getgid(), publication_tests.PublicationTests.fingerprint,
+                                   lambda fp: self.integration.activate('reload' if fp else 'deactivate'),
+                                   self.integration.validate_candidate, prepare=self.integration.prepare)
+
+
+class AdapterTests(AdapterFixture):
+    def test_first_publication_activates_manifest_with_one_reload(self):
+        with self.activation.locked():
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.assertIn('app.infra.example.com', self.boot.read_text())
+        self.assertEqual(1, self.commands.reloads)
+        self.assertFalse(self.activation.tls_journal.exists())
+
+    def test_failed_first_publication_restores_disk_and_proves_no_listener(self):
+        self.commands.fail_reload = True
+        previous = self.boot.read_bytes()
+        from tls_runtime.publication import PublicationError
+        with self.activation.locked(), self.assertRaises(PublicationError) as failure:
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.assertFalse(failure.exception.restoration_failed)
+        self.assertEqual(previous, self.boot.read_bytes())
+        self.assertEqual(self.old, self.commands.loaded)
+        self.assertFalse(os.path.lexists(self.integration.root / 'current'))
+
+    def test_preflight_failure_never_selects_or_installs_candidate(self):
+        self.commands.invalid = True
+        previous = self.boot.read_bytes()
+        with self.activation.locked(), self.assertRaises(self.module.ActivationError):
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.assertFalse(os.path.lexists(self.integration.root / 'current'))
+        self.assertEqual(previous, self.boot.read_bytes())
+        self.assertEqual(0, self.commands.reloads)
+
+    def test_restart_is_requested_with_durable_rollback_authority(self):
+        def broken(argv):
+            if argv[:6] == ['/usr/sbin/runuser', '-u', 'caddy', '--', '/usr/bin/caddy', 'reload']:
+                raise self.module.ActivationError('reload rejected')
+            return original(argv)
+        original = self.commands.run
+        self.commands.run = broken
+        self.commands.loaded = {'drift': True}
+        from tls_runtime.publication import PublicationError
+        with self.activation.locked(), self.assertRaises(PublicationError) as failure:
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.assertTrue(failure.exception.restoration_failed)
+        self.assertTrue(self.publisher._read_journal()['caddy']['restart'])
+
+    def test_inherited_fd9_is_exclusive_and_wrong_inode_is_rejected(self):
+        from tls_runtime import caddy
+        from types import SimpleNamespace
+        import fcntl
+        policy = SimpleNamespace(reader_gid=os.getgid(), endpoints=[{
+            'hostname': 'app.infra.example.com', 'address': '10.20.30.40', 'port': 443}])
+        deployment = caddy.Deployment(self.activation, policy)
+        script = self.root / 'fake-adapter'
+        script.write_text('#!' + sys.executable + '\nimport fcntl, os, sys\n'
+                          'assert sys.argv[1:] == ["reload"]\n'
+                          'expected = os.stat(' + repr(str(self.activation.lock_path)) + ')\n'
+                          'actual = os.fstat(9)\n'
+                          'assert (actual.st_dev, actual.st_ino) == (expected.st_dev, expected.st_ino)\n'
+                          'probe = os.open(' + repr(str(self.activation.lock_path)) + ', os.O_RDONLY)\n'
+                          'try:\n fcntl.flock(probe, fcntl.LOCK_SH | fcntl.LOCK_NB)\n'
+                          'except BlockingIOError:\n sys.exit(0)\n'
+                          'sys.exit(1)\n')
+        script.chmod(0o755)
+        with mock.patch.object(caddy, 'ADAPTER', str(script)), deployment.locked():
+            deployment.operation('reload')
+            alternate = os.open(self.boot, os.O_RDONLY)
+            saved = os.dup(9)
+            try:
+                os.dup2(alternate, 9)
+                with self.assertRaises(self.module.ActivationError):
+                    deployment.operation('reload')
+            finally:
+                os.dup2(saved, 9)
+                os.close(saved)
+                os.close(alternate)
+
+class CoordinatorScopeTests(unittest.TestCase):
+    def test_network_wait_is_outside_publication_lock(self):
+        from contextlib import contextmanager
+        from types import SimpleNamespace
+        from tls_runtime import runtime
+        held = []
+        @contextmanager
+        def scope():
+            held.append(True)
+            try:
+                yield
+            finally:
+                held.pop()
+        def recover():
+            self.assertEqual([True], held)
+        def issue():
+            self.assertEqual([], held)
+        def snapshot():
+            self.assertEqual([], held)
+            return b'certificate', b'key'
+        def publish(cert, key):
+            self.assertEqual([True], held)
+            return True
+        result = runtime.reconcile(SimpleNamespace(recover=recover, publish=publish),
+                                   issue, snapshot, publication_context=scope)
+        self.assertEqual('changed', result['publication'])
+
+class RestartAndInterruptionTests(AdapterFixture):
+    def test_restart_releases_lock_and_rechecks_revision_after_startup(self):
+        from tls_runtime.caddy import Deployment
+        from types import SimpleNamespace
+        import fcntl
+        policy = SimpleNamespace(reader_gid=os.getgid(), endpoints=[{
+            'hostname': 'app.infra.example.com', 'address': '10.20.30.40', 'port': 443}])
+        deployment = Deployment(self.activation, policy)
+        original = self.publisher._switch_current
+        self.publisher._switch_current = lambda name: (_ for _ in ()).throw(KeyboardInterrupt())
+        with self.assertRaises(KeyboardInterrupt):
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.publisher._switch_current = original
+        record = self.publisher._read_journal()
+        record['status'] = 'rollback_pending'
+        record['caddy']['restart'] = True
+        self.publisher._write_journal(record)
+        calls = []
+        host = self.commands.run
+        def restart(argv):
+            if argv == ['/usr/bin/systemctl', 'restart', 'caddy.service']:
+                with self.activation.lock_path.open('rb') as probe:
+                    fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                with self.assertRaises(self.module.ActivationError):
+                    self.activation.apply()
+                self.activation.recover()
+                self.commands.loaded = self.old
+                calls.append('startup completed')
+                return b''
+            return host(argv)
+        self.commands.run = restart
+        with deployment.locked():
+            deployment.restart(self.envelope['ingress']['manifest_sha256'])
+        self.assertEqual(['startup completed'], calls)
+        self.assertEqual('restored', self.publisher._read_journal()['caddy']['disk_recovery'])
+        self.assertTrue(self.publisher._read_journal()['caddy']['restart'])
+        self.integration.activate('deactivate')
+        self.assertFalse(self.publisher._read_journal()['caddy']['restart'])
+
+    def test_startup_repeats_each_interrupted_disk_boundary(self):
+        original_switch = self.publisher._switch_current
+        self.publisher._switch_current = lambda name: (_ for _ in ()).throw(KeyboardInterrupt())
+        with self.assertRaises(KeyboardInterrupt):
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.publisher._switch_current = original_switch
+        initial = self.publisher._read_journal()
+        for boundary in range(1, 5):
+            with self.subTest(boundary=boundary):
+                self.publisher._write_journal(initial)
+                self.publisher._switch_current(initial['generation'])
+                self.write(self.boot, initial['caddy']['candidate_boot'])
+                writes = []
+                journal = self.integration.publisher._write_journal
+                switch = self.integration.publisher._switch_current
+                boot = self.activation.durable_write
+                def after(operation):
+                    def call(*args):
+                        operation(*args)
+                        writes.append(True)
+                        if len(writes) == boundary:
+                            raise KeyboardInterrupt()
+                    return call
+                self.integration.publisher._write_journal = after(journal)
+                self.integration.publisher._switch_current = after(switch)
+                self.activation.durable_write = after(boot)
+                with self.assertRaises(KeyboardInterrupt):
+                    self.integration.recover_disk()
+                self.integration.publisher._write_journal = journal
+                self.integration.publisher._switch_current = switch
+                self.activation.durable_write = boot
+                self.integration.recover_disk()
+                self.assertEqual(initial['caddy']['previous_boot'], self.boot.read_text())
+                self.assertFalse(os.path.lexists(self.integration.root / 'current'))
+                self.assertTrue((self.integration.root / initial['generation']).exists())
+
+class PublicationActivationTests(AdapterFixture):
+    def test_same_material_reopens_once_without_creating_a_generation(self):
+        with self.activation.locked():
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+            before = os.readlink(self.integration.root / 'current')
+            self.assertFalse(self.publisher.publish(b'certificate-one', b'private-key-one'))
+        self.assertEqual(before, os.readlink(self.integration.root / 'current'))
+        self.assertEqual(2, self.commands.reloads)
+
+    def test_failed_first_keeps_unrelated_route_and_its_shared_listener(self):
+        from tls_runtime.publication import PublicationError
+        self.config['routes'].append({'hostname': 'other.example.com', 'backend_port': 18081,
+                                     'certificate_name': 'app'})
+        raw = json.dumps(self.config)
+        self.envelope['manifest'] = raw
+        self.envelope['ingress']['manifest_sha256'] = hashlib.sha256(raw.encode()).hexdigest()
+        self.write(self.state / 'desired.json', json.dumps(self.envelope), 0o600)
+        self.sans += b'    DNS:other.example.com\n'
+        self.write(self.boot, self.activation.manifest().render(self.config))
+        previous = self.boot.read_bytes()
+        self.commands.loaded = self.activation.adapted(self.boot)
+        activate = self.publisher.reload_and_verify
+        def fail_after_first_activation(fingerprint):
+            activate(fingerprint)
+            if fingerprint:
+                raise RuntimeError('injected endpoint verification failure')
+        self.publisher.reload_and_verify = fail_after_first_activation
+        with self.activation.locked(), self.assertRaises(PublicationError) as failure:
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.assertFalse(failure.exception.restoration_failed)
+        self.assertEqual(previous, self.boot.read_bytes())
+        active = self.commands.loaded
+        self.assertNotIn('app.infra.example.com', json.dumps(active))
+        self.assertIn('other.example.com', json.dumps(active))
+        self.assertEqual({('10.20.30.40', 443)}, self.activation.expected_listeners(active))
+
+    def test_renewal_failure_restores_previous_pointer_and_boot(self):
+        from tls_runtime.publication import PublicationError
+        with self.activation.locked():
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+            previous = os.readlink(self.integration.root / 'current')
+            boot = self.boot.read_bytes()
+            activate = self.publisher.reload_and_verify
+            def reject_new(fp):
+                activate(fp)
+                if (self.integration.root / 'current/fullchain.pem').read_bytes() == b'certificate-two':
+                    raise RuntimeError('injected served fingerprint mismatch')
+            self.publisher.reload_and_verify = reject_new
+            with self.assertRaises(PublicationError) as failure:
+                self.publisher.publish(b'certificate-two', b'private-key-two')
+            self.assertFalse(failure.exception.restoration_failed)
+        self.assertEqual(previous, os.readlink(self.integration.root / 'current'))
+        self.assertEqual(boot, self.boot.read_bytes())
+
+class RestartBindingTests(AdapterFixture):
+    def test_restart_rejects_changed_candidate_boot_authority(self):
+        from tls_runtime.caddy import Deployment
+        from types import SimpleNamespace
+        deployment = Deployment(self.activation, SimpleNamespace(reader_gid=os.getgid(), endpoints=[{
+            'hostname': 'app.infra.example.com', 'address': '10.20.30.40', 'port': 443}]))
+        self.publisher.reload_and_verify = lambda fp: (_ for _ in ()).throw(KeyboardInterrupt())
+        with self.assertRaises(KeyboardInterrupt):
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        self.publisher._switch_current(None)
+        record = self.publisher._read_journal()
+        record['status'] = 'rollback_pending'
+        record['caddy']['restart'] = True
+        self.publisher._write_journal(record)
+        original = self.commands.run
+        def restart(argv):
+            if argv == ['/usr/bin/systemctl', 'restart', 'caddy.service']:
+                self.activation.recover()
+                changed = self.publisher._read_journal()
+                changed['caddy']['candidate_boot'] += '\n'
+                self.publisher._write_journal(changed)
+                self.commands.loaded = self.old
+                return b''
+            return original(argv)
+        self.commands.run = restart
+        with deployment.locked(), self.assertRaises(ValueError):
+            deployment.restart(self.envelope['ingress']['manifest_sha256'])
+
+class JournalBoundaryTests(AdapterFixture):
+    def test_startup_rejects_nonprivate_journal_parent_before_disk_mutation(self):
+        self.publisher.reload_and_verify = lambda fp: (_ for _ in ()).throw(KeyboardInterrupt())
+        with self.assertRaises(KeyboardInterrupt):
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        previous = os.readlink(self.integration.root / 'current')
+        boot = self.boot.read_bytes()
+        self.activation.tls_journal.parent.chmod(0o750)
+        with self.assertRaises((ValueError, self.module.ActivationError)):
+            self.integration.recover_disk()
+        self.assertEqual(previous, os.readlink(self.integration.root / 'current'))
+        self.assertEqual(boot, self.boot.read_bytes())
+
+class InterruptedPublicationTests(AdapterFixture):
+    def exercise(self, phase, previous=True):
+        if previous:
+            with self.activation.locked():
+                self.publisher.publish(b'certificate-one', b'private-key-one')
+        original_reload = self.publisher.reload_and_verify
+        old_pointer = self.publisher._current_name()
+        old_boot = self.boot.read_bytes()
+        triggered = []
+        if phase in ('rollback_pending', 'rollback_failed', 'restored', 'retirement'):
+            def failure(fp):
+                if self.publisher._current_name() != old_pointer or phase == 'rollback_failed':
+                    raise RuntimeError('injected activation boundary failure')
+                return original_reload(fp)
+            self.publisher.reload_and_verify = failure
+        write = self.publisher._write_journal
+        boot_write = self.activation.durable_write
+        rename = os.replace
+        def journal(record):
+            write(record)
+            if record['status'] == phase:
+                triggered.append(True)
+                raise KeyboardInterrupt()
+        def boot(path, *args):
+            boot_write(path, *args)
+            if path == self.boot and phase == 'boot':
+                triggered.append(True)
+                raise KeyboardInterrupt()
+        def retirement(source, target):
+            rename(source, target)
+            if (phase == 'retirement' and Path(target).name.startswith('retired-')):
+                triggered.append(True)
+                raise KeyboardInterrupt()
+        self.publisher._write_journal = journal
+        self.activation.durable_write = boot
+        with mock.patch('os.replace', side_effect=retirement), self.activation.locked(), self.assertRaises(KeyboardInterrupt):
+            self.publisher.publish(b'certificate-two', b'private-key-two')
+        self.assertEqual([True], triggered)
+        self.publisher._write_journal = write
+        self.activation.durable_write = boot_write
+        self.publisher.reload_and_verify = original_reload
+        with self.activation.locked():
+            self.integration.recover_disk()
+            self.assertEqual(old_pointer, self.publisher._current_name())
+            self.assertEqual(old_boot, self.boot.read_bytes())
+            self.publisher.recover()
+        self.assertFalse(self.activation.tls_journal.exists())
+        if phase in ('restored', 'retirement'):
+            self.assertEqual(old_pointer, self.publisher._current_name())
+        else:
+            self.assertEqual(b'certificate-two', (self.integration.root / 'current/fullchain.pem').read_bytes())
+
+    def test_prepared_first_publication_recovers_retained_candidate(self):
+        self.exercise('prepared', previous=False)
+
+    def test_interrupted_switch_recovers_joint_configuration(self):
+        self.exercise('switched')
+
+    def test_interrupted_boot_write_recovers_joint_configuration(self):
+        self.exercise('boot')
+
+    def test_interrupted_rollback_pending_retains_candidate(self):
+        self.exercise('rollback_pending')
+
+    def test_interrupted_rollback_failure_retains_both_outcomes(self):
+        self.exercise('rollback_failed')
+
+    def test_interrupted_restored_record_completes_terminal_cleanup(self):
+        self.exercise('restored')
+
+    def test_interrupted_retirement_does_not_require_deleted_candidate(self):
+        self.exercise('retirement')

--- a/tests/tls/test_integration.py
+++ b/tests/tls/test_integration.py
@@ -465,3 +465,40 @@ class InterruptedPublicationTests(AdapterFixture):
 
     def test_interrupted_retirement_does_not_require_deleted_candidate(self):
         self.exercise('retirement')
+
+class DirectPreparedRecoveryTests(AdapterFixture):
+    def exercise(self, previous=False):
+        from tls_runtime import runtime
+        if previous:
+            with self.activation.locked():
+                self.publisher.publish(b'certificate-one', b'private-key-one')
+        write = self.publisher._write_journal
+        def interrupt_prepared(record):
+            write(record)
+            if record['status'] == 'prepared':
+                raise KeyboardInterrupt()
+        self.publisher._write_journal = interrupt_prepared
+        with self.activation.locked(), self.assertRaises(KeyboardInterrupt):
+            self.publisher.publish(b'certificate-two', b'private-key-two')
+        self.publisher._write_journal = write
+        retained = self.publisher._read_journal()
+        self.assertIsNone(retained['caddy']['disk_recovery'])
+        def forbidden_issuance():
+            self.fail('prepared integrated recovery must not start issuance')
+        def forbidden_snapshot():
+            self.fail('prepared integrated recovery must use its retained generation')
+        result = runtime.reconcile(self.publisher, forbidden_issuance, forbidden_snapshot,
+                                   publication_context=self.activation.locked)
+        self.assertEqual('not_run', result['issuance'])
+        self.assertEqual('changed', result['publication'])
+        self.assertFalse(result['activation_failed'])
+        self.assertFalse(result['restoration_failed'])
+        self.assertEqual(retained['generation'], os.readlink(self.integration.root / 'current'))
+        self.assertIn('app.infra.example.com', self.boot.read_text())
+        self.assertFalse(self.activation.tls_journal.exists())
+
+    def test_first_prepared_candidate_recovers_without_startup_or_issuance(self):
+        self.exercise()
+
+    def test_prepared_renewal_recovers_without_startup_or_issuance(self):
+        self.exercise(previous=True)

--- a/tests/tls/test_integration.py
+++ b/tests/tls/test_integration.py
@@ -467,33 +467,37 @@ class InterruptedPublicationTests(AdapterFixture):
         self.exercise('retirement')
 
 class DirectPreparedRecoveryTests(AdapterFixture):
-    def exercise(self, previous=False):
+    def exercise(self, previous=False, phase="prepared"):
         from tls_runtime import runtime
         if previous:
             with self.activation.locked():
                 self.publisher.publish(b'certificate-one', b'private-key-one')
         write = self.publisher._write_journal
-        def interrupt_prepared(record):
+        def interrupt_publication(record):
             write(record)
-            if record['status'] == 'prepared':
+            if record['status'] == phase:
                 raise KeyboardInterrupt()
-        self.publisher._write_journal = interrupt_prepared
+        self.publisher._write_journal = interrupt_publication
         with self.activation.locked(), self.assertRaises(KeyboardInterrupt):
             self.publisher.publish(b'certificate-two', b'private-key-two')
         self.publisher._write_journal = write
         retained = self.publisher._read_journal()
         self.assertIsNone(retained['caddy']['disk_recovery'])
         def forbidden_issuance():
-            self.fail('prepared integrated recovery must not start issuance')
+            self.fail('integrated recovery must not start issuance')
         def forbidden_snapshot():
-            self.fail('prepared integrated recovery must use its retained generation')
+            self.fail('integrated recovery must use its retained generation')
+        reloads_before = self.commands.reloads
         result = runtime.reconcile(self.publisher, forbidden_issuance, forbidden_snapshot,
                                    publication_context=self.activation.locked)
+        self.assertEqual(1, self.commands.reloads - reloads_before)
         self.assertEqual('not_run', result['issuance'])
         self.assertEqual('changed', result['publication'])
         self.assertFalse(result['activation_failed'])
         self.assertFalse(result['restoration_failed'])
         self.assertEqual(retained['generation'], os.readlink(self.integration.root / 'current'))
+        self.assertEqual(b'certificate-two', (self.integration.root / 'current/fullchain.pem').read_bytes())
+        self.assertIn('app.infra.example.com', json.dumps(self.commands.loaded))
         self.assertIn('app.infra.example.com', self.boot.read_text())
         self.assertFalse(self.activation.tls_journal.exists())
 
@@ -502,3 +506,46 @@ class DirectPreparedRecoveryTests(AdapterFixture):
 
     def test_prepared_renewal_recovers_without_startup_or_issuance(self):
         self.exercise(previous=True)
+
+    def test_first_switched_candidate_recovers_without_startup_or_issuance(self):
+        self.exercise(phase='switched')
+
+    def test_switched_renewal_recovers_without_startup_or_issuance(self):
+        self.exercise(previous=True, phase='switched')
+
+
+class DirectRestoredRecoveryTests(AdapterFixture):
+    def test_terminal_restoration_reports_failure_without_startup_or_issuance(self):
+        from tls_runtime import runtime
+        with self.activation.locked():
+            self.publisher.publish(b'certificate-one', b'private-key-one')
+        previous = self.publisher._current_name()
+        reload = self.publisher.reload_and_verify
+        write = self.publisher._write_journal
+        def activation_failure(fp):
+            reload(fp)
+            if self.publisher._current_name() != previous:
+                raise RuntimeError('injected activation failure')
+        def interrupt_terminal_cleanup(record):
+            write(record)
+            if record['status'] == 'restored':
+                raise KeyboardInterrupt()
+        self.publisher.reload_and_verify = activation_failure
+        self.publisher._write_journal = interrupt_terminal_cleanup
+        with self.activation.locked(), self.assertRaises(KeyboardInterrupt):
+            self.publisher.publish(b'certificate-two', b'private-key-two')
+        self.publisher.reload_and_verify = reload
+        self.publisher._write_journal = write
+        self.assertEqual('restored', self.publisher._read_journal()['status'])
+        def forbidden():
+            self.fail('terminal integrated recovery must not start issuance or snapshot')
+        reloads_before = self.commands.reloads
+        result = runtime.reconcile(self.publisher, forbidden, forbidden,
+                                   publication_context=self.activation.locked)
+        self.assertEqual('not_run', result['issuance'])
+        self.assertEqual('failed', result['publication'])
+        self.assertTrue(result['activation_failed'])
+        self.assertFalse(result['restoration_failed'])
+        self.assertEqual(previous, self.publisher._current_name())
+        self.assertEqual(reloads_before, self.commands.reloads)
+        self.assertFalse(self.activation.tls_journal.exists())

--- a/tests/tls/test_policy.py
+++ b/tests/tls/test_policy.py
@@ -21,6 +21,19 @@ def example_policy():
 
 
 class PolicyTests(unittest.TestCase):
+    def test_same_hostname_on_distinct_listeners_is_fully_verified(self):
+        raw = example_policy()
+        raw["endpoints"].append(dict(raw["endpoints"][0], address="fd00::40"))
+        policy = parse_policy(json.dumps(raw).encode())
+        self.assertEqual(2, len(policy.endpoints))
+
+    def test_address_spellings_cannot_hide_duplicate_endpoints(self):
+        raw = example_policy()
+        raw["endpoints"][0]["address"] = "fd00::40"
+        raw["endpoints"].append(dict(raw["endpoints"][0], address="fd00:0:0:0:0:0:0:40"))
+        with self.assertRaises(ValueError):
+            parse_policy(json.dumps(raw).encode())
+
     def test_exact_wildcard_and_private_listener(self):
         policy = parse_policy(json.dumps(example_policy()).encode())
         self.assertEqual(policy.sans, ["*.infra.example.com"])

--- a/tests/tls/test_runtime.py
+++ b/tests/tls/test_runtime.py
@@ -148,6 +148,7 @@ class RuntimeTests(unittest.TestCase):
             status_path.write_text('{"publication":"changed"}\n')
             status_path.chmod(0o600)
             publisher = Mock()
+            publisher.publication_context = nullcontext
             publisher.recover.side_effect = PublicationError(
                 RuntimeError("secret activation detail"),
                 RuntimeError("secret restoration detail"),
@@ -182,7 +183,8 @@ class RuntimeTests(unittest.TestCase):
 
     def test_observer_never_issues_or_reloads(self):
         with patch.object(runtime, "inspect_host"), patch.object(runtime, "active_fingerprint", return_value="abc"), \
-                patch.object(runtime, "verify_endpoints") as verify, patch.object(runtime, "run_fixed") as run:
+                patch.object(runtime, "verify_endpoints") as verify, patch.object(runtime, "run_fixed") as run, \
+                patch.object(runtime, "publication_locked", return_value=nullcontext(SimpleNamespace(a=Mock()))):
             runtime.observe(self.policy)
         verify.assert_called_once_with(self.policy, "abc")
         run.assert_not_called()
@@ -228,7 +230,10 @@ class RuntimeTests(unittest.TestCase):
             ) as current, patch.object(runtime, "secure_path"), patch.object(
                 runtime, "run_fixed", side_effect=lambda argv, **_kwargs: commands.append(argv)
             ), patch.object(runtime, "verify_endpoints") as verify:
-                publisher = runtime.publisher_for(self.policy)
+                deployment = SimpleNamespace(prepare=lambda record: None, locked=nullcontext,
+                    operation=lambda action, path=None: commands.append(
+                        [str(runtime.ADAPTER), action] + ([] if path is None else [str(path)])))
+                publisher = runtime.publisher_for(self.policy, deployment)
                 self.assertEqual("1" * 64, publisher.validate(generation))
                 self.assertEqual("2" * 64, publisher.validate(external))
                 publisher.preflight(generation)


### PR DESCRIPTION
Connect the lego/systemd TLS publisher to the host Caddy service. First publication activates declared `infra` routes; renewal and rollback coordinate certificate generations, Caddy configuration, reload, and served-certificate verification under the shared deployment lock. Recovery retries retained certificates without another issuance request.

Register `nuc4` in `tls_hosts` with the timer disabled, bind TLS verification targets to Caddy’s committed declaration, and support HTTP devices plus authenticated HTTPS devices with immutable trust bundles. Keep Rocky maintenance compatible with the Caddy role’s signed EPEL source, and update the installation and recovery guides.

Validation: `mise run ci:changed` passed, including fast validation, 114 TLS tests, 318 Ansible tests, and Ansible lint with no failures or warnings. All phases of `system_maintenance/default`, `system_maintenance/baseline`, and `reverse_proxy/default` passed on both Debian 13 and Rocky 9. The proxy scenarios cover publication, renewal, rollback, failed first publication, interrupted recovery, automatic restart, concurrent operations, and repeat provisioning. An independent OpenSSL strict-verification test covers the integration certificate fixture.

No production deployment, ACME issuance, or timer enablement was performed. Protected live inputs and the separately authorized initial renewal remain operator steps documented in the TLS README.

Refs #5.
