### PR TITLE
Select affected Molecule scenarios for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       run_molecule: ${{ steps.classify.outputs.run_molecule }}
       paths: ${{ steps.classify.outputs.paths }}
       reasons: ${{ steps.classify.outputs.reasons }}
+      molecule_matrix: ${{ steps.classify.outputs.molecule_matrix }}
+      molecule_plan: ${{ steps.classify.outputs.molecule_plan }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -46,7 +48,7 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          classify_args=(--format github)
+          classify_args=(--format github --summary "$GITHUB_STEP_SUMMARY")
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             classify_args+=(
               --base "$PR_BASE_SHA"
@@ -155,20 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 4
-      matrix:
-        include:
-          - selector: system_maintenance/default
-            platform: debian13
-          - selector: system_maintenance/default
-            platform: rockylinux9
-          - selector: system_maintenance/baseline
-            platform: debian13
-          - selector: system_maintenance/baseline
-            platform: rockylinux9
-          - selector: reverse_proxy/default
-            platform: debian13
-          - selector: reverse_proxy/default
-            platform: rockylinux9
+      matrix: ${{ fromJSON(needs.classify.outputs.molecule_matrix) }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -185,7 +174,8 @@ jobs:
       - name: Run Molecule platform validation
         env:
           HOMELAB_MOLECULE_PLATFORM: ${{ matrix.platform }}
-        run: mise run test:molecule -- ${{ matrix.selector }}
+          MOLECULE_SELECTOR: ${{ matrix.selector }}
+        run: mise run test:molecule -- "$MOLECULE_SELECTOR"
 
   merge-gate:
     name: merge-gate
@@ -215,13 +205,15 @@ jobs:
           FAST_RESULT: ${{ needs.fast.result }}
           ANSIBLE_RESULT: ${{ needs.ansible.result }}
           MOLECULE_RESULT: ${{ needs.molecule.result }}
+          MOLECULE_PLAN: ${{ needs.classify.outputs.molecule_plan }}
         run: |
           mise exec -- python scripts/ci/merge_gate.py \
             --depth "$SELECTED_DEPTH" \
             --classify-result "$CLASSIFY_RESULT" \
             --fast-result "$FAST_RESULT" \
             --ansible-result "$ANSIBLE_RESULT" \
-            --molecule-result "$MOLECULE_RESULT"
+            --molecule-result "$MOLECULE_RESULT" \
+            --molecule-plan "$MOLECULE_PLAN"
       - name: Write validation summary
         if: always()
         env:

--- a/README.md
+++ b/README.md
@@ -168,8 +168,16 @@ runs locally and in GitHub's native AMD64 matrix.
 `mise run test:molecule -- system_maintenance/baseline` runs complete Debian
 and Rocky composition. `mise run test:molecule -- reverse_proxy/default` exercises
 the private proxy using disposable certificates and HTTP/WebSocket backends.
-CI runs both platforms for all three scenarios as six exact
-selector-and-platform matrix jobs. Container results do not prove physical
+Change-directed validation selects affected scenarios on both platforms using
+[the checked-in impact map](scripts/ci/molecule-impact.json). Proxy and TLS role
+changes also select the baseline scenario, which exercises those integrations.
+Shared framework changes and uncertain impact select all six rows. Documentation
+changes under `docs/` or subsystem READMEs select no Molecule rows.
+
+Use `mise run ci:changed -- --dry-run` to inspect selected scenarios and reasons.
+GitHub Actions consumes the same plan and writes exact base/head SHAs and row
+reasons to its job summary. Scheduled and manual CI run the complete suite;
+`mise run ci` remains the explicit complete local validation command. Container results do not prove physical
 reboot, host-kernel enforcement, real network reachability, or Semaphore
 scheduling and notification delivery.
 

--- a/docs/specs/002-multi-os-molecule-validation.md
+++ b/docs/specs/002-multi-os-molecule-validation.md
@@ -1,6 +1,7 @@
 # Specification 002: Multi-OS Molecule validation
 
-Issue: [#11 Establish multi-OS Molecule validation](https://github.com/supermorphic/homelab-playbook/issues/11)
+Issues: [#11 Establish multi-OS Molecule validation](https://github.com/supermorphic/homelab-playbook/issues/11)
+and [#32 Deterministic Molecule CI gating](https://github.com/supermorphic/homelab-playbook/issues/32)
 
 ## Purpose
 
@@ -8,8 +9,9 @@ Add change-directed executable validation for the repository-owned
 `system_maintenance` role. The validation uses Molecule and rootless Podman to
 exercise Debian 13 and Rocky Linux 9 in systemd-capable containers.
 
-This initiative adds and activates the change-directed `molecule` validation
-depth. It adds container evidence without contacting an inventory host, using a
+The original initiative added the change-directed `molecule` validation depth.
+Issue #32 extends it with deterministic impact selection across all registered
+scenarios. It adds container evidence without contacting an inventory host, using a
 repository secret, or claiming VM or physical-hardware coverage.
 
 ## Governing decisions
@@ -37,7 +39,8 @@ change-directed validation, and container-only boundaries.
 
 ### Included
 
-- one `default` Molecule scenario for `roles/system_maintenance`;
+- `default` and `baseline` scenarios for `roles/system_maintenance`, plus
+  `reverse_proxy/default` integration coverage;
 - Debian 13 and Rocky Linux 9 container platforms;
 - rootless Podman preflight, image acquisition, image building, container
   lifecycle, and cleanup;
@@ -46,7 +49,7 @@ change-directed validation, and container-only boundaries.
 - explicit suppression of real reboot attempts during container tests while
   retaining the production default;
 - a public scenario test command and shared per-platform worker;
-- parallel local execution and a two-job GitHub Actions matrix;
+- parallel local platform execution and a generated GitHub Actions matrix;
 - activation of classifier, `full`, and merge-gate support for the `molecule`
   depth;
 - separate timing and image-provenance reporting; and
@@ -386,7 +389,7 @@ classify
          `-- Rocky Linux 9 ------------------------|
 ```
 
-The matrix uses `ubuntu-24.04`, `fail-fast: false`, and at most two concurrent
+The matrix uses `ubuntu-24.04`, `fail-fast: false`, and at most four concurrent
 jobs. Both platforms are native AMD64 in GitHub Actions. Each matrix job invokes
 the same platform worker used by the local command and has a bounded timeout.
 The initial timeout allows for a cold image build and full package upgrade; it
@@ -399,35 +402,76 @@ redundant cleanup or image-pruning stage beyond scenario cleanup.
 
 ## Change-directed validation
 
-The classifier begins emitting all four ordered depths:
+The classifier retains the four ordered depths:
 
 ```text
-fast < ansible < molecule < full
+fast -> ansible -> molecule -> full
 ```
 
-The intended mappings are:
+Within `molecule`, `scripts/ci/molecule_plan.py` selects scenarios using the
+checked-in `scripts/ci/molecule-impact.json`. The runner's `SCENARIOS` registry
+supplies the complete scenario/platform set, including fallback when the map is
+missing or invalid. Every selected scenario runs both Debian 13 and Rocky Linux
+9. Platform-specific impact selection is not supported.
 
-| Change | Selected depth |
+Each map rule declares directory prefixes, consuming selectors, and a reason.
+The most specific matching directory wins; equally specific rules union their
+consumers. This lets scenario-local tests select their own scenario while role
+changes select all consumers. Scenario paths require an explicit scenario-directory
+rule; a broad role rule cannot cover a missing scenario declaration. Rules naming `all` broaden to the complete suite.
+Selections and reasons are deduplicated and emitted in stable registry order.
+
+| Changed input | Scenario selection |
 | --- | --- |
-| `system_maintenance` role source or defaults | `molecule` |
-| its Molecule scenario, Containerfiles, runner, or focused tests | `molecule` |
-| other Ansible roles, playbooks, or inventories | `ansible` |
-| toolchain locks, Galaxy requirements, classifier, CI, or merge gate | `full` |
-| documentation and ordinary policy files | `fast` |
-| unknown or ambiguous path | `full` |
+| Maintenance role | Both maintenance scenarios |
+| OS playbooks, host identity, bootstrap, or Podman | Baseline scenario |
+| Shared security policy and OS baseline verifier | Baseline and proxy scenarios |
+| Proxy or TLS role/playbook | Baseline and proxy scenarios |
+| Default maintenance scenario assertions | Default maintenance scenario |
+| Proxy scenario assertions | Proxy scenario |
+| Baseline scenario assertions | Baseline scenario |
+| Shared default scenario create, cleanup, or destroy | Complete suite |
+| Molecule configuration, Containerfiles, create/destroy/cleanup | Complete suite |
+| Runner, CI, classifier, impact map, dependencies | Complete suite |
+| Unknown Molecule-relevant path or invalid impact map | Complete suite |
+| Documentation under `docs/` or direct subsystem README | No Molecule scenarios |
 
-Specific `system_maintenance` mappings take precedence over the existing generic
-`roles/ -> ansible` mapping. Classifier fixtures cover both the positive
-Molecule paths and unchanged shallower paths.
+The baseline scenario is a declared consumer of both proxy and TLS roles. A
+proxy-only role change therefore excludes `system_maintenance/default` but
+retains `system_maintenance/baseline`. The proxy also imports shared firewall
+policy and verification from `security_baseline` and `os_baseline_verify`, so
+changes to those roles select both consumers. A maintenance role change excludes
+the proxy scenario. Shared create, cleanup, and destroy implementations under the
+default maintenance scenario serve all three scenarios.
 
-`run_molecule` is true for `molecule` and `full`. `full` now means all
-implemented validation and therefore includes Molecule. The public `ci` task and
-`ci:changed -- --force-depth molecule` follow the same rule.
+The existing Git discovery retains deletion paths, both rename/copy paths, and
+local committed, staged, unstaged, and untracked paths. Discovery failure or an
+empty changed-path set selects `full`. A new scenario path enters the Molecule
+tier even if its role was previously static-only; missing impact mapping selects
+the complete registered suite. Add its runner registration and impact consumers
+together. An absent or invalid runner registry fails CI rather than reporting
+partial coverage as successful.
 
-The merge gate accepts `molecule` as an implemented depth, requires successful
-Ansible and Molecule results when selected, permits a skipped Molecule job only
-for `fast` or `ansible`, and continues to fail closed for missing or unknown
-results.
+The generated plan records resolved base/head commit SHAs, whether worktree
+changes are included, `none`, `selective`, or `full` mode, and exact matrix rows
+with reasons. SHAs are null when Git cannot resolve the requested range; the
+result still requires full validation. Local output explicitly marks worktree
+inclusion because a commit SHA does not identify uncommitted content.
+
+GitHub Actions consumes the generated matrix and appends the plan to the job
+summary. Scheduled and manually dispatched workflows force `full`, which always
+selects every registered scenario on both platforms. An explicitly forced
+Molecule tier without mapped Molecule inputs also selects the complete suite.
+`mise run ci:changed` executes only the selected scenarios and clears the internal
+platform override so local validation cannot silently omit a platform.
+`mise run ci` continues to execute the complete local validation suite.
+
+The merge gate requires successful Ansible and aggregate Molecule job results
+for `molecule` and `full`. It also rejects empty, malformed, duplicate, unknown,
+or incomplete platform rows, and requires complete registry coverage in `full`
+mode. Skipped Molecule jobs remain acceptable only for `fast` and `ansible`.
+A failed or cancelled matrix worker makes the required aggregate result fail.
+The matrix retains `fail-fast: false` and no continue-on-error behavior.
 
 ## Failure and cleanup behavior
 
@@ -465,7 +509,7 @@ Implementation follows repository test and validation policy:
 
 Focused tests use positive current invariants as their oracles. They require the
 exact Debian and Red Hat role dispatch set, the exact Debian 13 and Rocky Linux
-9 Molecule set, and the exact two-entry GitHub matrix. Complete OS provisioning
+9 Molecule set, and the complete six-row planned matrix. Complete OS provisioning
 must reject an unsupported operating-system family before configuration roles
 run, and the Molecule runner must reject an unknown workflow platform before
 invoking Podman. No permanent forbidden-reference scan is part of the contract.
@@ -511,9 +555,9 @@ The current contract is satisfied when:
    enabled and whose scenario value prevents actual container reboot;
 10. verification covers representative current role invariants, including Rocky
     kernel retention and EPEL settings;
-11. the classifier selects `molecule` only for explicitly mapped role/scenario
-    changes, retains shallower depths for unaffected changes, and selects all
-    implemented validation for `full`;
+11. the classifier retains four depths and selects affected scenario/platform
+    rows within `molecule`; unknown impact selects the complete Molecule suite,
+    shallower changes retain their depth, and `full` runs all validation;
 12. GitHub executes a bounded two-platform matrix in parallel and the stable
     merge gate requires its success when selected;
 13. local and GitHub workers report pull, build, Molecule, and platform-total

--- a/scripts/ci/classify.py
+++ b/scripts/ci/classify.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 from collections.abc import Sequence
+from pathlib import Path
 
 
 DEPTH_ORDER = {"fast": 0, "ansible": 1, "molecule": 2, "full": 3}
@@ -92,16 +93,28 @@ def classify_path(path: str) -> tuple[str, str]:
     ):
         return "full", "validation implementation changes require full validation"
 
+    if (path.endswith("/README.md") and len(path.split("/")) == 3
+            and _has_prefix(path, ("roles/", "playbooks/"))):
+        return "fast", "subsystem documentation changes require fast validation"
+    if "/molecule/" in path and path.startswith("roles/"):
+        if path.rsplit("/", 1)[-1].startswith("Containerfile") or path.endswith(
+            ("/molecule.yml", "/create.yml", "/destroy.yml", "/cleanup.yml")
+        ):
+            return "full", "Molecule framework changes require full validation"
+        return "molecule", "Molecule scenario changes require container validation"
+
     if _has_prefix(
         path,
         (
             "playbooks/os/",
             "playbooks/podman/",
             "playbooks/tls/",
+            "playbooks/reverse-proxy/",
             "roles/tls_automation/",
             "roles/podman_foundation/",
             "roles/os_baseline_verify/",
             "roles/os_bootstrap/",
+            "roles/host_identity/",
             "roles/security_baseline/",
             "roles/system_maintenance/",
             "roles/reverse_proxy/",
@@ -355,11 +368,15 @@ def format_text(result: dict[str, object]) -> str:
     reason_paths = paths if paths else sorted(reasons)
     for path in reason_paths:
         lines.append(f"  {json.dumps(path, ensure_ascii=True)}: {reasons[path]}")
+    if "molecule_plan" in result:
+        lines.append("molecule_plan: " + format_json(result["molecule_plan"]))
+        lines.append(f"base_sha: {result['base_sha']}")
+        lines.append(f"head_sha: {result['head_sha']}")
     return "\n".join(lines)
 
 
 def format_github(result: dict[str, object]) -> str:
-    return "\n".join(
+    output = "\n".join(
         [
             f"depth={result['depth']}",
             f"run_fast={str(result['run_fast']).lower()}",
@@ -370,6 +387,12 @@ def format_github(result: dict[str, object]) -> str:
             + json.dumps(result["reasons"], ensure_ascii=True, separators=(",", ":")),
         ]
     )
+    if "molecule_plan" in result:
+        output += "\nmolecule_matrix=" + format_json(result["molecule_plan"]["matrix"])
+        output += "\nmolecule_plan=" + format_json(result["molecule_plan"])
+        output += f"\nbase_sha={result['base_sha'] or ''}"
+        output += f"\nhead_sha={result['head_sha'] or ''}"
+    return output
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -381,15 +404,18 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--include-worktree", action="store_true")
     parser.add_argument("--force-depth", choices=EMITTED_DEPTHS)
     parser.add_argument("--format", choices=("text", "json", "github"), default="text")
+    parser.add_argument("--summary", type=Path, help="append the plan to a job summary")
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _parser()
     arguments = parser.parse_args(argv)
+    resolved_base = resolved_head = None
     try:
+        resolved_base, resolved_head = resolve_commits(arguments.base, arguments.head)
         paths = discover_changes(
-            arguments.base, arguments.head, arguments.include_worktree
+            resolved_base, resolved_head, arguments.include_worktree
         )
         result = classify_paths(paths)
         result = force_depth(result, arguments.force_depth)
@@ -403,6 +429,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error(str(error))
     except ValueError as error:
         parser.error(str(error))
+
+    import molecule_plan
+    result.update({
+        "base_sha": resolved_base,
+        "head_sha": resolved_head,
+        "include_worktree": arguments.include_worktree,
+        "molecule_plan": molecule_plan.build_plan(result),
+    })
+    if arguments.summary:
+        with arguments.summary.open("a", encoding="utf-8") as summary:
+            summary.write(molecule_plan.format_summary(result))
 
     formatter = {
         "text": format_text,

--- a/scripts/ci/merge_gate.py
+++ b/scripts/ci/merge_gate.py
@@ -1,11 +1,59 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Sequence
 
-
 IMPLEMENTED_DEPTHS = ("fast", "ansible", "molecule", "full")
+
+
+def plan_errors(depth: str, payload: str) -> list[str]:
+    from molecule_plan import SCENARIOS
+
+    try:
+        plan = json.loads(payload)
+        mode = plan["mode"]
+        rows = plan["matrix"]["include"]
+        if mode not in {"none", "selective", "full"} or not isinstance(rows, list):
+            raise ValueError("invalid plan structure")
+        pairs = set()
+        for row in rows:
+            selector, platform = row["selector"], row["platform"]
+            if selector not in SCENARIOS or platform not in {
+                entry.name for entry in SCENARIOS[selector].platforms
+            }:
+                raise ValueError("unknown scenario or platform")
+            if (selector, platform) in pairs:
+                raise ValueError("duplicate scenario/platform row")
+            reasons = row["reasons"]
+            if (
+                not isinstance(reasons, list)
+                or not reasons
+                or any(
+                    not isinstance(reason, str) or not reason.strip()
+                    for reason in reasons
+                )
+            ):
+                raise ValueError("missing selection reasons")
+            pairs.add((selector, platform))
+        if depth in {"fast", "ansible"}:
+            if mode != "none" or pairs:
+                raise ValueError("unexpected Molecule selection")
+        else:
+            if mode == "none" or not pairs:
+                raise ValueError("required Molecule selection is empty")
+            selectors = SCENARIOS if mode == "full" else {pair[0] for pair in pairs}
+            expected = {
+                (selector, platform.name)
+                for selector in selectors
+                for platform in SCENARIOS[selector].platforms
+            }
+            if pairs != expected or (depth == "full" and mode != "full"):
+                raise ValueError("incomplete scenario/platform coverage")
+    except (ValueError, TypeError, KeyError) as error:
+        return [f"invalid Molecule plan: {error}"]
+    return []
 
 
 def _result_error(job: str, result: str, expected: str) -> str:
@@ -43,9 +91,7 @@ def reconcile(
     if depth in {"fast", "ansible"}:
         if molecule_result not in {"success", "skipped"}:
             errors.append(
-                _result_error(
-                    "molecule", molecule_result, "'success' or 'skipped'"
-                )
+                _result_error("molecule", molecule_result, "'success' or 'skipped'")
             )
     elif molecule_result != "success":
         errors.append(_result_error("molecule", molecule_result, "'success'"))
@@ -62,6 +108,9 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--fast-result", required=True)
     parser.add_argument("--ansible-result", required=True)
     parser.add_argument("--molecule-result", required=True)
+    parser.add_argument(
+        "--molecule-plan", required=True, help="validate the selected matrix plan"
+    )
     return parser
 
 
@@ -74,6 +123,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         arguments.ansible_result,
         arguments.molecule_result,
     )
+    errors.extend(plan_errors(arguments.depth, arguments.molecule_plan))
     for error in errors:
         print(error, file=sys.stderr)
     return 1 if errors else 0

--- a/scripts/ci/molecule-impact.json
+++ b/scripts/ci/molecule-impact.json
@@ -1,0 +1,39 @@
+{
+  "rules": [
+    {
+      "prefixes": ["roles/system_maintenance/"],
+      "selectors": ["system_maintenance/default", "system_maintenance/baseline"],
+      "reason": "maintenance role is exercised by both maintenance scenarios"
+    },
+    {
+      "prefixes": ["roles/system_maintenance/molecule/default/"],
+      "selectors": ["system_maintenance/default"],
+      "reason": "maintenance default scenario coverage; shared lifecycle files require full depth"
+    },
+    {
+      "prefixes": ["roles/system_maintenance/molecule/baseline/"],
+      "selectors": ["system_maintenance/baseline"],
+      "reason": "baseline scenario coverage"
+    },
+    {
+      "prefixes": ["playbooks/os/", "roles/os_bootstrap/", "roles/host_identity/", "playbooks/podman/", "roles/podman_foundation/"],
+      "selectors": ["system_maintenance/baseline"],
+      "reason": "baseline scenario exercises host and Podman composition"
+    },
+    {
+      "prefixes": ["roles/security_baseline/", "roles/os_baseline_verify/"],
+      "selectors": ["system_maintenance/baseline", "reverse_proxy/default"],
+      "reason": "baseline and proxy scenarios consume shared firewall policy and verification"
+    },
+    {
+      "prefixes": ["playbooks/tls/", "roles/tls_automation/", "playbooks/reverse-proxy/", "roles/reverse_proxy/"],
+      "selectors": ["system_maintenance/baseline", "reverse_proxy/default"],
+      "reason": "baseline and proxy scenarios exercise proxy and TLS integration"
+    },
+    {
+      "prefixes": ["roles/reverse_proxy/molecule/default/"],
+      "selectors": ["reverse_proxy/default"],
+      "reason": "proxy scenario coverage"
+    }
+  ]
+}

--- a/scripts/ci/molecule_plan.py
+++ b/scripts/ci/molecule_plan.py
@@ -1,0 +1,149 @@
+"""Deterministic selection within the Molecule validation tier."""
+
+from __future__ import annotations
+
+import json
+import html
+import sys
+from pathlib import Path
+
+import classify
+
+# The runner registry is the authority for the complete suite, including when
+# the impact map is missing or invalid. Importing it does not invoke Podman.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from scripts.molecule import SCENARIOS
+
+MAP_PATH = Path(__file__).with_name("molecule-impact.json")
+
+
+def _load_rules(path: Path) -> list[dict]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict) or set(document) != {"rules"}:
+        raise ValueError("invalid impact map")
+    rules = document["rules"]
+    if not isinstance(rules, list) or not rules:
+        raise ValueError("empty impact map")
+    for rule in rules:
+        if not isinstance(rule, dict) or set(rule) != {
+            "prefixes",
+            "selectors",
+            "reason",
+        }:
+            raise ValueError("invalid impact rule")
+        prefixes, selectors = rule["prefixes"], rule["selectors"]
+        if (
+            not isinstance(prefixes, list)
+            or not prefixes
+            or any(
+                not isinstance(prefix, str)
+                or not classify._valid_relative_path(prefix)
+                or not prefix.endswith("/")
+                for prefix in prefixes
+            )
+        ):
+            raise ValueError("invalid impact prefixes")
+        if selectors != "all" and (
+            not isinstance(selectors, list)
+            or not selectors
+            or any(
+                not isinstance(selector, str) or selector not in SCENARIOS
+                for selector in selectors
+            )
+        ):
+            raise ValueError("unknown impact selector")
+        if not isinstance(rule["reason"], str) or not rule["reason"].strip():
+            raise ValueError("missing impact reason")
+    return rules
+
+
+def _plan(mode: str, selected: dict[str, set[str]]) -> dict:
+    return {
+        "mode": mode,
+        "matrix": {
+            "include": [
+                {
+                    "selector": selector,
+                    "platform": platform.name,
+                    "reasons": sorted(selected[selector]),
+                }
+                for selector, scenario in SCENARIOS.items()
+                if selector in selected
+                for platform in scenario.platforms
+            ]
+        },
+    }
+
+
+def _full(reasons: list[str]) -> dict:
+    return _plan("full", {selector: set(reasons) for selector in SCENARIOS})
+
+
+def build_plan(result: dict, *, map_path: Path = MAP_PATH) -> dict:
+    depth = result.get("depth")
+    if depth in {"fast", "ansible"}:
+        return _plan("none", {})
+    if depth != "molecule":
+        reasons = result.get("reasons", {})
+        return _full(
+            ["full validation depth requires the complete suite"]
+            + [f"{path}: {reason}" for path, reason in sorted(reasons.items())]
+        )
+    try:
+        rules = _load_rules(map_path)
+    except (OSError, ValueError, TypeError):
+        return _full(["missing or invalid impact map; complete suite required"])
+    selected: dict[str, set[str]] = {}
+    full_reasons = []
+    for path in result["paths"]:
+        if classify.classify_path(path)[0] in {"fast", "ansible"}:
+            continue
+        matches = [
+            (len(prefix), rule)
+            for rule in rules
+            for prefix in rule["prefixes"]
+            if path.startswith(prefix)
+        ]
+        if "/molecule/" in path:
+            # A role rule does not declare ownership of a newly added scenario.
+            # Require a scenario directory rule even when the role is mapped.
+            parts = path.split("/")
+            scenario_prefix = "/".join(parts[:4]) + "/"
+            matches = [
+                (length, rule)
+                for length, rule in matches
+                if len(parts) >= 5
+                and parts[2] == "molecule"
+                and length >= len(scenario_prefix)
+            ]
+        if not matches:
+            full_reasons.append(f"{path}: unmapped Molecule impact")
+            continue
+        longest = max(length for length, _ in matches)
+        for length, rule in matches:
+            if length != longest:
+                continue
+            reason = f"{path}: {rule['reason']}"
+            if rule["selectors"] == "all":
+                full_reasons.append(reason)
+            else:
+                for selector in rule["selectors"]:
+                    selected.setdefault(selector, set()).add(reason)
+    if full_reasons:
+        return _full(full_reasons)
+    if not selected:
+        return _full(["no mapped Molecule impact; complete suite required"])
+    return _plan("selective", selected)
+
+
+def format_summary(result: dict) -> str:
+    # Escape arbitrary Git path text so it cannot inject summary markup.
+    payload = {
+        key: result[key]
+        for key in ("base_sha", "head_sha", "include_worktree", "molecule_plan")
+    }
+    return (
+        "### Molecule validation plan\n\n<pre>"
+        + html.escape(json.dumps(payload, ensure_ascii=True, indent=2))
+        + "</pre>\n\n"
+    )

--- a/scripts/ci/run_changed.py
+++ b/scripts/ci/run_changed.py
@@ -8,53 +8,20 @@ import subprocess
 from collections.abc import Sequence
 
 import classify
+import molecule_plan
 
 
-COMMANDS = {
-    "fast": [["mise", "run", "validate:fast"]],
-    "ansible": [
-        ["mise", "run", "validate:fast"],
-        ["mise", "run", "validate:ansible"],
-    ],
-    "molecule": [
-        ["mise", "run", "validate:fast"],
-        ["mise", "run", "validate:ansible"],
-        [
-            "mise",
-            "run",
-            "test:molecule",
-            "--",
-            "system_maintenance/default",
-        ],
-        [
-            "mise",
-            "run",
-            "test:molecule",
-            "--",
-            "system_maintenance/baseline",
-        ],
-        ["mise", "run", "test:molecule", "--", "reverse_proxy/default"],
-    ],
-    "full": [
-        ["mise", "run", "validate:fast"],
-        ["mise", "run", "validate:ansible"],
-        [
-            "mise",
-            "run",
-            "test:molecule",
-            "--",
-            "system_maintenance/default",
-        ],
-        [
-            "mise",
-            "run",
-            "test:molecule",
-            "--",
-            "system_maintenance/baseline",
-        ],
-        ["mise", "run", "test:molecule", "--", "reverse_proxy/default"],
-    ],
-}
+def commands_for(result: dict) -> list[list[str]]:
+    commands = [["mise", "run", "validate:fast"]]
+    if result["run_ansible"]:
+        commands.append(["mise", "run", "validate:ansible"])
+    selectors = dict.fromkeys(
+        row["selector"] for row in result["molecule_plan"]["matrix"]["include"]
+    )
+    commands.extend(
+        ["mise", "run", "test:molecule", "--", selector] for selector in selectors
+    )
+    return commands
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -81,8 +48,7 @@ def _print_reasons(result: dict[str, object]) -> None:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _parser()
     arguments = parser.parse_args(argv)
-    resolved_base = arguments.base
-    resolved_head = arguments.head
+    resolved_base = resolved_head = None
 
     try:
         resolved_base, resolved_head = classify.resolve_commits(
@@ -113,22 +79,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Escalated validation depth: {classified_depth} -> {selected_depth}")
     _print_reasons(classified_result)
 
+    result["molecule_plan"] = molecule_plan.build_plan(result)
+    result.update(
+        {"base_sha": resolved_base, "head_sha": resolved_head, "include_worktree": True}
+    )
+    print("Molecule plan: " + classify.format_json(result["molecule_plan"]))
+    print(
+        f"Base SHA: {resolved_base or 'unresolved'}; "
+        f"head SHA: {resolved_head or 'unresolved'}; includes worktree"
+    )
     validation_environment = os.environ.copy()
+    validation_environment.pop("HOMELAB_MOLECULE_PLATFORM", None)
     validation_environment.update(
         {
-            "CI_BASE_SHA": resolved_base,
-            "CI_HEAD_SHA": resolved_head,
+            "CI_BASE_SHA": resolved_base or arguments.base,
+            "CI_HEAD_SHA": resolved_head or arguments.head,
             "LOCAL_CHANGE_DIRECTED": "1",
         }
     )
-    for command in COMMANDS[selected_depth]:
+    for command in commands_for(result):
         if arguments.dry_run:
             print(f"Would run: {shlex.join(command)}")
             continue
         print(f"Running: {shlex.join(command)}", flush=True)
-        completed = subprocess.run(
-            command, check=False, env=validation_environment
-        )
+        completed = subprocess.run(command, check=False, env=validation_environment)
         if completed.returncode != 0:
             return completed.returncode
     return 0

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -899,7 +899,7 @@ class MoleculeScenarioContractTests(unittest.TestCase):
             assertion["ansible.builtin.assert"]["that"],
         )
 
-    def test_ci_registers_exact_six_selector_platform_jobs(self) -> None:
+    def test_ci_consumes_planned_selector_platform_jobs(self) -> None:
         workflow = yaml.safe_load(
             (REPOSITORY_ROOT / ".github/workflows/ci.yml").read_text(
                 encoding="utf-8"
@@ -909,18 +909,14 @@ class MoleculeScenarioContractTests(unittest.TestCase):
         matrix = molecule_job["strategy"]["matrix"]
         self.assertEqual(4, molecule_job["strategy"]["max-parallel"])
         self.assertEqual(
-            [
-                {"selector": "system_maintenance/default", "platform": "debian13"},
-                {"selector": "system_maintenance/default", "platform": "rockylinux9"},
-                {"selector": "system_maintenance/baseline", "platform": "debian13"},
-                {"selector": "system_maintenance/baseline", "platform": "rockylinux9"},
-                {"selector": "reverse_proxy/default", "platform": "debian13"},
-                {"selector": "reverse_proxy/default", "platform": "rockylinux9"},
-            ],
-            matrix["include"],
+            "${{ fromJSON(needs.classify.outputs.molecule_matrix) }}", matrix
         )
         run_source = str(molecule_job["steps"][-1]["run"])
-        self.assertIn("matrix.selector", run_source)
+        self.assertIn('"$MOLECULE_SELECTOR"', run_source)
+        self.assertEqual(
+            "${{ matrix.selector }}",
+            molecule_job["steps"][-1]["env"]["MOLECULE_SELECTOR"],
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci/test_classify.py
+++ b/tests/ci/test_classify.py
@@ -162,10 +162,10 @@ class PathClassificationTests(unittest.TestCase):
             "roles/os_baseline_verify/tasks/main.yml": "molecule",
             "roles/security_baseline/tasks/main.yml": "molecule",
             "roles/system_maintenance/tasks/main.yml": "molecule",
-            "roles/system_maintenance/molecule/default/molecule.yml": "molecule",
-            "roles/system_maintenance/molecule/baseline/molecule.yml": "molecule",
+            "roles/system_maintenance/molecule/default/molecule.yml": "full",
+            "roles/system_maintenance/molecule/baseline/molecule.yml": "full",
             "roles/reverse_proxy/tasks/main.yml": "molecule",
-            "roles/reverse_proxy/molecule/default/molecule.yml": "molecule",
+            "roles/reverse_proxy/molecule/default/molecule.yml": "full",
             "playbooks/os/provision.yml": "molecule",
             "playbooks/podman/provision.yml": "molecule",
             "playbooks/podman/verify.yml": "molecule",
@@ -616,6 +616,28 @@ class ClassifierCliTests(unittest.TestCase):
         self.repository = TemporaryGitRepository()
         self.repository.initialize_fixture()
 
+    def test_plan_records_resolved_commits_and_summary(self) -> None:
+        self.repository.write("roles/reverse_proxy/tasks/new.yml", "---\n")
+        head = self.repository.commit_all("proxy change")
+        base = self.repository.git("rev-parse", "HEAD~1").stdout.strip()
+        summary = self.repository.root / "summary.md"
+        result = self.repository.run_python(
+            CLASSIFIER_PATH,
+            ["--base", "HEAD~1", "--head", "HEAD", "--format", "json",
+             "--summary", str(summary)],
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(base, payload["base_sha"])
+        self.assertEqual(head, payload["head_sha"])
+        self.assertFalse(payload["include_worktree"])
+        self.assertEqual("selective", payload["molecule_plan"]["mode"])
+        self.assertEqual(4, len(payload["molecule_plan"]["matrix"]["include"]))
+        summary_text = summary.read_text()
+        for expected in (base, head, "reverse_proxy/default", "debian13",
+                         "rockylinux9", "roles/reverse_proxy/tasks/new.yml"):
+            self.assertIn(expected, summary_text)
+
     def tearDown(self) -> None:
         self.repository.cleanup()
 
@@ -763,6 +785,11 @@ class ChangedRunnerTests(unittest.TestCase):
             result.stdout,
         )
 
+    def test_unresolved_refs_are_not_reported_as_commit_shas(self) -> None:
+        result = self.run_changed("--dry-run", "--base", "missing-ref")
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Base SHA: unresolved; head SHA: unresolved", result.stdout)
+
     def test_dry_run_rejects_requested_deescalation(self) -> None:
         self.repository.write("roles/update_pihole/tasks/new.yml", "---\n")
 
@@ -785,7 +812,7 @@ class ChangedRunnerTests(unittest.TestCase):
 
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("Selected validation depth: molecule", result.stdout)
-        self.assertEqual(5, result.stdout.count("Would run:"))
+        self.assertEqual(4, result.stdout.count("Would run:"))
         self.assertIn("Would run: mise run validate:fast", result.stdout)
         self.assertIn("Would run: mise run validate:ansible", result.stdout)
         self.assertIn(
@@ -796,7 +823,7 @@ class ChangedRunnerTests(unittest.TestCase):
             "Would run: mise run test:molecule -- system_maintenance/baseline",
             result.stdout,
         )
-        self.assertIn(
+        self.assertNotIn(
             "Would run: mise run test:molecule -- reverse_proxy/default",
             result.stdout,
         )

--- a/tests/ci/test_merge_gate.py
+++ b/tests/ci/test_merge_gate.py
@@ -267,6 +267,8 @@ class MergeGateReconciliationTests(unittest.TestCase):
                 "skipped",
                 "--molecule-result",
                 "failure",
+                "--molecule-plan",
+                '{"mode":"none","matrix":{"include":[]}}',
             ],
             cwd=REPOSITORY_ROOT,
             check=False,
@@ -312,6 +314,8 @@ class MergeGateReconciliationTests(unittest.TestCase):
                         "failure",
                         "--molecule-result",
                         "failure",
+                        "--molecule-plan",
+                        '{"mode":"none","matrix":{"include":[]}}',
                     ],
                     cwd=REPOSITORY_ROOT,
                     check=False,
@@ -327,11 +331,27 @@ class MergeGateReconciliationTests(unittest.TestCase):
                             "classify job result is 'failure', expected 'success'",
                             "fast job result is 'cancelled', expected 'success'",
                             depth_error,
+                            "invalid Molecule plan: required Molecule selection is empty",
                             "",
                         ]
                     ),
                     result.stderr,
                 )
+
+    def test_cli_requires_plan_even_when_all_job_results_succeed(self) -> None:
+        arguments = [
+            sys.executable, str(MERGE_GATE_PATH), "--depth", "fast",
+            "--classify-result", "success", "--fast-result", "success",
+            "--ansible-result", "skipped", "--molecule-result", "skipped",
+        ]
+        result = subprocess.run(arguments, capture_output=True, text=True)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("--molecule-plan", result.stderr)
+        result = subprocess.run(
+            arguments + ["--molecule-plan", '{"mode":"none","matrix":{"include":[]}}'],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
 
 
 class WorkflowContractTests(unittest.TestCase):
@@ -491,7 +511,7 @@ class WorkflowContractTests(unittest.TestCase):
 
         self.assertTrue(workflow_observability_errors(mutated_workflow))
 
-    def test_molecule_runs_an_exact_bounded_six_job_matrix(self) -> None:
+    def test_molecule_runs_the_planned_bounded_matrix(self) -> None:
         self.assertIn("needs: classify", self.molecule)
         self.assertEqual(
             ["needs.classify.outputs.run_molecule == 'true'"],
@@ -504,20 +524,7 @@ class WorkflowContractTests(unittest.TestCase):
                 "    strategy:",
                 "      fail-fast: false",
                 "      max-parallel: 4",
-                "      matrix:",
-                "        include:",
-                "          - selector: system_maintenance/default",
-                "            platform: debian13",
-                "          - selector: system_maintenance/default",
-                "            platform: rockylinux9",
-                "          - selector: system_maintenance/baseline",
-                "            platform: debian13",
-                "          - selector: system_maintenance/baseline",
-                "            platform: rockylinux9",
-                "          - selector: reverse_proxy/default",
-                "            platform: debian13",
-                "          - selector: reverse_proxy/default",
-                "            platform: rockylinux9",
+                "      matrix: ${{ fromJSON(needs.classify.outputs.molecule_matrix) }}",
             ]
         )
         self.assertIn(expected_strategy, self.molecule)
@@ -528,7 +535,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertEqual(
             1,
             self.molecule.count(
-                "run: mise run test:molecule -- ${{ matrix.selector }}"
+                'run: mise run test:molecule -- "$MOLECULE_SELECTOR"'
             ),
         )
         lowered = self.molecule.lower()
@@ -559,6 +566,7 @@ class WorkflowContractTests(unittest.TestCase):
             "FAST_RESULT: ${{ needs.fast.result }}",
             "ANSIBLE_RESULT: ${{ needs.ansible.result }}",
             "MOLECULE_RESULT: ${{ needs.molecule.result }}",
+            "MOLECULE_PLAN: ${{ needs.classify.outputs.molecule_plan }}",
         }
         for variable in expected_environment:
             with self.subTest(variable=variable):
@@ -569,6 +577,7 @@ class WorkflowContractTests(unittest.TestCase):
             '--fast-result "$FAST_RESULT"',
             '--ansible-result "$ANSIBLE_RESULT"',
             '--molecule-result "$MOLECULE_RESULT"',
+            '--molecule-plan "$MOLECULE_PLAN"',
         ):
             with self.subTest(argument=argument):
                 self.assertIn(argument, self.merge_gate)

--- a/tests/ci/test_molecule_plan.py
+++ b/tests/ci/test_molecule_plan.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "ci"))
+import classify
+
+
+class MoleculePlanTests(unittest.TestCase):
+    def plan(self, paths, depth=None):
+        result = classify.force_depth(classify.classify_paths(paths), depth)
+        # The public classifier owns depth; the planner adds scenario selection.
+        import molecule_plan
+
+        return molecule_plan.build_plan(result)
+
+    def test_selection_table(self):
+        maintenance = {"system_maintenance/default", "system_maintenance/baseline"}
+        consumers = {"system_maintenance/baseline", "reverse_proxy/default"}
+        all_scenarios = maintenance | consumers
+        cases = [
+            (
+                ["roles/system_maintenance/molecule/default/verify.yml"],
+                {"system_maintenance/default"},
+                "selective",
+            ),
+            (
+                ["roles/host_identity/tasks/main.yml"],
+                {"system_maintenance/baseline"},
+                "selective",
+            ),
+            (["roles/security_baseline/tasks/firewall.yml"], consumers, "selective"),
+            (["roles/os_baseline_verify/tasks/firewall.yml"], consumers, "selective"),
+            (
+                ["roles/reverse_proxy/molecule/future/verify.yml"],
+                all_scenarios,
+                "full",
+            ),
+            (
+                ["roles/system_maintenance/molecule/future/verify.yml"],
+                all_scenarios,
+                "full",
+            ),
+            (
+                ["roles/reverse_proxy/files/README.md"],
+                consumers,
+                "selective",
+            ),
+            (["roles/system_maintenance/tasks/main.yml"], maintenance, "selective"),
+            (["roles/reverse_proxy/tasks/main.yml"], consumers, "selective"),
+            (["playbooks/reverse-proxy/provision.yml"], consumers, "selective"),
+            (
+                ["roles/reverse_proxy/molecule/default/verify.yml"],
+                {"reverse_proxy/default"},
+                "selective",
+            ),
+            (
+                ["roles/tls_automation/files/tls_runtime/runtime.py"],
+                consumers,
+                "selective",
+            ),
+            (
+                ["roles/podman_foundation/tasks/main.yml"],
+                {"system_maintenance/baseline"},
+                "selective",
+            ),
+            (
+                ["roles/system_maintenance/molecule/default/create.yml"],
+                all_scenarios,
+                "full",
+            ),
+            (
+                ["roles/system_maintenance/molecule/default/molecule.yml"],
+                all_scenarios,
+                "full",
+            ),
+            (["roles/new_role/molecule/default/verify.yml"], all_scenarios, "full"),
+            (["scripts/molecule.py"], all_scenarios, "full"),
+            (["scripts/ci/molecule-impact.json"], all_scenarios, "full"),
+            ([".github/workflows/ci.yml"], all_scenarios, "full"),
+            (["requirements.yml"], all_scenarios, "full"),
+            (["unknown.txt"], all_scenarios, "full"),
+            ([], all_scenarios, "full"),
+            (["README.md"], set(), "none"),
+            (["playbooks/reverse-proxy/README.md"], set(), "none"),
+            (["roles/reverse_proxy/README.md"], set(), "none"),
+            (["inventory/production/hosts.yml"], set(), "none"),
+        ]
+        for paths, selectors, mode in cases:
+            with self.subTest(paths=paths):
+                plan = self.plan(paths)
+                self.assertEqual(mode, plan["mode"])
+                self.assertEqual(
+                    {
+                        (selector, platform)
+                        for selector in selectors
+                        for platform in ("debian13", "rockylinux9")
+                    },
+                    {
+                        (row["selector"], row["platform"])
+                        for row in plan["matrix"]["include"]
+                    },
+                )
+                for row in plan["matrix"]["include"]:
+                    self.assertTrue(row["reasons"])
+
+    def test_union_and_reasons_are_deterministic(self):
+        paths = [
+            "roles/tls_automation/tasks/main.yml",
+            "roles/system_maintenance/tasks/main.yml",
+        ]
+        plan = self.plan(paths)
+        self.assertEqual(plan, self.plan(list(reversed(paths)) + paths))
+        baseline = next(
+            row
+            for row in plan["matrix"]["include"]
+            if row["selector"] == "system_maintenance/baseline"
+        )
+        self.assertTrue(
+            all(any(path in reason for reason in baseline["reasons"]) for path in paths)
+        )
+
+    def test_forced_depth_cannot_produce_empty_molecule_suite(self):
+        for depth in ("molecule", "full"):
+            with self.subTest(depth=depth):
+                plan = self.plan(["README.md"], depth)
+                self.assertEqual("full", plan["mode"])
+                self.assertEqual(6, len(plan["matrix"]["include"]))
+
+    def test_unknown_molecule_impact_fails_closed(self):
+        import molecule_plan
+
+        result = {"depth": "molecule", "paths": ["roles/future/tasks/main.yml"]}
+        plan = molecule_plan.build_plan(result)
+        self.assertEqual("full", plan["mode"])
+        self.assertEqual(6, len(plan["matrix"]["include"]))
+
+    def test_missing_scenario_rule_does_not_inherit_role_mapping(self):
+        import molecule_plan
+
+        document = json.loads(molecule_plan.MAP_PATH.read_text())
+        document["rules"] = [
+            rule
+            for rule in document["rules"]
+            if "roles/reverse_proxy/molecule/default/" not in rule["prefixes"]
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            path.write_text(json.dumps(document))
+            result = classify.classify_paths(
+                [
+                    "roles/reverse_proxy/molecule/default/verify.yml",
+                    "roles/system_maintenance/tasks/main.yml",
+                ]
+            )
+            plan = molecule_plan.build_plan(result, map_path=path)
+            self.assertEqual("full", plan["mode"])
+            self.assertEqual(6, len(plan["matrix"]["include"]))
+
+    def test_invalid_map_falls_back_to_runner_registry(self):
+        import molecule_plan
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            for content in (
+                None,
+                "{",
+                "{}",
+                '{"rules": []}',
+                '{"rules": [{"prefixes": ["roles/"], "selectors": ["missing"]}]}',
+            ):
+                with self.subTest(content=content):
+                    if content is not None:
+                        path.write_text(content)
+                    plan = molecule_plan.build_plan(
+                        classify.classify_paths(["roles/reverse_proxy/tasks/main.yml"]),
+                        map_path=path,
+                    )
+                    self.assertEqual("full", plan["mode"])
+                    self.assertEqual(6, len(plan["matrix"]["include"]))
+
+    def test_merge_gate_checks_plan_completeness(self):
+        import merge_gate
+
+        valid = self.plan(["roles/reverse_proxy/tasks/main.yml"])
+        self.assertEqual([], merge_gate.plan_errors("molecule", json.dumps(valid)))
+        full = self.plan(["requirements.yml"])
+        self.assertEqual([], merge_gate.plan_errors("full", json.dumps(full)))
+        none = self.plan(["README.md"])
+        self.assertEqual([], merge_gate.plan_errors("fast", json.dumps(none)))
+        cases = [
+            ("molecule", ""),
+            ("molecule", "{"),
+            ("molecule", "null"),
+            ("molecule", json.dumps(none)),
+            ("full", json.dumps(valid)),
+            ("fast", json.dumps(valid)),
+        ]
+        one_platform = json.loads(json.dumps(valid))
+        one_platform["matrix"]["include"].pop()
+        cases.append(("molecule", json.dumps(one_platform)))
+        duplicate = json.loads(json.dumps(valid))
+        duplicate["matrix"]["include"].append(duplicate["matrix"]["include"][0])
+        cases.append(("molecule", json.dumps(duplicate)))
+        for depth, payload in cases:
+            with self.subTest(depth=depth, payload=payload):
+                self.assertTrue(merge_gate.plan_errors(depth, payload))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Molecule-relevant changes previously ran every scenario on both platforms. Add a checked-in impact map and deterministic planner so local `ci:changed` and GitHub Actions run the affected scenarios on Debian 13 and Rocky Linux 9. Maintenance role changes select the two maintenance scenarios; proxy and TLS changes select baseline and proxy coverage because both consume those roles.

Unknown impact, invalid mappings, shared framework changes, and scheduled/manual CI select the complete suite. Plans include exact base/head SHAs and row-selection reasons in the job summary. The merge gate requires a valid plan, complete platform coverage, and successful required jobs. Update specification 002 and the command documentation.

Validation:
- `mise run bootstrap`, `mise run validate:fast`, and `mise run validate:ansible` passed.
- `mise run ci:changed` passed all six Molecule scenario/platform combinations on native ARM64 rootless Podman, including cleanup.
- Final planner and gate edits passed fresh fast validation, including 142 CI tests; container scenario sources were unchanged during the full run.
- Independent code review and a transitive dependency audit found no remaining issues.
- GitHub-hosted AMD64 validation will run on this PR.

Closes #32.
