### PR TITLE
Onboard Room Alert and fix private proxy TLS renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ the private proxy using disposable certificates and HTTP/WebSocket backends.
 Change-directed validation selects affected scenarios on both platforms using
 [the checked-in impact map](scripts/ci/molecule-impact.json). Proxy and TLS role
 changes also select the baseline scenario, which exercises those integrations.
+TLS runtime tests and the three TLS-specific Ansible test files select the same
+two scenarios. Other Ansible validation tests retain full-suite selection.
 Shared framework changes and uncertain impact select all six rows. Documentation
 changes under `docs/` or subsystem READMEs select no Molecule rows.
 

--- a/docs/guides/device-proxy.md
+++ b/docs/guides/device-proxy.md
@@ -112,6 +112,12 @@ For the Room Alert 3E example, configure Caddy to use the explicit
 HTTPS and uses the public `*.infra.example.com` certificate. The Caddy-to-device
 connection is unencrypted because this device does not provide HTTPS.
 
+AVTECH's port reference limits HTTPS web access to the S models. The 3E user
+guide documents HTTP port 80 as the default; an operator can change it under
+**Settings → Advanced → General → HTTP Port**. Confirm the configured port
+before declaring the backend. The v2.4.0 release notes describe a change to
+data pushes, with no addition of HTTPS web access.
+
 Treat this as a route-specific transport property. Keep the backend on a trusted
 private management network, restrict access to NUC #4 and the required
 management clients, and do not expose port 80 through public routing or WAN port
@@ -184,6 +190,9 @@ proxied browser access, not the independent device function.
 
 ## References
 
+- [AVTECH Room Alert port requirements](https://avtech.com/articles/14315/list-of-ports-required-by-room-alert-products-2/)
+- [Room Alert 3E user guide, General settings on printed page 40](https://account.roomalert.com/documentation/AVTECH_Room_Alert_3E_Users_Guide.pdf)
+- [Room Alert 3E firmware release notes](https://avtech.com/articles/14644/room-alert-3e-firmware-release-notes/)
 - [ARRIS S33/S34 Web Manager access](https://arris.my.salesforce-sites.com/consumers/articles/knowledge/S33-Web-Manager-Access)
 - [ARRIS certificate-warning guidance](https://arris.my.salesforce-sites.com/consumers/articles/knowledge/Alert-Message-for-Web-Manager-Access)
 - [Caddy reverse proxy transport](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#the-http-transport)

--- a/docs/specs/002-multi-os-molecule-validation.md
+++ b/docs/specs/002-multi-os-molecule-validation.md
@@ -414,11 +414,14 @@ supplies the complete scenario/platform set, including fallback when the map is
 missing or invalid. Every selected scenario runs both Debian 13 and Rocky Linux
 9. Platform-specific impact selection is not supported.
 
-Each map rule declares directory prefixes, consuming selectors, and a reason.
-The most specific matching directory wins; equally specific rules union their
+Each map rule declares directory `prefixes`, exact-file `paths`, or both, plus
+consuming selectors and a reason. Exact files outrank directory prefixes;
+otherwise the most specific matching directory wins. Equally specific rules union their
 consumers. This lets scenario-local tests select their own scenario while role
 changes select all consumers. Scenario paths require an explicit scenario-directory
-rule; a broad role rule cannot cover a missing scenario declaration. Rules naming `all` broaden to the complete suite.
+rule; a broad role rule or exact-file entry cannot cover a missing scenario
+declaration. Exact-file entries do not participate in scenario-path matching.
+Rules naming `all` broaden to the complete suite.
 Selections and reasons are deduplicated and emitted in stable registry order.
 
 | Changed input | Scenario selection |
@@ -427,6 +430,7 @@ Selections and reasons are deduplicated and emitted in stable registry order.
 | OS playbooks, host identity, bootstrap, or Podman | Baseline scenario |
 | Shared security policy and OS baseline verifier | Baseline and proxy scenarios |
 | Proxy or TLS role/playbook | Baseline and proxy scenarios |
+| `tests/tls/` and the three TLS-specific Ansible test files | Baseline and proxy scenarios |
 | Default maintenance scenario assertions | Default maintenance scenario |
 | Proxy scenario assertions | Proxy scenario |
 | Baseline scenario assertions | Baseline scenario |
@@ -443,6 +447,13 @@ policy and verification from `security_baseline` and `os_baseline_verify`, so
 changes to those roles select both consumers. A maintenance role change excludes
 the proxy scenario. Shared create, cleanup, and destroy implementations under the
 default maintenance scenario serve all three scenarios.
+
+The TLS-specific Ansible files are `test_tls_role.py`, `test_tls_proxy_policy.py`,
+and `test_tls_fixture_material.py` under `tests/ansible/`. These exact files and
+`tests/tls/` cover TLS runtime, policy, and disposable certificate fixtures used
+by the baseline and proxy scenarios. Other files under `tests/ansible/` continue
+to require full validation. Changes to this classifier or impact map also require
+the complete suite, even when combined with TLS changes.
 
 The existing Git discovery retains deletion paths, both rename/copy paths, and
 local committed, staged, unstaged, and untracked paths. Discovery failure or an

--- a/docs/specs/007-off-cluster-tls-trust.md
+++ b/docs/specs/007-off-cluster-tls-trust.md
@@ -102,7 +102,30 @@ renewal do not create a new account. Failed DNS validation leaves the previously
 deployed certificate available and produces a failed operation with a bounded,
 credential-free diagnostic.
 
+The fixed lego command uses `--dns.resolvers 1.1.1.1:53` for ACME DNS discovery
+and propagation checks. This queries public DNS independently of the host's
+private application resolver. Both recursive and authoritative propagation
+checks remain enabled. The issuer requires outbound DNS access to the public
+resolver and authoritative nameservers; it does not modify host resolver policy.
+
+The issuer additionally retains the final 64 KiB of the latest lego invocation's
+combined output in `/var/lib/homelab-tls-issuer/last-issue.log`. It replaces the
+previous file without following links and updates the bounded tail during
+execution. The file is `svc-acme` owned, mode `0600`, beneath its existing `0700`
+state directory, with no named or inherited POSIX ACL access. This raw output
+is sensitive operator evidence, not a credential-free public diagnostic. It is
+never relayed to Ansible, journald, coordinator status, or repository artifacts.
+Failed and timed-out invocations retain available output; a failure before
+invocation may leave a stale or empty file. Logs are never execution inputs.
+
 ## Credentials and privilege boundaries
+
+The root TLS coordinator retains `CAP_SETUID` with
+`AmbientCapabilities=CAP_SETUID` for its fixed switch to the Caddy account.
+This preserves the required identity change through systemd 257's seccomp
+setup while keeping `NoNewPrivileges` and the other unit restrictions enabled.
+The root-to-Caddy UID switch clears ambient capabilities; Caddy validation
+and reload commands execute without permitted or effective capabilities.
 
 Each UniFi console owns a separate zone-scoped Cloudflare token. The NUC #4
 issuer gets another token, delivered from operator-managed SOPS inventory through

--- a/inventory/production/host_vars/nuc4/secrets.sops.yml
+++ b/inventory/production/host_vars/nuc4/secrets.sops.yml
@@ -1,0 +1,30 @@
+tls_automation_namespace: ENC[AES256_GCM,data:CYMQJKvvGor2eedLtx37OqOc3qdAjg==,iv:EwuLSqAGrv1XPBaAbL/qDb1arNclKhnuzWmBOAm6ay8=,tag:TBFHlX/YQdDrihwm4dm/gg==,type:str]
+tls_automation_email: ENC[AES256_GCM,data:QhN2mkYbGYNZVLqB/HKm0DxOzdSCkPs/WOBe,iv:9BiwnSx+FHPboCoKKMNQc9pg/KlI/0O3uX4z8Ct4sos=,tag:GNxr4FXEFBGz2qPNVU2plw==,type:str]
+tls_automation_timer_enabled: ENC[AES256_GCM,data:AyfLgA==,iv:ofSI2BqbEFd94oVUAql3XyP24LZbxJ9TsbPJF9WHFBc=,tag:5RbLU2+J2UDjsXf1bU6HXQ==,type:bool]
+tls_automation_cloudflare_token: ENC[AES256_GCM,data:GqjLrY/hXXxB3pf/OXDdJ/QXn41ErR817tDke+QjD1Wq3kS9izLG6mvrvjbqVz8TzpOSKcU=,iv:UO61HPiy1Bof19wSq4pdtTDqeHz2MssNvrKan+2MPHg=,tag:tBk35CAkUW3jHc2ehFNrNg==,type:str]
+reverse_proxy_bind_addresses:
+    - ENC[AES256_GCM,data:NCKfVKicXQQNz3mvcg==,iv:fUKm1yeO4unnNYNbw1r6IUinMAeK5t2mrqgIwzEcGaA=,tag:mOgh0XsDKQZtI/mIzfvPag==,type:str]
+reverse_proxy_client_sources:
+    - ENC[AES256_GCM,data:dd6kRHfJ8TjvkqUTCWI=,iv:0dvgYrjch/RcodxvBw+zzOLfcxKdWdSKbTo6pi5tARQ=,tag:RZAJAZOvQTKpl5FIKyb66A==,type:str]
+reverse_proxy_routes:
+    - hostname: ENC[AES256_GCM,data:77hLEs0A1q15LdgOLZvzQpg7XnuQRAX/h2mMXlqiJ/pL,iv:sd/6Qb4DC1Vj4v+mT4ZYsrnAHc7XlyZ+IUfFGrfsoPk=,tag:G4fHPmyYNHygcRqmURc5rg==,type:str]
+      certificate_name: ENC[AES256_GCM,data:0LE02QI=,iv:dYYpIZ90lMJPWRET/HH47MoewZN6xpxjLkCC9DYjqes=,tag:ThHUa3S5GPndBABOp6yYjA==,type:str]
+      backend:
+        transport: ENC[AES256_GCM,data:NmEcGQ==,iv:+yUj54SJOF0J7MBI6Xpzlqvw/j7YYAfARp5di4LFBZ4=,tag:Ii1zSXlIuBgScjwtKojfoQ==,type:str]
+        address: ENC[AES256_GCM,data:Zh7pBpRzun+g7doK,iv:40Q7uRaLOx1z3Q7FmYGbE115M3oEd9XEczxhTI7pzH8=,tag:+Mh4EZSEUVwwLUe9dU8ErA==,type:str]
+        port: ENC[AES256_GCM,data:DOU=,iv:kdfdP34nZzDClSPQJz5TjRB6OcHxxKU00cJfcHShhgQ=,tag:WKt6P3Un6/qB/ZPhq2aiuw==,type:int]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFWjBsc1BQZ3Z6TjBnTC9j
+            SElYcmhuTTlPd2J6YVhheEZNTDM1dFRla0UwCmNxejZPTG0raDNONnZiZWJtV0NF
+            VVFVdHZuYS9maVd2UFJZVjdMbk5iWE0KLS0tIDR1cm1XbVI3T0R2M1Y2VVdVU09q
+            U2tCMzZxamUrbnVCa3g0d1Znd2lvWnMKCHjnJKnHSF3mm0XJPLa7QOje8lu1H9f1
+            8wqovM3Rw4OWOigodeC+vjeSU40Z2YPDTljfOGKwKfr0xKPi4K0WSA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ehm0ehd2v2emfuycf2p0suhg94ej29zcu96ffmh3t6afchhjd99sxc4984
+    encrypted_regex: ^(.*)$
+    lastmodified: "2026-09-10T20:55:41Z"
+    mac: ENC[AES256_GCM,data:J4+LVk4p/xBNUgSZwg8oNF4y+rrcP0JXsEf2EOIVL0L8Y20W5+wdouYlb+YUaPFS+baSZD/5xYwm/zky0ChsZzNBDUdqyynwWB2ec3wSc7NQBBaTZi+SWSzAqlR9D624AM3TBMmOW/fPHm1gJmM1E3t624OUIyrWNqeGXpllM7o=,iv:XN7Fz85avs93D9BnWPP/KQHYn7ZOAyVNjN2DPG3+bJo=,tag:e8aHMI+pW/spY4hRhswUxg==,type:str]
+    version: 3.13.2

--- a/inventory/production/host_vars/nuc4/secrets.sops.yml
+++ b/inventory/production/host_vars/nuc4/secrets.sops.yml
@@ -1,11 +1,11 @@
 tls_automation_namespace: ENC[AES256_GCM,data:CYMQJKvvGor2eedLtx37OqOc3qdAjg==,iv:EwuLSqAGrv1XPBaAbL/qDb1arNclKhnuzWmBOAm6ay8=,tag:TBFHlX/YQdDrihwm4dm/gg==,type:str]
 tls_automation_email: ENC[AES256_GCM,data:QhN2mkYbGYNZVLqB/HKm0DxOzdSCkPs/WOBe,iv:9BiwnSx+FHPboCoKKMNQc9pg/KlI/0O3uX4z8Ct4sos=,tag:GNxr4FXEFBGz2qPNVU2plw==,type:str]
-tls_automation_timer_enabled: ENC[AES256_GCM,data:AyfLgA==,iv:ofSI2BqbEFd94oVUAql3XyP24LZbxJ9TsbPJF9WHFBc=,tag:5RbLU2+J2UDjsXf1bU6HXQ==,type:bool]
+tls_automation_timer_enabled: ENC[AES256_GCM,data:an6DQA==,iv:GcKl8Y4VaPxzPZkYC3PKU5h008NIvK9Z3JqP2swiN5M=,tag:tH8QhUIxbj+SppFgd1UXnQ==,type:bool]
 tls_automation_cloudflare_token: ENC[AES256_GCM,data:GqjLrY/hXXxB3pf/OXDdJ/QXn41ErR817tDke+QjD1Wq3kS9izLG6mvrvjbqVz8TzpOSKcU=,iv:UO61HPiy1Bof19wSq4pdtTDqeHz2MssNvrKan+2MPHg=,tag:tBk35CAkUW3jHc2ehFNrNg==,type:str]
 reverse_proxy_bind_addresses:
     - ENC[AES256_GCM,data:NCKfVKicXQQNz3mvcg==,iv:fUKm1yeO4unnNYNbw1r6IUinMAeK5t2mrqgIwzEcGaA=,tag:mOgh0XsDKQZtI/mIzfvPag==,type:str]
 reverse_proxy_client_sources:
-    - ENC[AES256_GCM,data:dd6kRHfJ8TjvkqUTCWI=,iv:0dvgYrjch/RcodxvBw+zzOLfcxKdWdSKbTo6pi5tARQ=,tag:RZAJAZOvQTKpl5FIKyb66A==,type:str]
+    - ENC[AES256_GCM,data:HRxRfL6awKXIJaYuQZNY,iv:v9NIrBswPePBQizIeCyYbJXv+2Gx1mu4oC64Ny7yMxg=,tag:yW25ZzNVGtuCSes/Q8guiw==,type:str]
 reverse_proxy_routes:
     - hostname: ENC[AES256_GCM,data:77hLEs0A1q15LdgOLZvzQpg7XnuQRAX/h2mMXlqiJ/pL,iv:sd/6Qb4DC1Vj4v+mT4ZYsrnAHc7XlyZ+IUfFGrfsoPk=,tag:G4fHPmyYNHygcRqmURc5rg==,type:str]
       certificate_name: ENC[AES256_GCM,data:0LE02QI=,iv:dYYpIZ90lMJPWRET/HH47MoewZN6xpxjLkCC9DYjqes=,tag:ThHUa3S5GPndBABOp6yYjA==,type:str]
@@ -25,6 +25,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ehm0ehd2v2emfuycf2p0suhg94ej29zcu96ffmh3t6afchhjd99sxc4984
     encrypted_regex: ^(.*)$
-    lastmodified: "2026-09-10T20:55:41Z"
-    mac: ENC[AES256_GCM,data:J4+LVk4p/xBNUgSZwg8oNF4y+rrcP0JXsEf2EOIVL0L8Y20W5+wdouYlb+YUaPFS+baSZD/5xYwm/zky0ChsZzNBDUdqyynwWB2ec3wSc7NQBBaTZi+SWSzAqlR9D624AM3TBMmOW/fPHm1gJmM1E3t624OUIyrWNqeGXpllM7o=,iv:XN7Fz85avs93D9BnWPP/KQHYn7ZOAyVNjN2DPG3+bJo=,tag:e8aHMI+pW/spY4hRhswUxg==,type:str]
+    lastmodified: "2026-09-10T23:47:42Z"
+    mac: ENC[AES256_GCM,data:gUe1v0nBngT96A6DcFOsCnvxd/rr3FvivD8yttmg625/6B9+L8op229Gb7ggrAUGeF7Thc5hpdMFK/DFf95F4LZeex2s1gC4uHrs2qYehr+Yttxlg9SFMw3jCrQMb1u/DB/vsGjEoq2cW3XCWXpfyIjlGPlnLP9Ht3p3cXrLHOM=,iv:736LfGe2Xh5A5co3iCJ38MVAQ3gH88FujjI0mnSqRNw=,tag:kFyUYr8HLvdY59DH+VIcIA==,type:str]
     version: 3.13.2

--- a/playbooks/tls/README.md
+++ b/playbooks/tls/README.md
@@ -84,6 +84,14 @@ capability. The host does not need an age identity for routine renewal.
 
 ## Disabled installation and bootstrap
 
+The issuer uses Cloudflare's public recursive resolver at `1.1.1.1:53` for
+ACME DNS discovery and propagation checks. It checks both recursive and
+authoritative DNS responses. Permit outbound DNS access to that resolver and
+the zone's authoritative nameservers. The host's system resolver and private
+application DNS remain unchanged; local DNS overrides and caches do not control
+the issuer's challenge checks. Public resolver caching can still delay a check;
+inspect the private diagnostic before retrying a failed issuance.
+
 The timer defaults to disabled. A disabled TLS provisioning run requires the
 installed Caddy capability and declared route inputs, but no Cloudflare
 credential. It installs pinned lego 5.4.1, the Python runtime, the real fixed
@@ -99,6 +107,14 @@ and package-owned `caddy:caddy` identity. The root coordinator can write only
 its managed state and transaction roots: `/var/lib/homelab-tls`, `/etc/caddy`,
 and `/var/lib/homelab-reverse-proxy`. The issuer still writes only its private
 ACME state and receives the Cloudflare credential through systemd.
+
+The root coordinator explicitly retains `CAP_SETUID` through
+`AmbientCapabilities` so it can run Caddy validation and reload commands as
+the `caddy` account. Systemd 257 can otherwise drop that capability during
+seccomp setup when `User=root` and `NoNewPrivileges=yes` are combined.
+The switch to Caddy's UID clears ambient capabilities; the Caddy commands
+run without permitted or effective capabilities. Existing sandbox restrictions
+remain enabled.
 
 Use this sequence for the first certificate:
 
@@ -145,6 +161,37 @@ keeps recovery blocked; do not remove the journal to bypass it.
 `status.json` under the private state directory records the current attempt. An
 `in_progress` attempt can indicate an interrupted operation; it is not evidence
 of successful completion. Observational verification does not change status.
+
+If issuance fails, inspect the issuer's private diagnostic on the target host:
+
+```bash
+sudo tail -n 80 /var/lib/homelab-tls-issuer/last-issue.log
+```
+
+Each lego invocation replaces this file and retains only the final 64 KiB of
+combined standard output and standard error. Output is updated while lego runs,
+including before a timeout. The file is owned by `svc-acme`, mode `0600`, inside
+its `0700` state directory; only that account and root can read it. Ansible,
+journald, and the coordinator's status receive no raw lego output. Treat the
+file as sensitive: inspect it locally and redact credentials and infrastructure
+identifiers before sharing an error. Do not attach it to issues or CI artifacts.
+
+Check the file's modification time against the failed attempt. A failure before
+lego starts may leave an older diagnostic or an empty file. Reprovisioning
+installs updated runtime code; it does not rerun issuance. After correcting the
+reported cause, a separately authorized `tls renew` retries through the normal
+coordinator and its recovery checks. Do not invoke lego directly or change the
+service's credential and isolation settings to obtain diagnostics.
+
+If issuance succeeds but publication fails, inspect the coordinator journal:
+
+```bash
+sudo journalctl -u homelab-tls-renew.service --since "5 minutes ago" --no-pager -n 30
+```
+
+The Caddy adapter reports its action and safe validation errors there. Raw
+Caddy output and unclassified exception contents remain suppressed. A successful
+issuance alone does not prove that Caddy has published the certificate.
 
 Keep encrypted backups of `/var/lib/homelab-tls-issuer` ACME account state,
 `/etc/caddy` configuration, trust, certificate and recovery state,

--- a/roles/tls_automation/files/tls_runtime/caddy.py
+++ b/roles/tls_automation/files/tls_runtime/caddy.py
@@ -223,7 +223,7 @@ class Deployment:
             revision = self.binding()
             argv = [ADAPTER, action] + ([] if path is None else [str(path)])
             result = subprocess.run(argv, pass_fds=(9,), stdin=subprocess.DEVNULL,
-                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                    stdout=subprocess.DEVNULL, stderr=None,
                                     cwd='/', timeout=900, check=False,
                                     env={'PATH': '/usr/sbin:/usr/bin:/sbin:/bin', 'LANG': 'C', 'LC_ALL': 'C', 'HOME': '/'})
             if result.returncode == RESTART_EXIT:
@@ -231,7 +231,7 @@ class Deployment:
                 # Startup restored disk authority. The same fixed action now
                 # verifies restoration; it cannot silently activate another revision.
                 result = subprocess.run(argv, pass_fds=(9,), stdin=subprocess.DEVNULL,
-                                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                        stdout=subprocess.DEVNULL, stderr=None,
                                         cwd='/', timeout=900, check=False,
                                         env={'PATH': '/usr/sbin:/usr/bin:/sbin:/bin', 'LANG': 'C', 'LC_ALL': 'C', 'HOME': '/'})
             if result.returncode:
@@ -267,10 +267,12 @@ def main(arguments=None):
     if not (args in (['reload'], ['deactivate']) or len(args) == 2 and args[0] == 'validate'):
         print('usage: homelab-tls-caddy {validate PATH|reload|deactivate}', file=sys.stderr)
         return 2
+    module = None
     try:
         if os.geteuid() != 0:
             raise ValueError('TLS integration requires root')
-        activator = activation_module().Activator()
+        module = activation_module()
+        activator = module.Activator()
         with activator.locked(inherited=True):
             integration = Integration(activator)
             if args[0] == 'validate':
@@ -280,6 +282,12 @@ def main(arguments=None):
         return 0
     except RestartNeeded:
         return RESTART_EXIT
-    except Exception:
-        print('TLS Caddy integration failed; inspect private transaction state', file=sys.stderr)
+    except Exception as error:
+        # ActivationError explicitly contains only safe, repository-owned
+        # diagnostics. Other exceptions can contain protected input values.
+        # HostCommands still discards raw Caddy and OpenSSL stderr.
+        if module is not None and isinstance(error, module.ActivationError):
+            print(f'TLS Caddy {args[0]} failed: {error}', file=sys.stderr)
+        else:
+            print('TLS Caddy integration failed; inspect private transaction state', file=sys.stderr)
         return 1

--- a/roles/tls_automation/files/tls_runtime/runtime.py
+++ b/roles/tls_automation/files/tls_runtime/runtime.py
@@ -8,12 +8,14 @@ import os
 from pathlib import Path
 import pwd
 import re
+import selectors
 import socket
 import ssl
 import stat
 import subprocess
 import sys
 import tempfile
+import time
 
 from .certificates import validate_certificate, validate_historical_certificate
 from .policy import (
@@ -77,6 +79,7 @@ UNIT_CONTRACTS = {
         "SupplementaryGroups": "",
         "Type": "oneshot",
         "NoNewPrivileges": "yes",
+        "AmbientCapabilities": "cap_setuid",
         "ProtectSystem": "strict",
         "PrivateTmp": "yes",
         "ReadWritePaths": str(STATE) + " /etc/caddy /var/lib/homelab-reverse-proxy",
@@ -98,6 +101,72 @@ def run_fixed(argv, timeout=60, environment=None, capture=False):
     if result.returncode:
         raise RuntimeError("fixed host operation failed")
     return result.stdout if capture else None
+
+
+def run_issuer(argv, timeout=900, environment=None):
+    """Keep a bounded private output tail; never relay child output to callers."""
+    directory = os.open(ISSUER_STATE, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        info = os.fstat(directory)
+        if info.st_uid != os.geteuid() or stat.S_IMODE(info.st_mode) != 0o700:
+            raise ValueError("expected private issuer diagnostic directory")
+        require_no_named_access_acl(directory)
+        require_no_default_acl(directory)
+        descriptor, temporary = tempfile.mkstemp(prefix=".last-issue-", dir=ISSUER_STATE)
+        try:
+            with os.fdopen(descriptor, "w+b", buffering=0) as diagnostic:
+                os.fchmod(diagnostic.fileno(), 0o600)
+                require_no_named_access_acl(diagnostic.fileno())
+                # Replace rather than truncate an existing path, which may be a link.
+                os.replace(temporary, "last-issue.log", dst_dir_fd=directory)
+                deadline = time.monotonic() + timeout
+                with subprocess.Popen(argv, stdin=subprocess.DEVNULL,
+                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                      env=environment or CLEAN_ENV, cwd="/") as process:
+                    try:
+                        tail = b""
+                        timed_out = False
+                        os.set_blocking(process.stdout.fileno(), False)
+                        with selectors.DefaultSelector() as selector:
+                            selector.register(process.stdout, selectors.EVENT_READ)
+                            while selector.get_map():
+                                remaining = deadline - time.monotonic()
+                                if remaining <= 0 and not timed_out:
+                                    timed_out = True
+                                    if process.poll() is None:
+                                        process.kill()
+                                    process.wait()
+                                # After termination, retain bytes already in the pipe.
+                                # Do not wait for a descriptor inherited by another process.
+                                if not selector.select(0 if timed_out else min(remaining, 0.2)):
+                                    if timed_out:
+                                        break
+                                    continue
+                                chunk = os.read(process.stdout.fileno(), 8192)
+                                if not chunk:
+                                    selector.unregister(process.stdout)
+                                    break
+                                tail = (tail + chunk)[-65536:]
+                                diagnostic.seek(0)
+                                diagnostic.write(tail)
+                                diagnostic.truncate()
+                        if timed_out:
+                            raise RuntimeError("issuer timed out; inspect private diagnostic")
+                        try:
+                            code = process.wait(timeout=max(0, deadline - time.monotonic()))
+                        except subprocess.TimeoutExpired:
+                            raise RuntimeError("issuer timed out; inspect private diagnostic") from None
+                        if code:
+                            raise RuntimeError(f"issuer exited with code {code}; inspect private diagnostic")
+                    finally:
+                        if process.poll() is None:
+                            process.kill()
+                        process.wait()
+        finally:
+            if os.path.lexists(temporary):
+                os.unlink(temporary)
+    finally:
+        os.close(directory)
 
 
 def _descriptor_read_only(descriptor):
@@ -262,6 +331,7 @@ def issuer_command(policy):
             "--server", "https://acme-v02.api.letsencrypt.org/directory",
             "--path", str(ISSUER_STATE), "--cert.name", "caddy",
             "--domains", policy.sans[0], "--dns", "cloudflare", "--force-cert-domains",
+            "--dns.resolvers", "1.1.1.1:53",
             "--no-random-sleep", "--ari-wait-to-renew-duration", "0s", "--http-timeout", "30"]
 
 
@@ -273,7 +343,7 @@ def issue(policy):
     secure_path(ISSUER_STATE, account.pw_uid, directory=True)
     validate_runtime_credential(Path(TOKEN_RUNTIME), account.pw_uid, account.pw_gid)
     environment = dict(CLEAN_ENV, CF_DNS_API_TOKEN_FILE=TOKEN_RUNTIME)
-    run_fixed(issuer_command(policy), timeout=900, environment=environment)
+    run_issuer(issuer_command(policy), timeout=900, environment=environment)
 
 
 def inspect_host(policy):
@@ -547,7 +617,7 @@ def renew_attempt():
     result.update(reconcile(publisher, start_issuer, snapshot, publisher.publication_context))
     failed = result["issuance"] == "failed" or result["publication"] == "failed"
     result["attempt"] = "failed" if failed else "completed"
-    # Only fixed phase outcomes are recorded; subprocess output is never stored.
+    # Status contains only fixed phase outcomes, never private issuer output.
     write_status(result)
     print(json.dumps(result, sort_keys=True))
     return int(failed)
@@ -583,4 +653,7 @@ def main(action, arguments=None):
         return 0
     except (OSError, ValueError, KeyError, RuntimeError, subprocess.SubprocessError):
         print("TLS " + action + " failed; inspect configuration, unit metadata and phase status", file=sys.stderr)
+        if action == "issue":
+            print("If lego started, inspect /var/lib/homelab-tls-issuer/last-issue.log locally; "
+                  "it may contain sensitive output", file=sys.stderr)
         return 1

--- a/roles/tls_automation/filter_plugins/validation.py
+++ b/roles/tls_automation/filter_plugins/validation.py
@@ -49,6 +49,7 @@ _UNITS = {
         "ExecStartPost": "",
         "LoadCredential": "",
         "NoNewPrivileges": "yes",
+        "AmbientCapabilities": "cap_setuid",
         "ProtectSystem": "strict",
         "PrivateTmp": "yes",
         "ReadWritePaths": "/var/lib/homelab-tls /etc/caddy /var/lib/homelab-reverse-proxy",
@@ -321,6 +322,11 @@ def validate_units(value: object, allow_absent: object, array_value: object) -> 
                   and properties.get(key) == "/var/lib/homelab-tls"):
                 # Preflight permits upgrading only the earlier canonical,
                 # narrower sandbox. Installed-unit verification stays strict.
+                continue
+            elif (allow_absent and name == "homelab-tls-renew.service"
+                  and key == "AmbientCapabilities" and properties.get(key) == ""):
+                # Provision may upgrade the previous unit, but renewal and
+                # post-install verification require the UID-switch capability.
                 continue
             elif properties.get(key) != expected_value:
                 raise ValueError(f"{name} has an unexpected {key} property")

--- a/roles/tls_automation/tasks/inspect-units.yml
+++ b/roles/tls_automation/tasks/inspect-units.yml
@@ -15,6 +15,7 @@
       - --property=Type
       - --property=ExecStart
       - --property=NoNewPrivileges
+      - --property=AmbientCapabilities
       - --property=ProtectSystem
       - --property=PrivateTmp
       - --property=ReadWritePaths

--- a/roles/tls_automation/templates/homelab-tls-renew.service.j2
+++ b/roles/tls_automation/templates/homelab-tls-renew.service.j2
@@ -10,6 +10,9 @@ Group=root
 SupplementaryGroups=
 ExecStart=/usr/local/libexec/homelab-tls-reconcile
 NoNewPrivileges=yes
+# Retain the coordinator's ability to drop to Caddy's UID after systemd's
+# seccomp setup. The root-to-Caddy UID switch clears ambient capabilities.
+AmbientCapabilities=CAP_SETUID
 PrivateTmp=yes
 PrivateDevices=yes
 ProtectSystem=strict

--- a/scripts/ci/classify.py
+++ b/scripts/ci/classify.py
@@ -87,6 +87,12 @@ def classify_path(path: str) -> tuple[str, str]:
         return "full", "dependency automation changes require full validation"
     if _has_prefix(path, ("scripts/repository/", "tests/repository/")):
         return "full", "GitHub protection tooling changes require full validation"
+    if path.startswith("tests/tls/") or path in {
+        "tests/ansible/test_tls_role.py",
+        "tests/ansible/test_tls_proxy_policy.py",
+        "tests/ansible/test_tls_fixture_material.py",
+    }:
+        return "molecule", "TLS tests require baseline and proxy container validation"
     if _has_prefix(
         path,
         ("scripts/ci/", "tests/ci/", "tests/ansible/", "tests/toolchain/"),

--- a/scripts/ci/molecule-impact.json
+++ b/scripts/ci/molecule-impact.json
@@ -31,6 +31,12 @@
       "reason": "baseline and proxy scenarios exercise proxy and TLS integration"
     },
     {
+      "prefixes": ["tests/tls/"],
+      "paths": ["tests/ansible/test_tls_role.py", "tests/ansible/test_tls_proxy_policy.py", "tests/ansible/test_tls_fixture_material.py"],
+      "selectors": ["system_maintenance/baseline", "reverse_proxy/default"],
+      "reason": "TLS tests cover runtime, policy, and fixtures consumed by baseline and proxy scenarios"
+    },
+    {
       "prefixes": ["roles/reverse_proxy/molecule/default/"],
       "selectors": ["reverse_proxy/default"],
       "reason": "proxy scenario coverage"

--- a/scripts/ci/molecule_plan.py
+++ b/scripts/ci/molecule_plan.py
@@ -25,24 +25,29 @@ def _load_rules(path: Path) -> list[dict]:
     if not isinstance(rules, list) or not rules:
         raise ValueError("empty impact map")
     for rule in rules:
-        if not isinstance(rule, dict) or set(rule) != {
-            "prefixes",
-            "selectors",
-            "reason",
-        }:
-            raise ValueError("invalid impact rule")
-        prefixes, selectors = rule["prefixes"], rule["selectors"]
         if (
-            not isinstance(prefixes, list)
-            or not prefixes
-            or any(
-                not isinstance(prefix, str)
-                or not classify._valid_relative_path(prefix)
-                or not prefix.endswith("/")
-                for prefix in prefixes
-            )
+            not isinstance(rule, dict)
+            or not {"selectors", "reason"} <= set(rule)
+            or set(rule) - {"prefixes", "paths", "selectors", "reason"}
+            or not {"prefixes", "paths"} & set(rule)
         ):
-            raise ValueError("invalid impact prefixes")
+            raise ValueError("invalid impact rule")
+        selectors = rule["selectors"]
+        for key in ("prefixes", "paths"):
+            if key not in rule:
+                continue
+            matchers = rule[key]
+            if (
+                not isinstance(matchers, list)
+                or not matchers
+                or any(
+                    not isinstance(matcher, str)
+                    or not classify._valid_relative_path(matcher)
+                    or matcher.endswith("/") != (key == "prefixes")
+                    for matcher in matchers
+                )
+            ):
+                raise ValueError(f"invalid impact {key}")
         if selectors != "all" and (
             not isinstance(selectors, list)
             or not selectors
@@ -101,7 +106,7 @@ def build_plan(result: dict, *, map_path: Path = MAP_PATH) -> dict:
         matches = [
             (len(prefix), rule)
             for rule in rules
-            for prefix in rule["prefixes"]
+            for prefix in rule.get("prefixes", [])
             if path.startswith(prefix)
         ]
         if "/molecule/" in path:
@@ -116,6 +121,14 @@ def build_plan(result: dict, *, map_path: Path = MAP_PATH) -> dict:
                 and parts[2] == "molecule"
                 and length >= len(scenario_prefix)
             ]
+        else:
+            # Exact files outrank directory rules. They cannot replace the
+            # explicit directory declaration required for a Molecule scenario.
+            matches.extend(
+                (len(path) + 1, rule)
+                for rule in rules
+                if path in rule.get("paths", [])
+            )
         if not matches:
             full_reasons.append(f"{path}: unmapped Molecule impact")
             continue

--- a/tests/ansible/test_tls_role.py
+++ b/tests/ansible/test_tls_role.py
@@ -29,6 +29,7 @@ def registered_units(absent=False, omit_arrays=False):
         if not absent and unit.endswith("service"):
             command = "/usr/local/libexec/homelab-tls-" + ("issue" if user == "svc-acme" else "reconcile")
             properties.update(User=user, Group=user, SupplementaryGroups="", Type="oneshot",
+                              AmbientCapabilities="cap_setuid" if user == "root" else "",
                               NoNewPrivileges="yes", ProtectSystem="strict", PrivateTmp="yes",
                               ReadWritePaths=path, TimeoutStartUSec=timeout,
                               LoadCredential="cloudflare-token:/etc/homelab-tls/cloudflare-token" if user == "svc-acme" else "",
@@ -59,6 +60,19 @@ def registered_arrays(absent=False):
 
 
 class RoleUnitTests(unittest.TestCase):
+    def test_renewal_ambient_capability_is_exact_with_preflight_upgrade(self):
+        for capability in ('', 'cap_setuid', 'cap_setuid cap_net_admin'):
+            for preflight in (True, False):
+                value = registered_units()
+                value['results'][1]['stdout'] = value['results'][1]['stdout'].replace(
+                    'AmbientCapabilities=cap_setuid', 'AmbientCapabilities=' + capability)
+                with self.subTest(capability=capability, preflight=preflight):
+                    if capability == 'cap_setuid' or (preflight and capability == ''):
+                        self.assertTrue(validation.validate_units(value['results'], preflight, registered_arrays()['results']))
+                    else:
+                        with self.assertRaises(ValueError):
+                            validation.validate_units(value['results'], preflight, registered_arrays()['results'])
+
     def test_previous_canonical_write_scope_can_upgrade_only_in_preflight(self):
         value = registered_units()
         value["results"][1]["stdout"] = value["results"][1]["stdout"].replace(
@@ -232,6 +246,7 @@ class RoleUnitTests(unittest.TestCase):
         self.assertIn('User=', directives)
         production = (ROLE / 'templates/homelab-tls-renew.service.j2').read_text().splitlines()
         for directive in ('User=root', 'Group=root', 'SupplementaryGroups=', 'NoNewPrivileges=yes',
+                          'AmbientCapabilities=CAP_SETUID',
                           'PrivateDevices=yes', 'ProtectKernelTunables=yes', 'ProtectKernelModules=yes',
                           'LockPersonality=yes', 'RestrictSUIDSGID=yes',
                           'RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6'):

--- a/tests/ci/test_molecule_plan.py
+++ b/tests/ci/test_molecule_plan.py
@@ -23,6 +23,20 @@ class MoleculePlanTests(unittest.TestCase):
         consumers = {"system_maintenance/baseline", "reverse_proxy/default"}
         all_scenarios = maintenance | consumers
         cases = [
+            *[
+                ([path], consumers, "selective")
+                for path in (
+                    "tests/tls/test_runtime.py",
+                    "tests/tls/cert_fixtures.py",
+                    "tests/ansible/test_tls_role.py",
+                    "tests/ansible/test_tls_proxy_policy.py",
+                    "tests/ansible/test_tls_fixture_material.py",
+                )
+            ],
+            (["tests/tls/test_runtime.py", "scripts/ci/classify.py"], all_scenarios, "full"),
+            (["tests/ansible/test_tls_role.py.bak"], all_scenarios, "full"),
+            (["tests/ansible/test_tls_future.py"], all_scenarios, "full"),
+            (["tests/tls_extra/test_runtime.py"], all_scenarios, "full"),
             (
                 ["roles/system_maintenance/molecule/default/verify.yml"],
                 {"system_maintenance/default"},
@@ -111,6 +125,8 @@ class MoleculePlanTests(unittest.TestCase):
     def test_union_and_reasons_are_deterministic(self):
         paths = [
             "roles/tls_automation/tasks/main.yml",
+            "tests/tls/test_runtime.py",
+            "tests/ansible/test_tls_role.py",
             "roles/system_maintenance/tasks/main.yml",
         ]
         plan = self.plan(paths)
@@ -146,7 +162,7 @@ class MoleculePlanTests(unittest.TestCase):
         document["rules"] = [
             rule
             for rule in document["rules"]
-            if "roles/reverse_proxy/molecule/default/" not in rule["prefixes"]
+            if "roles/reverse_proxy/molecule/default/" not in rule.get("prefixes", [])
         ]
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "map.json"
@@ -182,6 +198,64 @@ class MoleculePlanTests(unittest.TestCase):
                     )
                     self.assertEqual("full", plan["mode"])
                     self.assertEqual(6, len(plan["matrix"]["include"]))
+
+    def test_exact_paths_override_prefixes_without_matching_other_files(self):
+        import molecule_plan
+
+        target = "tests/tls/test_runtime.py"
+        rules = [
+            {"prefixes": ["tests/tls/"], "selectors": "all", "reason": "shared"},
+            {"paths": [target], "selectors": ["reverse_proxy/default"], "reason": "proxy"},
+            {"paths": [target], "selectors": ["system_maintenance/baseline"], "reason": "baseline"},
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            path.write_text(json.dumps({"rules": rules}))
+            result = classify.classify_paths([target])
+            plan = molecule_plan.build_plan(result, map_path=path)
+            self.assertEqual("selective", plan["mode"])
+            self.assertEqual(4, len(plan["matrix"]["include"]))
+            path.write_text(json.dumps({"rules": list(reversed(rules))}))
+            self.assertEqual(plan, molecule_plan.build_plan(result, map_path=path))
+            for other in (target + ".bak", "tests/tls/test_policy.py"):
+                with self.subTest(other=other):
+                    self.assertEqual("full", molecule_plan.build_plan(
+                        classify.classify_paths([other]), map_path=path)["mode"])
+
+    def test_invalid_matchers_fail_closed(self):
+        import molecule_plan
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            for matchers in (
+                {}, {"paths": []}, {"paths": "tests/tls/test_runtime.py"},
+                {"paths": [None]}, {"paths": ["../outside.py"]},
+                {"paths": ["/absolute.py"]}, {"paths": ["tests/tls/"]},
+                {"prefixes": []}, {"prefixes": ["tests/tls"]},
+                {"paths": ["tests/tls/test_runtime.py"], "unknown": True},
+            ):
+                with self.subTest(matchers=matchers):
+                    path.write_text(json.dumps({"rules": [{
+                        **matchers, "selectors": ["reverse_proxy/default"], "reason": "test"
+                    }]}))
+                    plan = molecule_plan.build_plan(
+                        classify.classify_paths(["tests/tls/test_runtime.py"]), map_path=path)
+                    self.assertEqual("full", plan["mode"])
+                    self.assertEqual(6, len(plan["matrix"]["include"]))
+
+    def test_exact_file_cannot_declare_a_new_scenario(self):
+        import molecule_plan
+
+        target = "roles/reverse_proxy/molecule/future/verify.yml"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            path.write_text(json.dumps({"rules": [{
+                "prefixes": ["roles/reverse_proxy/"], "paths": [target],
+                "selectors": ["reverse_proxy/default"], "reason": "proxy"
+            }]}))
+            plan = molecule_plan.build_plan(classify.classify_paths([target]), map_path=path)
+            self.assertEqual("full", plan["mode"])
+            self.assertEqual(6, len(plan["matrix"]["include"]))
 
     def test_merge_gate_checks_plan_completeness(self):
         import merge_gate

--- a/tests/tls/test_integration.py
+++ b/tests/tls/test_integration.py
@@ -1,5 +1,7 @@
 """Joint publication recovery uses the real Publisher journal and filesystem."""
 import json
+import io
+from contextlib import nullcontext, redirect_stderr
 from pathlib import Path
 import unittest
 
@@ -58,6 +60,38 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'ansible'))
 from test_reverse_proxy_activation import ActivationFixture
 import test_reverse_proxy_activation as proxy_tests
+
+
+class AdapterDiagnosticTests(unittest.TestCase):
+    def test_safe_activation_failure_reaches_operator(self):
+        from tls_runtime import caddy
+        module = proxy_tests.load_activation()
+        activator = mock.Mock()
+        activator.locked.return_value = nullcontext()
+        output = io.StringIO()
+        with mock.patch.object(caddy, 'activation_module', return_value=module), \
+                mock.patch.object(module, 'Activator', return_value=activator), \
+                mock.patch.object(caddy.os, 'geteuid', return_value=0), \
+                mock.patch.object(caddy, 'Integration') as integration, redirect_stderr(output):
+            integration.return_value.validate_candidate.side_effect = module.ActivationError(
+                'external certificate is not currently valid')
+            self.assertEqual(1, caddy.main(['validate', '/synthetic/candidate']))
+        self.assertIn('TLS Caddy validate failed: external certificate is not currently valid', output.getvalue())
+
+    def test_unclassified_failure_does_not_expose_exception_contents(self):
+        from tls_runtime import caddy
+        module = proxy_tests.load_activation()
+        activator = mock.Mock()
+        activator.locked.return_value = nullcontext()
+        output = io.StringIO()
+        with mock.patch.object(caddy, 'activation_module', return_value=module), \
+                mock.patch.object(module, 'Activator', return_value=activator), \
+                mock.patch.object(caddy.os, 'geteuid', return_value=0), \
+                mock.patch.object(caddy, 'Integration') as integration, redirect_stderr(output):
+            integration.return_value.validate_candidate.side_effect = ValueError('synthetic-private-value')
+            self.assertEqual(1, caddy.main(['validate', '/synthetic/candidate']))
+        self.assertNotIn('synthetic-private-value', output.getvalue())
+        self.assertIn('TLS Caddy integration failed', output.getvalue())
 
 
 class AdapterFixture(ActivationFixture):
@@ -164,6 +198,26 @@ class AdapterTests(AdapterFixture):
             self.publisher.publish(b'certificate-one', b'private-key-one')
         self.assertTrue(failure.exception.restoration_failed)
         self.assertTrue(self.publisher._read_journal()['caddy']['restart'])
+
+    def test_adapter_diagnostics_reach_journal_on_initial_and_retry_calls(self):
+        from tls_runtime import caddy
+        from types import SimpleNamespace
+        deployment = caddy.Deployment(self.activation, SimpleNamespace(
+            reader_gid=os.getgid(), endpoints=[{
+                'hostname': 'app.infra.example.com', 'address': '10.20.30.40', 'port': 443}]))
+        for outcomes in ([1], [caddy.RESTART_EXIT, 1]):
+            with self.subTest(outcomes=outcomes), deployment.locked(), \
+                    mock.patch.object(caddy.subprocess, 'run', side_effect=[
+                        SimpleNamespace(returncode=code) for code in outcomes]) as run, \
+                    mock.patch.object(deployment, 'restart'), \
+                    self.assertRaisesRegex(RuntimeError, 'fixed Caddy integration operation failed'):
+                try:
+                    deployment.operation('reload')
+                finally:
+                    self.assertEqual(len(outcomes), run.call_count)
+                    for call in run.call_args_list:
+                        self.assertIsNone(call.kwargs['stderr'])
+                        self.assertEqual(caddy.subprocess.DEVNULL, call.kwargs['stdout'])
 
     def test_inherited_fd9_is_exclusive_and_wrong_inode_is_rejected(self):
         from tls_runtime import caddy

--- a/tests/tls/test_runtime.py
+++ b/tests/tls/test_runtime.py
@@ -1,5 +1,7 @@
 """Fixed host operations and independent local TLS handshake evidence."""
 from contextlib import nullcontext
+from contextlib import redirect_stderr, redirect_stdout
+import io
 import errno
 import hashlib
 import json
@@ -11,6 +13,7 @@ import stat
 import struct
 import sys
 import tempfile
+import time
 import threading
 from types import SimpleNamespace
 import unittest
@@ -44,6 +47,28 @@ def _named_acl_on(path, attribute="system.posix_acl_access"):
 
 
 class RuntimeTests(unittest.TestCase):
+    def test_renewal_requires_exact_effective_ambient_capability(self):
+        contract = runtime.UNIT_CONTRACTS[runtime.RENEW_UNIT]
+        self.assertEqual('cap_setuid', contract['AmbientCapabilities'])
+        typed = b'a(sasbttttuii) 0\na(sasbttttuii) 0\na(sasbttttuii) 0\na(ss) 0\n'
+        fragment = SimpleNamespace(st_mode=stat.S_IFREG | 0o644, st_gid=0)
+        for capability in ('cap_setuid', '', 'cap_setuid cap_net_admin', None):
+            actual = dict(contract)
+            command = actual['ExecStart']
+            actual['ExecStart'] = '{ path=' + command + ' ; argv[]=' + command + ' ; ignore_errors=no }'
+            actual['AmbientCapabilities'] = capability
+            if capability is None:
+                del actual['AmbientCapabilities']
+            raw = '\n'.join(key + '=' + value for key, value in actual.items()).encode()
+            with self.subTest(capability=capability), \
+                    patch.object(runtime, 'run_fixed', side_effect=[raw, typed]), \
+                    patch.object(runtime, 'secure_path', return_value=fragment):
+                if capability == 'cap_setuid':
+                    runtime.inspect_unit(runtime.RENEW_UNIT, contract)
+                else:
+                    with self.assertRaises(ValueError):
+                        runtime.inspect_unit(runtime.RENEW_UNIT, contract)
+
     def setUp(self):
         self.policy = parse_policy(json.dumps(example_policy()).encode())
 
@@ -51,8 +76,10 @@ class RuntimeTests(unittest.TestCase):
         command = runtime.issuer_command(self.policy)
         self.assertEqual(command[:2], ["/usr/local/libexec/lego-5.4.1", "run"])
         for flag, value in [("--domains", "*.infra.example.com"), ("--dns", "cloudflare"),
+                            ("--dns.resolvers", "1.1.1.1:53"),
                             ("--cert.name", "caddy"), ("--path", "/var/lib/homelab-tls-issuer"),
                             ("--server", "https://acme-v02.api.letsencrypt.org/directory")]:
+            self.assertIn(flag, command)
             self.assertEqual(command[command.index(flag) + 1], value)
         self.assertIn("--force-cert-domains", command)
         for forbidden in ["--renew-force", "--renew-days", "--ari-disable", "--deploy-hook"]:
@@ -255,7 +282,7 @@ class RuntimeTests(unittest.TestCase):
             runtime.os, "geteuid", return_value=2010
         ), patch.object(runtime, "secure_path"), patch.object(
             runtime, "validate_runtime_credential"
-        ) as credential, patch.object(runtime, "run_fixed") as run:
+        ) as credential, patch.object(runtime, "run_issuer") as run:
             runtime.issue(self.policy)
 
         credential.assert_called_once_with(Path(runtime.TOKEN_RUNTIME), 2010, 2010)
@@ -739,6 +766,100 @@ class StatusDirectoryBoundaryTests(unittest.TestCase):
         with patch.object(runtime, "secure_path"), patch.object(
                 runtime, "_directory_without_extra_acl", side_effect=ValueError("named ACL")), self.assertRaises(ValueError):
             runtime.validate_status_directory()
+
+
+class IssuerDiagnosticTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.log = self.directory / "last-issue.log"
+        state = patch.object(runtime, "ISSUER_STATE", self.directory)
+        state.start()
+        self.addCleanup(state.stop)
+
+    def run_script(self, script, timeout=5):
+        self.assertTrue(callable(getattr(runtime, "run_issuer", None)),
+                        "issuer output must have a protected diagnostic runner")
+        return runtime.run_issuer([sys.executable, "-c", script],
+                                  environment=runtime.CLEAN_ENV, timeout=timeout)
+
+    def test_failed_child_keeps_both_streams_private_and_preserves_failure(self):
+        output, errors = io.StringIO(), io.StringIO()
+        with redirect_stdout(output), redirect_stderr(errors):
+            with self.assertRaisesRegex(RuntimeError, "issuer exited with code 7") as caught:
+                self.run_script("import sys; print('synthetic stdout'); "
+                                "print('synthetic private error', file=sys.stderr); sys.exit(7)")
+        self.assertEqual("", output.getvalue() + errors.getvalue())
+        self.assertNotIn("synthetic", str(caught.exception))
+        self.assertIn(b"synthetic stdout", self.log.read_bytes())
+        self.assertIn(b"synthetic private error", self.log.read_bytes())
+        self.assertEqual(0o600, stat.S_IMODE(self.log.stat().st_mode))
+        self.assertEqual(os.geteuid(), self.log.stat().st_uid)
+
+    def test_only_latest_attempt_and_last_64_kib_are_retained(self):
+        self.run_script("print('previous attempt')")
+        self.run_script("import os; os.write(1, b'x' * 200000 + b'END')")
+        self.assertEqual(b"x" * (65536 - 3) + b"END", self.log.read_bytes())
+        self.assertEqual([self.log], list(self.directory.iterdir()))
+
+    def test_timeout_keeps_partial_output_and_stops_child(self):
+        started = time.monotonic()
+        with self.assertRaisesRegex(RuntimeError, "issuer timed out"):
+            self.run_script("import os,time; print('started', os.getpid(), flush=True); "
+                            "time.sleep(30)", timeout=0.5)
+        self.assertLess(time.monotonic() - started, 5)
+        words = self.log.read_text().split()
+        self.assertEqual("started", words[0])
+        with self.assertRaises(ProcessLookupError):
+            os.kill(int(words[1]), 0)
+
+    def test_closed_output_does_not_bypass_timeout(self):
+        with self.assertRaisesRegex(RuntimeError, "issuer timed out"):
+            self.run_script("import os,time; os.close(1); os.close(2); time.sleep(30)", timeout=0.5)
+
+    def test_timeout_drains_output_already_buffered_before_deadline(self):
+        ready = self.directory / "ready"
+        clock = time.monotonic
+
+        def expired_after_child_writes():
+            deadline = clock() + 5
+            while not ready.exists():
+                if clock() >= deadline:
+                    self.fail("fixture did not write its diagnostic")
+                time.sleep(0.01)
+            return 100
+
+        clock_first = [True]
+
+        def advance_clock():
+            if clock_first[0]:
+                clock_first[0] = False
+                return 0
+            return expired_after_child_writes()
+
+        with patch.object(runtime.time, "monotonic", side_effect=advance_clock):
+            with self.assertRaisesRegex(RuntimeError, "issuer timed out"):
+                self.run_script("import os,time; from pathlib import Path; "
+                                "os.write(2, b'final buffered diagnostic'); "
+                                f"Path({str(ready)!r}).touch(); time.sleep(30)", timeout=1)
+        self.assertEqual(b"final buffered diagnostic", self.log.read_bytes())
+
+    def test_log_symlink_is_replaced_without_touching_target(self):
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "keep"
+            target.write_text("keep")
+            self.log.symlink_to(target)
+            self.run_script("print('new diagnostic')")
+            self.assertEqual("keep", target.read_text())
+            self.assertFalse(self.log.is_symlink())
+            self.assertEqual(b"new diagnostic\n", self.log.read_bytes())
+
+    def test_public_directory_is_rejected_before_child_runs(self):
+        self.directory.chmod(0o755)
+        with self.assertRaisesRegex(ValueError, "private issuer diagnostic directory"):
+            self.run_script("raise SystemExit(0)")
+        self.assertFalse(self.log.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Room Alert now uses the shared private Caddy proxy with an HTTP backend and a SOPS-protected route. TLS renewal uses an explicit public resolver for DNS-01 checks and preserves the capability needed to validate Caddy configuration as its service user inside the renewal sandbox.

Issuance keeps a bounded, protected diagnostic log, and reconciliation reports the failing publication operation in the journal. The device guide and TLS specification describe deployment, verification, and troubleshooting.

A separate commit narrows future TLS-only CI selection to the baseline and reverse-proxy scenarios on Debian 13 and Rocky Linux 9. Exact-file impact entries cover the three TLS-specific Ansible tests without narrowing the rest of that test directory. Invalid maps, unknown impact, and changes to CI selection still require the complete suite. This PR selects all six Molecule jobs.

Validation:

- After rebasing onto the deterministic CI changes: bootstrap, fast validation, and Ansible validation passed for the Room Alert fix.
- After the mapping change: all 145 focused CI tests passed; candidate whitespace and Gitleaks safeguards passed.
- The change-directed dry-run selected full validation. Full local CI was skipped at the operator's request; GitHub CI supplies the required container evidence.
- Live troubleshooting confirmed successful certificate issuance and publication, backend HTTP access, and proxy HTTPS access. The operator confirmed browser access works.

Remaining operator acceptance checks include the full device login/navigation/sensor workflow, intended network access, and route rollback. These are separate from offline CI evidence.

Refs #31. Keep the issue open until the remaining live acceptance checks are confirmed.
