### PR TITLE
Fix Caddy startup recovery after delayed network addressing

### DIFF
--- a/docs/specs/008-shared-private-reverse-proxy.md
+++ b/docs/specs/008-shared-private-reverse-proxy.md
@@ -376,7 +376,8 @@ loopback address inside the container network namespace. The startup regression
 first proves an absent-address bind failure, then adds the address and requires
 automatic recovery with trusted HTTPS. A second persistent failure uses the
 installed retry count and window with only the fixture retry delay shortened;
-it must reach `start-limit-hit`. Cleanup restores configuration, removes the
+it must stop retrying at the configured limit, with no running process and a
+journal record confirming that the start limit was reached. Cleanup restores configuration, removes the
 temporary address and delay override, clears test failure state, and starts the
 original fixture service. These checks do not perform a physical host reboot.
 These capabilities belong to the rootless test container; the

--- a/docs/specs/008-shared-private-reverse-proxy.md
+++ b/docs/specs/008-shared-private-reverse-proxy.md
@@ -245,6 +245,16 @@ authoritative recovery data.
 
 ## Configuration activation and failure behavior
 
+The managed Caddy unit requests and orders itself after `network-online.target`.
+That target is not proof that a private DHCP address is already assigned. Use
+`Restart=on-failure` with `RestartSec=10s`, `StartLimitIntervalSec=300s`, and
+`StartLimitBurst=12`. This permits recovery after a transient bind failure while
+leaving repeated immediate failures in a failed state after the start budget is
+exhausted. This is a start-rate limit, not a lifetime retry count.
+Explicit stops remain stopped. The observer verifies these effective properties.
+Recovery after correcting a persistent fault can clear the budget with an
+authorized `systemctl reset-failed caddy.service` before starting the service.
+
 Provide one root-owned activation helper used by Ansible. It accepts only the
 managed candidate path and fixed service paths, not arbitrary shell commands.
 Stage candidates on the same filesystem as the managed configuration and use
@@ -361,6 +371,14 @@ adapter from switching to the Caddy user. The early probe verifies effective
 root identity and a successful unprivileged user switch, and the integrated
 driver independently checks its root identity. The remaining sandbox settings
 stay in place; production units retain their explicit service identities.
+The proxy fixtures additionally grant `NET_ADMIN` to add and remove one synthetic
+loopback address inside the container network namespace. The startup regression
+first proves an absent-address bind failure, then adds the address and requires
+automatic recovery with trusted HTTPS. A second persistent failure uses the
+installed retry count and window with only the fixture retry delay shortened;
+it must reach `start-limit-hit`. Cleanup restores configuration, removes the
+temporary address and delay override, clears test failure state, and starts the
+original fixture service. These checks do not perform a physical host reboot.
 These capabilities belong to the rootless test container; the
 managed Caddy service still receives only `CAP_NET_BIND_SERVICE`, and the
 production coordinator restrictions remain unchanged.

--- a/playbooks/reverse-proxy/README.md
+++ b/playbooks/reverse-proxy/README.md
@@ -112,6 +112,14 @@ do not promise automatic installation of every upstream Caddy release.
 Binary upgrades may restart Caddy and briefly interrupt every route;
 configuration rollback is not package rollback.
 
+Caddy requests and starts after `network-online.target`. Some network managers
+reach that target before DHCP supplies every configured address. Failed starts
+therefore retry every 10 seconds, with at most 12 starts in five minutes. A short
+address delay can recover without operator action; repeated immediate failures
+reach the start limit and remain failed. The limit is a rate limit, not a lifetime
+retry count. Explicit service stops do not trigger retries.
+Standalone verification checks this effective startup policy as well as activity.
+
 Configuration changes validate under the service identity before reload and
 preserve the committed boot configuration on failure. A root-owned transaction
 record permits interrupted configuration recovery before systemd starts Caddy.
@@ -130,6 +138,12 @@ certificate condition and rerun provisioning. Failed first activation retains
 the admin-only configuration. If recovery fails, retain its diagnostic and
 inspect the target through the independent administration path; do not delete
 transaction records to bypass the failure.
+
+If startup reaches the retry limit, inspect the Caddy journal and correct the
+reported address, configuration, or certificate problem. Once corrected, an
+authorized `systemctl reset-failed caddy.service` clears the start limit, and
+`systemctl start caddy.service` attempts recovery immediately. Verify the proxy
+and trusted HTTPS afterward. Reboot recovery does not require certificate renewal.
 
 After package maintenance, run proxy verification and a trusted HTTPS check from
 an approved client. Separately check denial from outside the allowed network.

--- a/roles/reverse_proxy/molecule/default/files/startup_recovery.py
+++ b/roles/reverse_proxy/molecule/default/files/startup_recovery.py
@@ -21,6 +21,7 @@ def properties():
     return dict(line.split("=", 1) for line in run(
         "systemctl", "show", "caddy.service", "-p", "ActiveState", "-p", "Result",
         "-p", "NRestarts", "-p", "RestartUSec", "-p", "StartLimitBurst",
+        "-p", "SubState", "-p", "MainPID",
     ).stdout.splitlines())
 
 
@@ -75,10 +76,23 @@ def main():
         run("systemctl", "daemon-reload")
         run("systemctl", "reset-failed", "caddy.service")
         run("systemctl", "start", "caddy.service", check=False)
-        exhausted = wait_for(lambda state: state["Result"] == "start-limit-hit",
+        # systemd may retain Result=exit-code after refusing an automatic restart.
+        # Prove the service stopped retrying, independently of that result label.
+        exhausted = wait_for(lambda state: state["ActiveState"] == "failed"
+                             and state["SubState"] == "failed"
+                             and state["NRestarts"] == "12",
                              "Persistent bind failure did not exhaust the retry budget")
-        assert exhausted["ActiveState"] == "failed"
+        assert exhausted["MainPID"] == "0"
         assert exhausted["StartLimitBurst"] == "12"
+        log = run("journalctl", "-u", "caddy.service", "-n", "25", "--no-pager", "-o", "cat").stdout
+        assert "Start request repeated too quickly." in log
+        # Observe for ten fixture retry intervals to reject a transient failure.
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            state = properties()
+            assert all(state[key] == exhausted[key]
+                       for key in ("ActiveState", "SubState", "NRestarts", "MainPID"))
+            time.sleep(0.1)
         print("PASS: persistent bind failure stops at the installed retry limit")
     finally:
         run("systemctl", "stop", "caddy.service")

--- a/roles/reverse_proxy/molecule/default/files/startup_recovery.py
+++ b/roles/reverse_proxy/molecule/default/files/startup_recovery.py
@@ -1,0 +1,95 @@
+"""Exercise the installed Caddy unit only inside the disposable proxy scenario."""
+
+import ipaddress
+import json
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+
+BOOT = Path("/etc/caddy/Caddyfile")
+FAST_RETRY = Path("/etc/systemd/system/caddy.service.d/zz-molecule-retry.conf")
+ADDRESS = "192.0.2.123"
+
+
+def run(*args, check=True):
+    return subprocess.run(args, check=check, capture_output=True, text=True, timeout=45)
+
+
+def properties():
+    return dict(line.split("=", 1) for line in run(
+        "systemctl", "show", "caddy.service", "-p", "ActiveState", "-p", "Result",
+        "-p", "NRestarts", "-p", "RestartUSec", "-p", "StartLimitBurst",
+    ).stdout.splitlines())
+
+
+def wait_for(predicate, message, timeout=35):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        state = properties()
+        if predicate(state):
+            return state
+        time.sleep(0.2)
+    raise AssertionError(message + ": " + repr(properties()))
+
+
+def main():
+    original_address = str(ipaddress.ip_address(sys.argv[1]))
+    original = BOOT.read_text()
+    # Refuse to touch a host without the dedicated synthetic fixture material.
+    assert Path("/var/lib/reverse-proxy-molecule/ca.pem").is_file()
+    assert "app.example.test" in original and original_address in original
+    assert not FAST_RETRY.exists()
+    addresses = json.loads(run("ip", "-j", "address").stdout)
+    assert not any(entry.get("local") == ADDRESS
+                   for interface in addresses for entry in interface.get("addr_info", []))
+    added_address = False
+    try:
+        run("systemctl", "stop", "caddy.service")
+        run("systemctl", "reset-failed", "caddy.service")
+        BOOT.write_text(original.replace(original_address, ADDRESS))
+        first = run("systemctl", "start", "caddy.service", check=False)
+        assert first.returncode != 0, "Caddy unexpectedly bound an absent address"
+        log = run("journalctl", "-u", "caddy.service", "-n", "25", "--no-pager", "-o", "cat").stdout
+        assert ADDRESS + ":443" in log and "cannot assign requested address" in log
+        assert properties()["RestartUSec"] == "10s"
+
+        # Model delayed DHCP without changing the controller connection address.
+        run("ip", "address", "add", ADDRESS + "/32", "dev", "lo")
+        added_address = True
+        recovered = wait_for(lambda state: state["ActiveState"] == "active",
+                             "Caddy did not recover after its address appeared")
+        assert int(recovered["NRestarts"]) >= 1
+        probe = run("/usr/local/libexec/reverse-proxy-molecule-probe.py",
+                    "--address", ADDRESS, "--hostname", "app.example.test",
+                    "--ca-file", "/var/lib/reverse-proxy-molecule/ca.pem", "https")
+        assert json.loads(probe.stdout)["status"] == 200
+        print("PASS: unavailable bind address recovered automatically with trusted HTTPS")
+
+        run("systemctl", "stop", "caddy.service")
+        run("ip", "address", "del", ADDRESS + "/32", "dev", "lo")
+        added_address = False
+        # Keep the installed retry count/window; shorten only the fixture delay.
+        FAST_RETRY.write_text("[Service]\nRestartSec=100ms\n")
+        run("systemctl", "daemon-reload")
+        run("systemctl", "reset-failed", "caddy.service")
+        run("systemctl", "start", "caddy.service", check=False)
+        exhausted = wait_for(lambda state: state["Result"] == "start-limit-hit",
+                             "Persistent bind failure did not exhaust the retry budget")
+        assert exhausted["ActiveState"] == "failed"
+        assert exhausted["StartLimitBurst"] == "12"
+        print("PASS: persistent bind failure stops at the installed retry limit")
+    finally:
+        run("systemctl", "stop", "caddy.service")
+        BOOT.write_text(original)
+        FAST_RETRY.unlink(missing_ok=True)
+        if added_address:
+            run("ip", "address", "del", ADDRESS + "/32", "dev", "lo")
+        run("systemctl", "daemon-reload")
+        run("systemctl", "reset-failed", "caddy.service")
+        run("systemctl", "start", "caddy.service")
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/reverse_proxy/molecule/default/molecule.yml
+++ b/roles/reverse_proxy/molecule/default/molecule.yml
@@ -19,6 +19,7 @@ platforms:
     container_cap_add:
       - SYS_PTRACE
       - SYS_ADMIN
+      - NET_ADMIN
     container_privileged: false
     container_systemd: always
     restart_policy: always

--- a/roles/reverse_proxy/molecule/default/verify.yml
+++ b/roles/reverse_proxy/molecule/default/verify.yml
@@ -623,6 +623,12 @@
             (reverse_proxy_molecule_after_restart.stdout | from_json).body
             == 'fixture host=app.example.test path=/\n'
 
+    - name: Verify recovery from a delayed bind address and finite failure retries
+      ansible.builtin.script:
+        cmd: "files/startup_recovery.py {{ reverse_proxy_molecule_address }}"
+        executable: /usr/bin/python3
+      changed_when: false
+
     - name: Reconcile and diagnose removal of the first route
       block:
         - name: Reconcile the proxy with only the second route  # noqa: var-naming[no-role-prefix]

--- a/roles/reverse_proxy/tasks/verify.yml
+++ b/roles/reverse_proxy/tasks/verify.yml
@@ -174,6 +174,12 @@
       - --property=ReadWritePaths
       - --property=ExecStartPre
       - --property=ExecReload
+      - --property=Wants
+      - --property=After
+      - --property=Restart
+      - --property=RestartUSec
+      - --property=StartLimitIntervalUSec
+      - --property=StartLimitBurst
   register: reverse_proxy_verify_unit
   changed_when: false
 
@@ -195,6 +201,16 @@
       - "'ProtectHome=yes' in reverse_proxy_verify_unit.stdout_lines"
       - "'ProtectSystem=strict' in reverse_proxy_verify_unit.stdout_lines"
       - "'UMask=0077' in reverse_proxy_verify_unit.stdout_lines"
+      - >-
+        'network-online.target' in (reverse_proxy_verify_unit.stdout_lines
+        | select('match', '^Wants=') | first).split('=', 1)[1].split()
+      - >-
+        'network-online.target' in (reverse_proxy_verify_unit.stdout_lines
+        | select('match', '^After=') | first).split('=', 1)[1].split()
+      - "'Restart=on-failure' in reverse_proxy_verify_unit.stdout_lines"
+      - "'RestartUSec=10s' in reverse_proxy_verify_unit.stdout_lines"
+      - "'StartLimitIntervalUSec=5min' in reverse_proxy_verify_unit.stdout_lines"
+      - "'StartLimitBurst=12' in reverse_proxy_verify_unit.stdout_lines"
       - >-
         'ReadWritePaths=/var/lib/caddy /run/caddy'
         in reverse_proxy_verify_unit.stdout_lines

--- a/roles/reverse_proxy/templates/caddy.service.conf.j2
+++ b/roles/reverse_proxy/templates/caddy.service.conf.j2
@@ -1,4 +1,12 @@
+[Unit]
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=300s
+StartLimitBurst=12
+
 [Service]
+Restart=on-failure
+RestartSec=10s
 User=caddy
 Group=caddy
 SupplementaryGroups=

--- a/tests/ansible/test_molecule_contract.py
+++ b/tests/ansible/test_molecule_contract.py
@@ -171,7 +171,7 @@ class MoleculeScenarioContractTests(unittest.TestCase):
                 self.assertEqual(image, platform["image"])
                 self.assertEqual(container_name, platform["container_name"])
                 self.assertEqual(["reverse_proxy"], platform["groups"])
-                expected_capabilities = ["SYS_PTRACE", "SYS_ADMIN"]
+                expected_capabilities = ["SYS_PTRACE", "SYS_ADMIN", "NET_ADMIN"]
                 self.assertEqual(expected_capabilities, platform["container_cap_add"])
                 self.assertIs(platform["container_privileged"], False)
                 self.assertEqual("always", platform["container_systemd"])

--- a/tests/ansible/test_reverse_proxy_role.py
+++ b/tests/ansible/test_reverse_proxy_role.py
@@ -209,6 +209,16 @@ class SystemdRestrictionTests(unittest.TestCase):
         cls.unit = configparser.ConfigParser(strict=False)
         cls.unit.read_file(io.StringIO(cls.rendered))
 
+    def test_startup_waits_for_network_and_retries_with_a_finite_budget(self) -> None:
+        unit = dict(self.unit.items("Unit")) if self.unit.has_section("Unit") else {}
+        service = self.unit["Service"]
+        self.assertIn("network-online.target", unit.get("wants", "").split())
+        self.assertIn("network-online.target", unit.get("after", "").split())
+        self.assertEqual("on-failure", service["Restart"])
+        self.assertEqual("10s", service["RestartSec"])
+        self.assertEqual("300s", unit["startlimitintervalsec"])
+        self.assertEqual("12", unit["startlimitburst"])
+
     def test_unit_runs_caddy_with_minimum_required_capability(self) -> None:
         service = self.unit["Service"]
 
@@ -694,6 +704,12 @@ class ObservationalVerificationTests(unittest.TestCase):
                 "--property=ReadWritePaths",
                 "--property=ExecStartPre",
                 "--property=ExecReload",
+                "--property=Wants",
+                "--property=After",
+                "--property=Restart",
+                "--property=RestartUSec",
+                "--property=StartLimitIntervalUSec",
+                "--property=StartLimitBurst",
             ],
             unit["ansible.builtin.command"]["argv"],
         )


### PR DESCRIPTION
Caddy could remain stopped after reboot when it tried to bind before DHCP supplied its configured address. Request and order startup after `network-online.target`, retry failures every 10 seconds, and limit starts to 12 per five minutes so repeated immediate failures remain visible.

The proxy verifier checks the effective startup policy. A disposable Debian 13 regression exercises delayed address availability, trusted HTTPS recovery, and retry exhaustion. Exhaustion requires a failed service with no process, 12 restarts, a start-limit journal event, and stable state across further retry intervals; it does not depend on systemd's retained `Result` label. The test's additional `NET_ADMIN` capability is confined to its container network namespace; Caddy's service capability is unchanged.

This branch is based on current `main` after #43. Debian 13 is the sole managed-host platform; the removed Rocky fixture and checks remain removed. Operator guidance and specification 008 describe startup and recovery behavior.

Fixes #41.

Validation:
- All 26 focused reverse-proxy role tests passed.
- After rebase, `mise run bootstrap` passed. `mise run ci:changed` passed fast validation and 328 Ansible tests; the remaining required checks are in progress.
- Independent review of the rebase and corrected retry assertion found no actionable issues.
- The prior CI run proved delayed-address HTTPS recovery, but its retry-limit assertion expected a `Result` label systemd did not report. This revision fixes that assertion; new CI results are pending.
- This source change has not been deployed, and no physical reboot test has been performed.
