### PR TITLE
Prepare Semaphore production settings for NUC4

### DIFF
--- a/inventory/production/host_vars/nuc4/secrets.sops.yml
+++ b/inventory/production/host_vars/nuc4/secrets.sops.yml
@@ -13,6 +13,18 @@ reverse_proxy_routes:
         transport: ENC[AES256_GCM,data:NmEcGQ==,iv:+yUj54SJOF0J7MBI6Xpzlqvw/j7YYAfARp5di4LFBZ4=,tag:Ii1zSXlIuBgScjwtKojfoQ==,type:str]
         address: ENC[AES256_GCM,data:Zh7pBpRzun+g7doK,iv:40Q7uRaLOx1z3Q7FmYGbE115M3oEd9XEczxhTI7pzH8=,tag:+Mh4EZSEUVwwLUe9dU8ErA==,type:str]
         port: ENC[AES256_GCM,data:DOU=,iv:kdfdP34nZzDClSPQJz5TjRB6OcHxxKU00cJfcHShhgQ=,tag:WKt6P3Un6/qB/ZPhq2aiuw==,type:int]
+    - hostname: ENC[AES256_GCM,data:SVS6cav0aTK3xG6/Q3q1zc/e+o1f+5zIjEJ2ZDDd474=,iv:Mmkhoh5rU05H8lZRqz1/j9m21c/Wk0VATW3iRfnR7kI=,tag:UXVSsAe+nlIw2sW+Is3hQg==,type:str]
+      certificate_name: ENC[AES256_GCM,data:0LE02QI=,iv:dYYpIZ90lMJPWRET/HH47MoewZN6xpxjLkCC9DYjqes=,tag:ThHUa3S5GPndBABOp6yYjA==,type:str]
+      backend_port: ENC[AES256_GCM,data:kbM9OYM=,iv:yeOCG1p0NkqI2idQkakaSWqfl5D17fVlN7CkfKWRQNE=,tag:hoh59asMDkVCpsizxUECnA==,type:int]
+semaphore_database_password: ENC[AES256_GCM,data:NFFrKiHxpvxDRI4+ffKrlvL8XFMpX4m2DeqvL6mRiD26U3zQOAd1aA==,iv:wkeXL0XBCqLsvXe0JsXAYo2jcr965dojRyQ9vBNpLCI=,tag:lhRFTJdQX1CKfw6RJp5Cxg==,type:str]
+semaphore_admin_login: ENC[AES256_GCM,data:kuAVe8c=,iv:uR8Ri00FktXYXZvI6Uw0Y66sJsdztV637pNQ+5++1nk=,tag:J8ziuS+2RQvLFVSxQqfxhA==,type:str]
+semaphore_admin_password: ENC[AES256_GCM,data:AUbGpQdtUxRuX+fBGvadLXXtU6Z/obH89B7oiPOGTMNMLre1i/txow==,iv:WJKShEhn6LCpekSVDztVTQksnZZuTcGpz7L9B9gm4Rg=,tag:B8XHfaHIddZMbbrhFg21pA==,type:str]
+semaphore_admin_name: ENC[AES256_GCM,data:FpPogufTp+N36bCXXg==,iv:R2GVdMSXUvfVzdvVMorziQKaeQfY++yj64cUV4caQLI=,tag:D3BqWcTOe+fNUq/6bjVwRg==,type:str]
+semaphore_admin_email: ENC[AES256_GCM,data:tlyKMMQUULXnWEviXVEn8AiKFhUeHIDZvONz5ehQLm75XQ==,iv:3HVmOxcTht38IRGS8jPIo+wSLeE9mR3aEPatvzqK14I=,tag:GucvDXPm2uq+WWqCHajdXQ==,type:str]
+semaphore_cookie_hash: ENC[AES256_GCM,data:NFQ4yh1blr2HEGOqVzgDMzgwWK8Z9jkatkCzoWJsgh4mZsbTPM3GJPXdznE=,iv:EpsWjBlt+ehz03p+ZKLOuPJ6myNBn2rGEALfDJePJ94=,tag:uqPk3Vu/Gr6hMXScaske3g==,type:str]
+semaphore_cookie_encryption: ENC[AES256_GCM,data:eRNSnuFbiocfX1lc9NnWrlHzEfpKqDV70bDXNxSjv3ZY5FSH9Ipo22WP+Ak=,iv:gcOgqdTnlFeEW0wBqAPSwSPmqDz0wojgftMhlAP6OmM=,tag:TEpDWd4m2nppQnfpp69b0w==,type:str]
+semaphore_access_key_encryption: ENC[AES256_GCM,data:qnYe+nTxt7NljaXlACnwQicSgor5D7XVBbpZrOYkQXrlWSZeXZ0cI5VlvPg=,iv:3STfWlbp3Tmius5T3FuQdr7fi67DusJNDDHCf96pG48=,tag:wvLpMJEVcxBE5yxFjitDNw==,type:str]
+semaphore_rclone_config: ENC[AES256_GCM,data:rjsxV6A/YY/VfH1NxSffF/Pu0pXhkh8CW/2zEzAkHVxiMs4oOMOOCzHmDydd5NgiIp7iKJbVw6Foy8W/bqg4dd8WuxvhmaM3x9LXxS2Q79xi,iv:e3EXU5nO8Dcq2yNRURP+6Tiuy71gNJb9fmnsQLi+NDo=,tag:8cTJDp4VUxh0lTsid289vA==,type:str]
 sops:
     age:
         - enc: |
@@ -25,6 +37,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ehm0ehd2v2emfuycf2p0suhg94ej29zcu96ffmh3t6afchhjd99sxc4984
     encrypted_regex: ^(.*)$
-    lastmodified: "2026-09-10T23:47:42Z"
-    mac: ENC[AES256_GCM,data:gUe1v0nBngT96A6DcFOsCnvxd/rr3FvivD8yttmg625/6B9+L8op229Gb7ggrAUGeF7Thc5hpdMFK/DFf95F4LZeex2s1gC4uHrs2qYehr+Yttxlg9SFMw3jCrQMb1u/DB/vsGjEoq2cW3XCWXpfyIjlGPlnLP9Ht3p3cXrLHOM=,iv:736LfGe2Xh5A5co3iCJ38MVAQ3gH88FujjI0mnSqRNw=,tag:kFyUYr8HLvdY59DH+VIcIA==,type:str]
+    lastmodified: "2026-09-13T00:43:07Z"
+    mac: ENC[AES256_GCM,data:9j5r0fPgVE2wdsRckzY6uHTWnAaqX7HivWLKv9EemWXwXBmcWF2hfhqe8BIZuy1qRTDKRe2YIbeF8z6/uF6UoseAa4A/sVroch9DY9LCdNhZbqhU7hDqCSr4gJuxEyyS6/fgknbIv1F7vIQn7b7KRZ9gWNqQjNCmK1zhD3ywNa8=,iv:1HF/ecIImbCpx7Tc1Nd/ZRLn0Vs1YwMlKbrB6Vitifc=,tag:6fgiYYTxPluO8TJm2xC9Tw==,type:str]
     version: 3.13.2

--- a/inventory/production/host_vars/nuc4/vars.yml
+++ b/inventory/production/host_vars/nuc4/vars.yml
@@ -16,6 +16,7 @@ podman_foundation_accounts:
 semaphore_hostname: semaphore.infra.supermorphic.com
 semaphore_backend_port: 18080
 semaphore_certificate_name: infra
+semaphore_rclone_remote: "nas:Semaphore/postgres"
 # Enable after the dedicated identity and controller inputs are enrolled.
 semaphore_controller_enabled: false
 semaphore_controller_identity_enabled: false


### PR DESCRIPTION
Prepare NUC4's Semaphore deployment with operator-supplied SOPS runtime settings and a shared proxy route. Declare the PostgreSQL archive destination in public host variables. Controller execution remains disabled pending separate enrollment.

Validation: bootstrap, encrypted inventory structure and recipients, required protected field names, whitespace checks, and the staged secret scan passed. No protected values were decrypted or verified. Local CI remains disabled at the operator's request; GitHub CI must validate this candidate. No production playbooks were run.

Follow-up to #4. Live deployment and NAS transfer/recovery verification remain operator steps after merge.
