### PR TITLE
Fix Semaphore preflight with mixed proxy routes

### DIFF
--- a/roles/semaphore/tasks/preflight.yml
+++ b/roles/semaphore/tasks/preflight.yml
@@ -282,6 +282,7 @@
         | list | length == 1
       - >-
         reverse_proxy_routes | default([])
+        | selectattr('backend_port', 'defined')
         | selectattr('backend_port', 'equalto', semaphore_backend_port)
         | list | length == 1
     fail_msg: >-

--- a/scripts/semaphore/fixture.py
+++ b/scripts/semaphore/fixture.py
@@ -243,6 +243,20 @@ class Fixture:
                     "--env-file", str(self.root / "semaphore.env"), self.restore.SEMAPHORE_IMAGE)
         for _ in range(90):
             if self._curl("--fail", "http://source-semaphore:3000/api/ping", check=False).returncode == 0:
+                probe = self.podman(
+                    "exec", self.application, "/usr/bin/curl", "--fail", "--silent",
+                    "--show-error", "--max-time", "10", "--output", "/dev/null",
+                    "http://fixture-target:8000/recovery.git/info/refs", check=False,
+                )
+                if probe.returncode != 0:
+                    state = self.podman(
+                        "inspect", "--format", "{{.State.Status}} exit={{.State.ExitCode}}",
+                        self.target, check=False,
+                    )
+                    raise FixtureFailure(
+                        f"source repository readiness failed: {probe.stderr.strip()}; "
+                        f"target state: {state.stdout.strip()}"
+                    )
                 return
             time.sleep(1)
         raise FixtureFailure("source Semaphore readiness timed out")

--- a/tests/ansible/test_semaphore_role.py
+++ b/tests/ansible/test_semaphore_role.py
@@ -472,6 +472,28 @@ class SemaphoreInputValidationTests(unittest.TestCase):
             "semaphore_helper_root": "/usr/local/libexec/semaphore",
         }
 
+    def test_shared_proxy_accepts_device_routes_and_rejects_local_conflicts(self) -> None:
+        tasks = yaml.safe_load((ROLE / "tasks/preflight.yml").read_text())
+        validation = next(task for task in tasks if task["name"] == "Require declared shared proxy route")
+        device = {
+            "hostname": "device.example.test", "certificate_name": "infra",
+            "backend": {"transport": "http", "address": "192.0.2.10", "port": 80},
+        }
+        application = {
+            "hostname": "semaphore.example.test", "certificate_name": "semaphore",
+            "backend_port": 13000,
+        }
+        cases = [
+            ("mixed routes", [device, application], True),
+            ("missing application", [device], False),
+            ("duplicate hostname", [device, application, application], False),
+            ("duplicate local port", [device, application, application | {"hostname": "other.example.test"}], False),
+        ]
+        for label, routes, accepted in cases:
+            with self.subTest(label=label):
+                result = self.run_task(validation, self.public_variables() | {"reverse_proxy_routes": routes})
+                self.assertEqual(accepted, result.returncode == 0, result.stdout + result.stderr)
+
     def test_negative_foundation_identity_is_rejected_before_host_observation(self) -> None:
         tasks = yaml.safe_load((ROLE / "tasks/preflight.yml").read_text())
         validation = next(


### PR DESCRIPTION
Semaphore provisioning fails when the shared proxy list contains a device route because its local-port uniqueness check reads `backend_port` on every entry. Filter to routes that define that field before comparing ports, preserving the exact application route and uniqueness requirements.

The recovery fixture also checks repository reachability from the source application before seeding a task. A failure reports the target container's status and exit code without dumping its configuration. This makes fixture startup and DNS failures easier to locate; the earlier DNS failure did not recur in the subsequent GitHub run.

Validation: a focused Ansible regression test reproduced the failure before the fix and passed afterward. It covers mixed route types, a missing application route, duplicate hostnames, and duplicate local ports. Bootstrap, whitespace checks, and the staged secret scan passed. Full local CI remains disabled at the operator's request; GitHub CI must validate this candidate. No production playbooks or protected inventory decryption were performed.

Follow-up to #4 and #44.
